### PR TITLE
Add Instant Launch metadata management endpoints

### DIFF
--- a/app.go
+++ b/app.go
@@ -47,6 +47,7 @@ type ExposerAppInit struct {
 	AppsServiceBaseURL            string
 	db                            *sqlx.DB
 	UserSuffix                    string
+	MetadataBaseURL               string
 }
 
 // NewExposerApp creates and returns a newly instantiated *ExposerApp.
@@ -159,7 +160,7 @@ func NewExposerApp(init *ExposerAppInit, ingressClass string, cs kubernetes.Inte
 	ingress.DELETE("/:name", app.external.DeleteIngress)
 
 	ilgroup := app.router.Group("/instantlaunches")
-	app.instantlaunches = instantlaunches.New(app.db, ilgroup, init.UserSuffix)
+	app.instantlaunches = instantlaunches.New(app.db, ilgroup, init.UserSuffix, init.MetadataBaseURL)
 
 	return app
 }

--- a/instantlaunches/defaults_test.go
+++ b/instantlaunches/defaults_test.go
@@ -26,7 +26,7 @@ func SetupApp() (*App, sqlmock.Sqlmock, *echo.Echo, error) {
 	e := echo.New()
 	g := e.Group("/instantlaunches")
 
-	app := New(sqlxMockDB, g, "@iplantcollaborative.org")
+	app := New(sqlxMockDB, g, "@iplantcollaborative.org", "")
 	return app, mock, e, nil
 }
 

--- a/instantlaunches/main.go
+++ b/instantlaunches/main.go
@@ -136,17 +136,19 @@ type UserInstantLaunchMapping struct {
 
 // App provides an API for managing instant launches.
 type App struct {
-	DB         *sqlx.DB
-	Group      *echo.Group
-	UserSuffix string
+	DB              *sqlx.DB
+	Group           *echo.Group
+	UserSuffix      string
+	MetadataBaseURL string
 }
 
 // New returns a newly created *App.
-func New(db *sqlx.DB, group *echo.Group, userSuffix string) *App {
+func New(db *sqlx.DB, group *echo.Group, userSuffix string, metadataBaseURL string) *App {
 	instance := &App{
-		DB:         db,
-		Group:      group,
-		UserSuffix: userSuffix,
+		DB:              db,
+		Group:           group,
+		UserSuffix:      userSuffix,
+		MetadataBaseURL: metadataBaseURL,
 	}
 
 	// swagger:route get /instantlaunches/mappings/defaults instantlaunches listDefaults

--- a/instantlaunches/main.go
+++ b/instantlaunches/main.go
@@ -419,6 +419,8 @@ func New(db *sqlx.DB, group *echo.Group, userSuffix string) *App {
 	//			default: errorResponse
 	instance.Group.DELETE("/mappings/:username/:version", instance.DeleteUserMappingsByVersionHandler)
 
+	instance.Group.GET("/metadata", instance.ListMetadataHandler)
+
 	// swagger.route PUT /instantlaunches/ instantlaunches addInstantLaunch
 	//
 	// Adds a new instant launch to the system.
@@ -499,6 +501,10 @@ func New(db *sqlx.DB, group *echo.Group, userSuffix string) *App {
 	//		Responses:
 	//			default: errorResponse
 	instance.Group.DELETE("/:id", instance.DeleteInstantLaunchHandler)
+
+	instance.Group.GET("/:id/metadata", instance.GetMetadataHandler)
+	instance.Group.POST("/:id/metadata", instance.AddOrUpdateMetadataHandler)
+	instance.Group.PUT("/:id/metadata", instance.SetAllMetadataHandler)
 
 	return instance
 }

--- a/instantlaunches/metadata.go
+++ b/instantlaunches/metadata.go
@@ -1,26 +1,62 @@
 package instantlaunches
 
-import "github.com/labstack/echo/v4"
+import (
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"path"
+
+	"github.com/labstack/echo/v4"
+)
 
 // ListMetadataHandler lists all of the instant launch metadata
 // based on the attributes and values contained in the body.
 func (a *App) ListMetadataHandler(c echo.Context) error {
+
 	return nil
 }
 
 // GetMetadataHandler returns all of the metadata associated with an instant launch.
 func (a *App) GetMetadataHandler(c echo.Context) error {
-	return nil
+	id := c.Param("id")
+	if id == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "id is missing")
+	}
+
+	svc, err := url.Parse(a.MetadataBaseURL)
+	if err != nil {
+		return err
+	}
+
+	svc.Path = path.Join(svc.Path, "/avus", "quick_launch", id)
+	resp, err := http.Get(svc.String())
+	if err != nil {
+		return err
+	}
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+
+	return c.Blob(resp.StatusCode, resp.Header.Get(http.CanonicalHeaderKey("content-type")), body)
 }
 
 // AddOrUpdateMetadataHandler adds or updates one or more AVUs on an instant
 // launch.
 func (a *App) AddOrUpdateMetadataHandler(c echo.Context) error {
+	id := c.Param("id")
+	if id == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "id is missing")
+	}
 	return nil
 }
 
 // SetAllMetadataHandler sets all of the AVUs associated with an instant
 // launch to the set contained in the body of the request.
 func (a *App) SetAllMetadataHandler(c echo.Context) error {
+	id := c.Param("id")
+	if id == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "id is missing")
+	}
 	return nil
 }

