### PR TITLE
CORE-660: VICE job limits initial implementation

### DIFF
--- a/vice.go
+++ b/vice.go
@@ -171,7 +171,7 @@ func (e *ExposerApp) countJobsForUser(username string) (int, error) {
 const getJobLimitForUserSQL = `
 	SELECT concurrent_jobs FROM job_limits
 	WHERE launcher = $1 OR launcher IS NULL
-	ORDER BY launcher DESC
+	ORDER BY launcher ASC
 `
 
 func (e *ExposerApp) getJobLimitForUser(username string) (int, error) {

--- a/vice.go
+++ b/vice.go
@@ -160,12 +160,13 @@ func (e *ExposerApp) countJobsForUser(username string) (int, error) {
 		LabelSelector: set.AsSelector().String(),
 	}
 
-	podlist, err := e.clientset.CoreV1().Pods(e.viceNamespace).List(listoptions)
+	depclient := e.clientset.AppsV1().Deployments(e.viceNamespace)
+	deplist, err := depclient.List(listoptions)
 	if err != nil {
 		return 0, err
 	}
 
-	return len(podlist.Items), nil
+	return len(deplist.Items), nil
 }
 
 const getJobLimitForUserSQL = `

--- a/vice.go
+++ b/vice.go
@@ -182,7 +182,7 @@ func (e *ExposerApp) getJobLimitForUser(username string) (int, error) {
 	return jobLimit, nil
 }
 
-func (e *ExposerApp) validateJob(job *model.Job, request *http.Request) error {
+func (e *ExposerApp) validateJob(job *model.Job) error {
 
 	// Verify that the job type is supported by this service
 	if strings.ToLower(job.ExecutionTarget) != "interapps" {
@@ -190,11 +190,7 @@ func (e *ExposerApp) validateJob(job *model.Job, request *http.Request) error {
 	}
 
 	// Get the username
-	users, found := request.URL.Query()["user"]
-	if !found {
-		return fmt.Errorf("user is not set")
-	}
-	user := users[0]
+	user := slugString(job.Submitter)
 
 	// Verify that the user hasn't exceeded their limit for the number of concurrent jobs.
 	jobCount, err := e.countJobsForUser(user)
@@ -229,7 +225,7 @@ func (e *ExposerApp) VICELaunchApp(writer http.ResponseWriter, request *http.Req
 		return
 	}
 
-	if err = e.validateJob(job, request); err != nil {
+	if err = e.validateJob(job); err != nil {
 		http.Error(writer, err.Error(), http.StatusBadRequest)
 		return
 	}


### PR DESCRIPTION
This time around, we're simply going to reject attempts to launch VICE jobs when the user has reached their concurrent job limit.