### PR TITLE
Monitor K8s events

### DIFF
--- a/app.go
+++ b/app.go
@@ -27,6 +27,7 @@ type ExposerApp struct {
 	InputPathListIdentifier       string
 	TicketInputPathListIdentifier string
 	router                        *mux.Router
+	statusPublisher               AnalysisStatusPublisher
 }
 
 // ExposerAppInit contains configuration settings for creating a new ExposerApp.
@@ -37,6 +38,7 @@ type ExposerAppInit struct {
 	PorklockTag                   string // The docker tag for the image containing the porklock tool
 	InputPathListIdentifier       string // Header line for input path lists
 	TicketInputPathListIdentifier string // Header line for ticket input path lists
+	statusPublisher               AnalysisStatusPublisher
 }
 
 // NewExposerApp creates and returns a newly instantiated *ExposerApp.
@@ -53,6 +55,7 @@ func NewExposerApp(init *ExposerAppInit, ingressClass string, cs kubernetes.Inte
 		EndpointController:            NewEndpointer(cs.CoreV1().Endpoints(init.Namespace)),
 		IngressController:             NewIngresser(cs.ExtensionsV1beta1().Ingresses(init.Namespace), ingressClass),
 		router:                        mux.NewRouter(),
+		statusPublisher:               init.statusPublisher,
 	}
 	app.router.HandleFunc("/", app.Greeting).Methods("GET")
 	app.router.HandleFunc("/vice/launch", app.VICELaunchApp).Methods("POST")

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,8 @@ require (
 	github.com/BurntSushi/toml v0.3.1 // indirect
 	github.com/cyverse-de/configurate v0.0.0-20190318152107-8f767cb828d9
 	github.com/cyverse-de/job-templates v5.4.0+incompatible
-	github.com/cyverse-de/model v0.0.0-20190314231011-f13a2e5cf151 // indirect
+	github.com/cyverse-de/messaging v6.0.0+incompatible
+	github.com/cyverse-de/model v0.0.0-20190314231011-f13a2e5cf151
 	github.com/evanphx/json-patch v4.1.0+incompatible // indirect
 	github.com/gogo/protobuf v1.0.0 // indirect
 	github.com/google/gofuzz v0.0.0-20170612174753-24818f796faf // indirect
@@ -23,6 +24,7 @@ require (
 	github.com/pkg/errors v0.8.0
 	github.com/sirupsen/logrus v1.4.1
 	github.com/spf13/viper v1.3.2
+	github.com/streadway/amqp v0.0.0-20190404075320-75d898a42a94 // indirect
 	github.com/stretchr/testify v1.3.0 // indirect
 	golang.org/x/oauth2 v0.0.0-20190402181905-9f3314589c9a // indirect
 	golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,8 @@ github.com/cyverse-de/configurate v0.0.0-20190318152107-8f767cb828d9 h1:GXDamvpo
 github.com/cyverse-de/configurate v0.0.0-20190318152107-8f767cb828d9/go.mod h1:QMZ4G8bX5f0vKiH9+/2JqV687mN1byJ18tjZwIJIagI=
 github.com/cyverse-de/job-templates v5.4.0+incompatible h1:jmUbvh9kaMKJPvrTfdbyaW/6aQLZAkZxjz7OABmfEfo=
 github.com/cyverse-de/job-templates v5.4.0+incompatible/go.mod h1:H0f7nV67/X6VgWsj4Tzy9YOQ96N8xbmrYV3Xazgfd6Y=
+github.com/cyverse-de/messaging v6.0.0+incompatible h1:qt06ANdPHtxtuXW+1Km1u2uvhBrEZjuGMoy9STqfHE4=
+github.com/cyverse-de/messaging v6.0.0+incompatible/go.mod h1:P8+11w9KLDLVt4zlLI0iIvqj4Byj3098+S3xxFuXxwY=
 github.com/cyverse-de/model v0.0.0-20190314231011-f13a2e5cf151 h1:zA3yEPSTCa27WQjKicm+YnFyOkfhe+SL+XbMEJOWYqc=
 github.com/cyverse-de/model v0.0.0-20190314231011-f13a2e5cf151/go.mod h1:baDVP9GnFuZ3A/u/vW5CJgaGcs+1C6lKeC0PIE4i8y0=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
@@ -77,6 +79,8 @@ github.com/spf13/pflag v1.0.3 h1:zPAT6CGy6wXeQ7NtTnaTerfKOsV6V6F8agHXFiazDkg=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/viper v1.3.2 h1:VUFqw5KcqRf7i70GOzW7N+Q7+gxVBkSSqiXB12+JQ4M=
 github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DMA2s=
+github.com/streadway/amqp v0.0.0-20190404075320-75d898a42a94 h1:0ngsPmuP6XIjiFRNFYlvKwSr5zff2v+uPHaffZ6/M4k=
+github.com/streadway/amqp v0.0.0-20190404075320-75d898a42a94/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=

--- a/main.go
+++ b/main.go
@@ -127,5 +127,6 @@ func main() {
 
 	app := NewExposerApp(exposerInit, *ingressClass, clientset)
 	log.Printf("listening on port %d", *listenPort)
+	app.MonitorVICEEvents()
 	log.Fatal(http.ListenAndServe(fmt.Sprintf(":%s", strconv.Itoa(*listenPort)), app.router))
 }

--- a/main.go
+++ b/main.go
@@ -105,9 +105,14 @@ func main() {
 		log.Fatal(errors.Wrap(err, "error creating clientset from config"))
 	}
 
-	cfg, err = configurate.Init(*configPath)
-	if err != nil {
-		log.Fatal(errors.Wrap(err, "error reading config file"))
+	jobStatusURL := cfg.GetString("vice.job-status.base")
+	if jobStatusURL == "" {
+		jobStatusURL = "http://job-status-listener"
+	}
+
+	// Create the JSLPublisher for job status updates
+	jsl := &JSLPublisher{
+		statusURL: jobStatusURL,
 	}
 
 	exposerInit := &ExposerAppInit{
@@ -117,6 +122,7 @@ func main() {
 		PorklockTag:                   cfg.GetString("vice.file-transfers.tag"),
 		InputPathListIdentifier:       cfg.GetString("path_list.file_identifier"),
 		TicketInputPathListIdentifier: cfg.GetString("tickets_path_list.file_identifier"),
+		statusPublisher:               jsl,
 	}
 
 	app := NewExposerApp(exposerInit, *ingressClass, clientset)

--- a/status.go
+++ b/status.go
@@ -9,13 +9,13 @@ import (
 	"os"
 	"path"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/apimachinery/pkg/watch"
-	apiv1 "k8s.io/api/core/v1"
 	"github.com/cyverse-de/messaging"
 	"github.com/pkg/errors"
+	apiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes"
 )
 
 // AnalysisStatusPublisher is the interface for types that need to publish a job
@@ -213,13 +213,13 @@ func (e *ExposerApp) processPodEvent(event *watch.Event) error {
 				continue
 			}
 
-			ii err = e.statusPublisher.Fail(
+			if err = e.statusPublisher.Fail(
 				jobID,
 				fmt.Sprintf(
-					"pod %s for analysis %s failed: %s", 
-					obj.Name, 
-					obj.Labels["analysis-name"], 
-					containerStatus.State.Terminated.Reason
+					"pod %s for analysis %s failed: %s",
+					obj.Name,
+					obj.Labels["analysis-name"],
+					containerStatus.State.Terminated.Reason,
 				),
 			); err != nil {
 				return err

--- a/status.go
+++ b/status.go
@@ -1,0 +1,240 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"path"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/apimachinery/pkg/watch"
+	apiv1 "k8s.io/api/core/v1"
+	"github.com/cyverse-de/messaging"
+	"github.com/pkg/errors"
+)
+
+// AnalysisStatusPublisher is the interface for types that need to publish a job
+// update.
+type AnalysisStatusPublisher interface {
+	Fail(jobID, msg string) error
+	Success(jobID, msg string) error
+	Running(jobID, msg string) error
+}
+
+// JSLPublisher is a concrete implementation of AnalysisStatusPublisher that
+// posts status updates to the job-status-listener service.
+type JSLPublisher struct {
+	statusURL string
+}
+
+// AnalysisStatus contains the data needed to post a status update to the
+// notification-agent service.
+type AnalysisStatus struct {
+	Host    string
+	State   messaging.JobState
+	Message string
+}
+
+func (j *JSLPublisher) postStatus(jobID, msg string, jobState messaging.JobState) error {
+	status := &AnalysisStatus{
+		Host:    hostname(),
+		State:   jobState,
+		Message: msg,
+	}
+
+	u, err := url.Parse(j.statusURL)
+	if err != nil {
+		return errors.Wrapf(
+			err,
+			"error parsing URL %s for job %s before posting %s status",
+			j,
+			jobID,
+			jobState,
+		)
+	}
+	u.Path = path.Join(jobID, "status")
+
+	js, err := json.Marshal(status)
+	if err != nil {
+		return errors.Wrapf(
+			err,
+			"error marshalling JSON for analysis %s before posting %s status",
+			jobID,
+			jobState,
+		)
+
+	}
+	response, err := http.Post(u.String(), "application/json", bytes.NewReader(js))
+	if err != nil {
+		return errors.Wrapf(
+			err,
+			"error returned posting %s status for job %s to %s",
+			jobState,
+			jobID,
+			u.String(),
+		)
+	}
+	if response.StatusCode < 200 || response.StatusCode > 399 {
+		return errors.Wrapf(
+			err,
+			"error status code %d returned after posting %s status for job %s to %s: %s",
+			response.StatusCode,
+			jobState,
+			jobID,
+			u.String(),
+			response.Body,
+		)
+	}
+	return nil
+}
+
+// Fail sends an analysis failure update with the provided message via the AMQP
+// broker. Should be sent once.
+func (j *JSLPublisher) Fail(jobID, msg string) error {
+	return j.postStatus(jobID, msg, messaging.FailedState)
+}
+
+// Success sends a success update via the AMQP broker. Should be sent once.
+func (j *JSLPublisher) Success(jobID, msg string) error {
+	return j.postStatus(jobID, msg, messaging.SucceededState)
+}
+
+// Running sends an analysis running status update with the provided message via the
+// AMQP broker. May be sent multiple times, preferably with different messages.
+func (j *JSLPublisher) Running(jobID, msg string) error {
+	return j.postStatus(jobID, msg, messaging.RunningState)
+}
+
+// MonitorVICEEvents fires up a goroutine that forwards events from the cluster
+// to the status receiving service (probably job-status-listener).
+func (e *ExposerApp) MonitorVICEEvents() {
+	go func(namespace string, clientset kubernetes.Interface) {
+		for {
+			log.Debug("beginning to monitor k8s events")
+			set := labels.Set(map[string]string{
+				"app-type": "interactive",
+			})
+
+			listoptions := metav1.ListOptions{
+				LabelSelector: set.AsSelector().String(),
+			}
+
+			podwatcher, err := clientset.CoreV1().Pods(namespace).Watch(listoptions)
+			if err != nil {
+				log.Error(err)
+				return
+			}
+			podchan := podwatcher.ResultChan()
+
+			depwatcher, err := clientset.AppsV1().Deployments(e.viceNamespace).Watch(listoptions)
+			if err != nil {
+				log.Error(err)
+				return
+			}
+			depchan := depwatcher.ResultChan()
+
+			svcwatcher, err := clientset.CoreV1().Services(e.viceNamespace).Watch(listoptions)
+			if err != nil {
+				log.Error(err)
+				return
+			}
+			svcchan := svcwatcher.ResultChan()
+
+			ingwatcher, err := clientset.ExtensionsV1beta1().Ingresses(e.viceNamespace).Watch(listoptions)
+			if err != nil {
+				log.Error(err)
+				return
+			}
+			ingchan := ingwatcher.ResultChan()
+
+			for {
+				select {
+				case event := <-podchan:
+
+				case event := <-depchan:
+				case event := <-svcchan:
+				case event := <-ingchan:
+				}
+			}
+			log.Debug("stopped monitoring k8s events, probably restarting")
+		}
+	}(e.namespace, e.clientset)
+}
+
+// processPodEvent will send out notifications based on pod events. Partially
+// adapted/inspired by code at https://github.com/dtan4/k8s-pod-notifier/blob/master/kubernetes/client.go.
+func (e *ExposerApp) processPodEvent(event *watch.Event) error {
+	var err error
+
+	obj, ok := event.Object.(*apiv1.Pod)
+	if !ok {
+		return errors.New("unexpected type for pod object")
+	}
+
+	jobID, ok := obj.Labels["external-id"]
+	if !ok {
+		return errors.New("pod is missing external-id label")
+	}
+
+	switch event.Type {
+	case watch.Added:
+		if err = e.statusPublisher.Running(
+			jobID,
+			fmt.Sprintf("pod %s has started for analysis %s", obj.Name, obj.Labels["analysis-name"]),
+		); err != nil {
+			return err
+		}
+		break
+	case watch.Modified:
+		if err = e.statusPublisher.Running(
+			jobID,
+			fmt.Sprintf("pod %s has been modified for analysis %s", obj.Name, obj.Labels["analysis-name"]),
+		); err != nil {
+			return err
+		}
+		break
+	case watch.Deleted:
+		// Deletions are a success. Crashes are a failure. Those usually pop up as a Modified event.
+		if err = e.statusPublisher.Success(
+			jobID,
+			fmt.Sprintf("pod %s has been deleted for analysis %s", obj.Name, obj.Labels["analysis-name"]),
+		); err != nil {
+			return err
+		}
+		break
+	default:
+		for _, containerStatus := range obj.Status.ContainerStatuses {
+			if containerStatus.State.Terminated == nil {
+				continue
+			}
+
+			ii err = e.statusPublisher.Fail(
+				jobID,
+				fmt.Sprintf(
+					"pod %s for analysis %s failed: %s", 
+					obj.Name, 
+					obj.Labels["analysis-name"], 
+					containerStatus.State.Terminated.Reason
+				),
+			); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func hostname() string {
+	h, err := os.Hostname()
+	if err != nil {
+		log.Errorf("Couldn't get the hostname: %s", err.Error())
+		return ""
+	}
+	return h
+}

--- a/vice.go
+++ b/vice.go
@@ -53,13 +53,16 @@ func int64Ptr(i int64) *int64 { return &i }
 
 // labelsFromJob returns a map[string]string that can be used as labels for K8s resources.
 func labelsFromJob(job *model.Job) map[string]string {
+	name := []rune(job.Name)
+
 	return map[string]string{
-		"external-id": job.InvocationID,
-		"app-name":    job.AppName,
-		"app-id":      job.AppID,
-		"username":    job.Submitter,
-		"user-id":     job.UserID,
-		"app-type":    "interactive",
+		"external-id":   job.InvocationID,
+		"app-name":      job.AppName,
+		"app-id":        job.AppID,
+		"username":      job.Submitter,
+		"user-id":       job.UserID,
+		"analysis-name": string(name[:63]),
+		"app-type":      "interactive",
 	}
 }
 

--- a/vice.go
+++ b/vice.go
@@ -615,7 +615,7 @@ func (e *ExposerApp) UpsertDeployment(job *model.Job) error {
 	return nil
 }
 
-// LaunchApp is the HTTP handler that orchestrates the launching of a VICE analysis inside
+// VICELaunchApp is the HTTP handler that orchestrates the launching of a VICE analysis inside
 // the k8s cluster. This get passed to the router to be associated with a route. The Job
 // is passed in as the body of the request.
 func (e *ExposerApp) VICELaunchApp(writer http.ResponseWriter, request *http.Request) {


### PR DESCRIPTION
Monitors k8s events for pods and deployments in the vice-apps namespace and forwards them on as notifications through the job-status-listener service.