### PR TITLE
CORE-1286: fix a bug in concurrent job limit checks for usernames containing underscores

### DIFF
--- a/internal/limits.go
+++ b/internal/limits.go
@@ -177,10 +177,11 @@ func (i *Internal) validateJob(job *model.Job) (int, error) {
 	}
 
 	// Get the username
-	user := slugString(job.Submitter)
+	usernameLabelValue := labelValueString(job.Submitter)
+	user := job.Submitter
 
 	// Validate the number of concurrent jobs for the user.
-	jobCount, err := i.countJobsForUser(user)
+	jobCount, err := i.countJobsForUser(usernameLabelValue)
 	if err != nil {
 		return http.StatusInternalServerError, errors.Wrapf(err, "unable to determine the number of jobs that %s is currently running", user)
 	}

--- a/internal/limits.go
+++ b/internal/limits.go
@@ -179,7 +179,7 @@ func (i *Internal) validateJob(job *model.Job) (int, error) {
 	// Get the username
 	user := slugString(job.Submitter)
 
-	// Look
+	// Validate the number of concurrent jobs for the user.
 	jobCount, err := i.countJobsForUser(user)
 	if err != nil {
 		return http.StatusInternalServerError, errors.Wrapf(err, "unable to determine the number of jobs that %s is currently running", user)


### PR DESCRIPTION
Usernames containing hyphens and underscores have been problematic for us when we're doing limit checks. This was occurring because the username that we were using to query the database was not necessarily the actual username. This change fixes that problem and adds some more unit tests.

The change to fix the problem involves some special processing for usernames containing leading and trailing hyphens or underscores in an attempt to make it fairly unlikely that the pod label values for two different usernames will be the same, which would also break concurrency limit checks.
