### PR TITLE
Use the 'nice' Ingress name as the pod hostname, hopefully

### DIFF
--- a/internal/deployments.go
+++ b/internal/deployments.go
@@ -545,6 +545,7 @@ func (i *Internal) getDeployment(job *model.Job) (*appsv1.Deployment, error) {
 					Labels: labels,
 				},
 				Spec: apiv1.PodSpec{
+	                                Hostname:                     IngressName(job.UserID, job.InvocationID),
 					RestartPolicy:                apiv1.RestartPolicy("Always"),
 					Volumes:                      i.deploymentVolumes(job),
 					InitContainers:               i.initContainers(job),


### PR DESCRIPTION
I decided to look and this is actually pretty easy to do, assuming I didn't screw something up, and will make the hostnames shown in terminals and stuff way shorter (and match the URL in the address bar). It at least compiles, but I admit I didn't really test it further just yet since it's not really on-task for me :)