### PR TITLE
Account for ip_address possibly being null

### DIFF
--- a/apps/main.go
+++ b/apps/main.go
@@ -63,12 +63,23 @@ const getUserIPQuery = `
 
 // GetUserIP returns the latest login ip address for the given user ID.
 func (a *Apps) GetUserIP(userID string) (string, error) {
-	var ipAddr string
+	var (
+		ipAddr sql.NullString
+		retval string
+	)
+
 	err := a.DB.QueryRow(getUserIPQuery, userID).Scan(&ipAddr)
 	if err != nil {
 		return "", err
 	}
-	return ipAddr, nil
+
+	if ipAddr.Valid {
+		retval = ipAddr.String
+	} else {
+		retval = ""
+	}
+
+	return retval, nil
 }
 
 const getAnalysisStatusQuery = `


### PR DESCRIPTION
Turns ip_address into an empty string if the value from the database ends up being null. Scans for a sql.NullString instead of a string in the query that was breaking.