--- a/instantlaunches/metadata.go
+++ b/instantlaunches/metadata.go
@@ -22,6 +22,8 @@ func handleError(err error, statusCode int) error {
 // ListMetadataHandler lists all of the instant launch metadata
 // based on the attributes and values contained in the body.
 func (a *App) ListMetadataHandler(c echo.Context) error {
+	log.Debug("in ListMetadataHandler")
+
 	user := c.QueryParam("user")
 	if user == "" {
 		return echo.NewHTTPError(http.StatusBadRequest, "user is missing")
@@ -73,6 +75,8 @@ func (a *App) ListMetadataHandler(c echo.Context) error {
 
 // GetMetadataHandler returns all of the metadata associated with an instant launch.
 func (a *App) GetMetadataHandler(c echo.Context) error {
+	log.Debug("int GetMetadataHandler")
+
 	id := c.Param("id")
 	if id == "" {
 		return echo.NewHTTPError(http.StatusBadRequest, "id is missing")
@@ -93,10 +97,15 @@ func (a *App) GetMetadataHandler(c echo.Context) error {
 	query.Add("user", user)
 	svc.RawQuery = query.Encode()
 
+	log.Debug(fmt.Sprintf("metadata endpoint: %s", svc.String()))
+
 	resp, err := http.Get(svc.String())
 	if err != nil {
 		return handleError(err, http.StatusInternalServerError)
 	}
+
+	log.Debug(fmt.Sprintf("metadata endpoint: %s, status code: %d", svc.String(), resp.StatusCode))
+
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return handleError(err, http.StatusInternalServerError)
@@ -108,6 +117,8 @@ func (a *App) GetMetadataHandler(c echo.Context) error {
 // AddOrUpdateMetadataHandler adds or updates one or more AVUs on an instant
 // launch.
 func (a *App) AddOrUpdateMetadataHandler(c echo.Context) error {
+	log.Debug("in AddOrUpdateMetadataHandler")
+
 	id := c.Param("id")
 	if id == "" {
 		return echo.NewHTTPError(http.StatusBadRequest, "id is missing")
@@ -133,10 +144,14 @@ func (a *App) AddOrUpdateMetadataHandler(c echo.Context) error {
 	query.Add("user", user)
 	svc.RawQuery = query.Encode()
 
+	log.Debug(fmt.Sprintf("metadata endpoint: %s", svc.String()))
+
 	resp, err := http.Post(svc.String(), "application/json", bytes.NewReader(inBody))
 	if err != nil {
 		return handleError(err, http.StatusInternalServerError)
 	}
+
+	log.Debug(fmt.Sprintf("metadata endpoint: %s, status code: %d", svc.String(), resp.StatusCode))
 
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
@@ -149,6 +164,8 @@ func (a *App) AddOrUpdateMetadataHandler(c echo.Context) error {
 // SetAllMetadataHandler sets all of the AVUs associated with an instant
 // launch to the set contained in the body of the request.
 func (a *App) SetAllMetadataHandler(c echo.Context) error {
+	log.Debug("in SetAllMetadataHandler")
+
 	id := c.Param("id")
 	if id == "" {
 		return echo.NewHTTPError(http.StatusBadRequest, "id is missing")
@@ -174,6 +191,8 @@ func (a *App) SetAllMetadataHandler(c echo.Context) error {
 	query.Add("user", user)
 	svc.RawQuery = query.Encode()
 
+	log.Debug(fmt.Sprintf("metadata endpoint: %s", svc.String()))
+
 	req, err := http.NewRequest(http.MethodPut, svc.String(), bytes.NewReader(inBody))
 	if err != nil {
 		return handleError(err, http.StatusInternalServerError)
@@ -183,6 +202,8 @@ func (a *App) SetAllMetadataHandler(c echo.Context) error {
 	if err != nil {
 		return handleError(err, http.StatusInternalServerError)
 	}
+
+	log.Debug(fmt.Sprintf("metadata endpoint: %s, status code: %d", svc.String(), resp.StatusCode))
 
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {

--- a/instantlaunches/metadata.go
+++ b/instantlaunches/metadata.go
@@ -27,7 +27,7 @@ func (a *App) ListMetadataHandler(c echo.Context) error {
 		return err
 	}
 
-	svc.Path = path.Join(svc.Path, "/avus", "instant_launch", id)
+	svc.Path = path.Join(svc.Path, "/avus")
 	query := svc.Query()
 	query.Add("user", user)
 	query.Add("target-type", "instant_launch")

--- a/instantlaunches/metadata.go
+++ b/instantlaunches/metadata.go
@@ -1,0 +1,26 @@
+package instantlaunches
+
+import "github.com/labstack/echo/v4"
+
+// ListMetadataHandler lists all of the instant launch metadata
+// based on the attributes and values contained in the body.
+func (a *App) ListMetadataHandler(c echo.Context) error {
+	return nil
+}
+
+// GetMetadataHandler returns all of the metadata associated with an instant launch.
+func (a *App) GetMetadataHandler(c echo.Context) error {
+	return nil
+}
+
+// AddOrUpdateMetadataHandler adds or updates one or more AVUs on an instant
+// launch.
+func (a *App) AddOrUpdateMetadataHandler(c echo.Context) error {
+	return nil
+}
+
+// SetAllMetadataHandler sets all of the AVUs associated with an instant
+// launch to the set contained in the body of the request.
+func (a *App) SetAllMetadataHandler(c echo.Context) error {
+	return nil
+}

--- a/instantlaunches/metadata.go
+++ b/instantlaunches/metadata.go
@@ -24,12 +24,21 @@ func (a *App) GetMetadataHandler(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, "id is missing")
 	}
 
+	user := c.QueryParam("user")
+	if user == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "user is missing")
+	}
+
 	svc, err := url.Parse(a.MetadataBaseURL)
 	if err != nil {
 		return err
 	}
 
 	svc.Path = path.Join(svc.Path, "/avus", "instant_launch", id)
+	query := svc.Query()
+	query.Add("user", user)
+	svc.RawQuery = query.Encode()
+
 	resp, err := http.Get(svc.String())
 	if err != nil {
 		return err
@@ -50,6 +59,11 @@ func (a *App) AddOrUpdateMetadataHandler(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, "id is missing")
 	}
 
+	user := c.QueryParam("user")
+	if user == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "user is missing")
+	}
+
 	inBody, err := ioutil.ReadAll(c.Request().Body)
 	if err != nil {
 		return err
@@ -61,6 +75,10 @@ func (a *App) AddOrUpdateMetadataHandler(c echo.Context) error {
 	}
 
 	svc.Path = path.Join(svc.Path, "/avus", "instant_launch", id)
+	query := svc.Query()
+	query.Add("user", user)
+	svc.RawQuery = query.Encode()
+
 	resp, err := http.Post(svc.String(), "application/json", bytes.NewReader(inBody))
 	if err != nil {
 		return err
@@ -82,6 +100,11 @@ func (a *App) SetAllMetadataHandler(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, "id is missing")
 	}
 
+	user := c.QueryParam("user")
+	if user == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "user is missing")
+	}
+
 	inBody, err := ioutil.ReadAll(c.Request().Body)
 	if err != nil {
 		return err
@@ -93,6 +116,10 @@ func (a *App) SetAllMetadataHandler(c echo.Context) error {
 	}
 
 	svc.Path = path.Join(svc.Path, "/avus", "instant_launch", id)
+	query := svc.Query()
+	query.Add("user", user)
+	svc.RawQuery = query.Encode()
+
 	req, err := http.NewRequest(http.MethodPut, svc.String(), bytes.NewReader(inBody))
 	if err != nil {
 		return err

--- a/instantlaunches/metadata.go
+++ b/instantlaunches/metadata.go
@@ -56,7 +56,7 @@ func (a *App) ListMetadataHandler(c echo.Context) error {
 	}
 	svc.RawQuery = query.Encode()
 
-	log.Debug(fmt.Sprintf("metadata endpoint: %s", svc.String()))
+	log.Debug(fmt.Sprintf("metadata endpoint: GET %s", svc.String()))
 
 	resp, err := http.Get(svc.String())
 	if err != nil {
@@ -97,7 +97,7 @@ func (a *App) GetMetadataHandler(c echo.Context) error {
 	query.Add("user", user)
 	svc.RawQuery = query.Encode()
 
-	log.Debug(fmt.Sprintf("metadata endpoint: %s", svc.String()))
+	log.Debug(fmt.Sprintf("metadata endpoint: GET %s", svc.String()))
 
 	resp, err := http.Get(svc.String())
 	if err != nil {
@@ -144,7 +144,7 @@ func (a *App) AddOrUpdateMetadataHandler(c echo.Context) error {
 	query.Add("user", user)
 	svc.RawQuery = query.Encode()
 
-	log.Debug(fmt.Sprintf("metadata endpoint: %s", svc.String()))
+	log.Debug(fmt.Sprintf("metadata endpoint: POST %s", svc.String()))
 
 	resp, err := http.Post(svc.String(), "application/json", bytes.NewReader(inBody))
 	if err != nil {
@@ -191,12 +191,14 @@ func (a *App) SetAllMetadataHandler(c echo.Context) error {
 	query.Add("user", user)
 	svc.RawQuery = query.Encode()
 
-	log.Debug(fmt.Sprintf("metadata endpoint: %s", svc.String()))
+	log.Debug(fmt.Sprintf("metadata endpoint: PUT %s", svc.String()))
 
 	req, err := http.NewRequest(http.MethodPut, svc.String(), bytes.NewReader(inBody))
 	if err != nil {
 		return handleError(err, http.StatusInternalServerError)
 	}
+
+	req.Header.Set(http.CanonicalHeaderKey("content-type"), "application/json")
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -173,6 +173,11 @@ func main() {
 		appsServiceBaseURL = "http://apps"
 	}
 
+	metadataBaseURL := cfg.GetString("metadata.base")
+	if metadataBaseURL == "" {
+		metadataBaseURL = "http://metadata"
+	}
+
 	var proxyImage string
 	proxyTag := cfg.GetString("interapps.proxy.tag")
 	if proxyTag == "" {
@@ -204,6 +209,7 @@ func main() {
 		AppsServiceBaseURL:            appsServiceBaseURL,
 		db:                            db,
 		UserSuffix:                    *userSuffix,
+		MetadataBaseURL:               metadataBaseURL,
 	}
 
 	app := NewExposerApp(exposerInit, *ingressClass, clientset)


### PR DESCRIPTION
Adds fairly basic proxy endpoints to metadata that manage AVUs specifically for instant launches.