### PR TITLE
Add actionable instant launch endpoints

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,7 @@ require (
 	github.com/spf13/viper v1.7.0
 	github.com/streadway/amqp v0.0.0-20190404075320-75d898a42a94 // indirect
 	github.com/stretchr/testify v1.6.1
+	github.com/valyala/fastjson v1.6.3 // indirect
 	golang.org/x/crypto v0.0.0-20201016220609-9e8e0b390897 // indirect
 	golang.org/x/net v0.0.0-20201110031124-69a78807bb2b // indirect
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d // indirect

--- a/go.sum
+++ b/go.sum
@@ -314,6 +314,8 @@ github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
+github.com/valyala/fastjson v1.6.3 h1:tAKFnnwmeMGPbwJ7IwxcTPCNr3uIzoIj3/Fh90ra4xc=
+github.com/valyala/fastjson v1.6.3/go.mod h1:CLCAqky6SMuOcxStkYQvblddUtoRxhYMGLrsQns1aXY=
 github.com/valyala/fasttemplate v1.0.1/go.mod h1:UQGH1tvbgY+Nz5t2n7tXsz52dQxojPUpymEIMZ47gx8=
 github.com/valyala/fasttemplate v1.2.1 h1:TVEnxayobAdVkhQfrfes2IzOB6o+z4roRkPF52WA1u4=
 github.com/valyala/fasttemplate v1.2.1/go.mod h1:KHLXt3tVN2HBp8eijSv/kGJopbvo7S+qRAEEKiv+SiQ=

--- a/instantlaunches/db.go
+++ b/instantlaunches/db.go
@@ -1,0 +1,403 @@
+package instantlaunches
+
+import (
+	"github.com/lib/pq"
+)
+
+const fullListingQuery = `
+SELECT
+	il.id,
+	ilu.username AS added_by,
+	il.added_on,
+	il.quick_launch_id,
+	ql.name AS ql_name,
+	ql.description AS ql_description,
+	qlu.username AS ql_creator,
+	sub.submission AS submission,
+	ql.app_id,
+	ql.is_public,
+	a.name AS app_name,
+	a.description AS app_description,
+	a.deleted AS app_deleted,
+	a.disabled AS app_disabled,
+	iu.username as integrator
+
+
+FROM instant_launches il
+	JOIN quick_launches ql ON il.quick_launch_id = ql.id
+	JOIN submissions sub ON ql.submission_id = sub.id
+	JOIN apps a ON ql.app_id = a.id
+	JOIN integration_data integ ON a.integration_data_id = integ.id
+	JOIN users iu ON integ.user_id = iu.id
+	JOIN users qlu ON ql.creator = qlu.id
+	JOIN users ilu ON il.added_by = ilu.id
+
+
+WHERE il.id = any($1);
+`
+
+// ListFullInstantLaunchesByIDs returns the full instant launches associated with the UUIDs
+// passed in. Includes quick launch, app, and submission info.
+func (a *App) ListFullInstantLaunchesByIDs(ids []string) ([]FullInstantLaunch, error) {
+	fullListing := []FullInstantLaunch{}
+	err := a.DB.Select(&fullListing, fullListingQuery, pq.Array(ids))
+	return fullListing, err
+}
+
+const addInstantLaunchQuery = `
+	INSERT INTO instant_launches (quick_launch_id, added_by)
+	VALUES ( $1, ( SELECT u.id FROM users u WHERE u.username = $2 ) )
+	RETURNING id, quick_launch_id, added_by, added_on;
+`
+
+// AddInstantLaunch registers a new instant launch in the database.
+func (a *App) AddInstantLaunch(quickLaunchID, username string) (*InstantLaunch, error) {
+	newvalues := &InstantLaunch{}
+	err := a.DB.QueryRowx(addInstantLaunchQuery, quickLaunchID, username).StructScan(newvalues)
+	return newvalues, err
+}
+
+const getInstantLaunchQuery = `
+	SELECT i.id, i.quick_launch_id, i.added_by, i.added_on
+	FROM instant_launches i
+	WHERE i.id = $1;
+`
+
+// GetInstantLaunch returns a stored instant launch by ID.
+func (a *App) GetInstantLaunch(id string) (*InstantLaunch, error) {
+	il := &InstantLaunch{}
+	err := a.DB.QueryRowx(getInstantLaunchQuery, id).StructScan(il)
+	return il, err
+}
+
+const fullInstantLaunchQuery = `
+SELECT
+	il.id,
+	ilu.username AS added_by,
+	il.added_on,
+	il.quick_launch_id,
+	ql.name AS ql_name,
+	ql.description AS ql_description,
+	qlu.username AS ql_creator,
+	sub.submission AS submission,
+	ql.app_id,
+	ql.is_public,
+	a.name AS app_name,
+	a.description AS app_description,
+	a.deleted AS app_deleted,
+	a.disabled AS app_disabled,
+	iu.username as integrator
+
+
+FROM instant_launches il
+	JOIN quick_launches ql ON il.quick_launch_id = ql.id
+	JOIN submissions sub ON ql.submission_id = sub.id
+	JOIN apps a ON ql.app_id = a.id
+	JOIN integration_data integ ON a.integration_data_id = integ.id
+	JOIN users iu ON integ.user_id = iu.id
+	JOIN users qlu ON ql.creator = qlu.id
+	JOIN users ilu ON il.added_by = ilu.id
+
+
+WHERE il.id = $1;
+`
+
+// FullInstantLaunch returns an instant launch from the database that
+// includes quick launch, app, and submission information.
+func (a *App) FullInstantLaunch(id string) (*FullInstantLaunch, error) {
+	fil := &FullInstantLaunch{}
+	err := a.DB.QueryRowx(fullInstantLaunchQuery, id).StructScan(fil)
+	return fil, err
+}
+
+const updateInstantLaunchQuery = `
+	UPDATE ONLY instant_launches
+	SET quick_launch_id = $1
+	WHERE id = $2
+	RETURNING id, quick_launch_id, added_by, added_by;
+`
+
+// UpdateInstantLaunch updates a stored instant launch with new values.
+func (a *App) UpdateInstantLaunch(id, quickLaunchID string) (*InstantLaunch, error) {
+	il := &InstantLaunch{}
+	err := a.DB.QueryRowx(updateInstantLaunchQuery, quickLaunchID, id).StructScan(il)
+	return il, err
+}
+
+const deleteInstantLaunchQuery = `
+	DELETE FROM instant_launches WHERE id = $1;
+`
+
+// DeleteInstantLaunch deletes a stored instant launch.
+func (a *App) DeleteInstantLaunch(id string) error {
+	_, err := a.DB.Exec(deleteInstantLaunchQuery, id)
+	return err
+}
+
+const listInstantLaunchesQuery = `
+	SELECT i.id, i.quick_launch_id, i.added_by, i.added_on
+	FROM instant_launches i;
+`
+
+// ListInstantLaunches lists all registered instant launches.
+func (a *App) ListInstantLaunches() ([]InstantLaunch, error) {
+	all := []InstantLaunch{}
+	err := a.DB.Select(&all, listInstantLaunchesQuery)
+	return all, err
+}
+
+const userMappingQuery = `
+    SELECT u.id,
+           u.version,
+           u.instant_launches as mapping
+      FROM user_instant_launches u
+      JOIN users ON u.user_id = users.id
+     WHERE users.username = $1
+  ORDER BY u.version DESC
+     LIMIT 1;
+`
+
+// UserMapping returns the user's instant launch mappings.
+func (a *App) UserMapping(user string) (*UserInstantLaunchMapping, error) {
+	m := &UserInstantLaunchMapping{}
+	err := a.DB.Get(m, userMappingQuery, user)
+	return m, err
+}
+
+const updateUserMappingQuery = `
+    UPDATE ONLY user_instant_launches
+            SET user_instant_launches.instant_launches = $1
+           FROM users
+          WHERE user_instant_launches.version = (
+              SELECT max(u.version)
+                FROM user_instant_launches u
+          )
+            AND user_id = users.id
+            AND users.username = $2
+          RETURNING user_instant_launches.instant_launches;
+`
+
+// UpdateUserMapping updates the the latest version of the user's custom
+// instant launch mappings.
+func (a *App) UpdateUserMapping(user string, update *InstantLaunchMapping) (*InstantLaunchMapping, error) {
+	updated := &InstantLaunchMapping{}
+	err := a.DB.QueryRowx(updateUserMappingQuery, update, user).Scan(updated)
+	return updated, err
+}
+
+const deleteUserMappingQuery = `
+	DELETE FROM ONLY user_instant_launches
+	USING users
+	WHERE user_instant_launches.user_id = users.id
+	  AND users.username = $1
+	  AND user_instant_launches.version = (
+		  SELECT max(u.version)
+		    FROM user_instant_launches u
+	  );
+`
+
+// DeleteUserMapping is intended as an admin only operation that completely removes
+// the latest mapping for the user.
+func (a *App) DeleteUserMapping(user string) error {
+	_, err := a.DB.Exec(deleteUserMappingQuery, user)
+	return err
+}
+
+const createUserMappingQuery = `
+	INSERT INTO user_instant_launches (instant_launches, user_id)
+	VALUES ( $1, (SELECT id FROM users WHERE username = $2) )
+	RETURNING instant_launches;
+`
+
+// AddUserMapping adds a new record to the database for the user's instant launches.
+func (a *App) AddUserMapping(user string, mapping *InstantLaunchMapping) (*InstantLaunchMapping, error) {
+	newvalue := &InstantLaunchMapping{}
+	err := a.DB.QueryRowx(createUserMappingQuery, mapping, user).Scan(newvalue)
+	if err != nil {
+		return nil, err
+	}
+	return newvalue, nil
+}
+
+const allUserMappingsQuery = `
+  SELECT u.id,
+		 u.version,
+		 u.user_id,
+         u.instant_launches as mapping
+    FROM user_instant_launches u
+    JOIN users ON u.user_id = users.id
+   WHERE users.username = ?;
+`
+
+// AllUserMappings returns all of the user's instant launch mappings regardless of version.
+func (a *App) AllUserMappings(user string) ([]UserInstantLaunchMapping, error) {
+	m := []UserInstantLaunchMapping{}
+	err := a.DB.Select(&m, allUserMappingsQuery, user)
+	return m, err
+}
+
+const userMappingsByVersionQuery = `
+    SELECT u.id,
+           u.version,
+           u.instant_launches as mapping
+      FROM user_instant_launches u
+      JOIN users ON u.user_id = users.id
+     WHERE users.username = ?
+       AND u.version = ?
+`
+
+// UserMappingsByVersion returns a specific version of the user's instant launch mappings.
+func (a *App) UserMappingsByVersion(user string, version int) (UserInstantLaunchMapping, error) {
+	m := UserInstantLaunchMapping{}
+	err := a.DB.Get(&m, userMappingsByVersionQuery, user, version)
+	return m, err
+}
+
+const updateUserMappingsByVersionQuery = `
+    UPDATE ONLY user_instant_launches AS def
+            SET def.instant_launches = jsonb_object(?)
+           FROM users
+          WHERE def.version = ?
+            AND def.user_id = users.id
+            AND users.username = ?
+        RETURNING def.instant_launches;
+`
+
+// UpdateUserMappingsByVersion updates the user's instant launches for a specific version.
+func (a *App) UpdateUserMappingsByVersion(user string, version int, update *InstantLaunchMapping) (*InstantLaunchMapping, error) {
+	retval := &InstantLaunchMapping{}
+	err := a.DB.QueryRowx(updateUserMappingsByVersionQuery, update, version, user).Scan(retval)
+	if err != nil {
+		return nil, err
+	}
+	return retval, nil
+}
+
+const deleteUserMappingsByVersionQuery = `
+	DELETE FROM ONLY user_instant_launches AS def
+	USING users
+	WHERE def.user_id = users.id
+	  AND users.username = ?
+	  AND def.version = ?;
+`
+
+// DeleteUserMappingsByVersion deletes a user's instant launch mappings at a specific version.
+func (a *App) DeleteUserMappingsByVersion(user string, version int) error {
+	_, err := a.DB.Exec(deleteUserMappingsByVersionQuery, user, version)
+	return err
+}
+
+const latestDefaultsQuery = `
+    SELECT def.id,
+           def.version,
+           def.instant_launches AS mapping
+      FROM default_instant_launches def
+  ORDER BY def.version DESC
+     LIMIT 1;
+`
+
+// LatestDefaults returns the latest version of the default instant launches.
+func (a *App) LatestDefaults() (DefaultInstantLaunchMapping, error) {
+	m := DefaultInstantLaunchMapping{}
+	err := a.DB.Get(&m, latestDefaultsQuery)
+	return m, err
+}
+
+const updateLatestDefaultsQuery = `
+    UPDATE ONLY default_instant_launches
+            SET instant_launches = $1
+          WHERE version = (
+              SELECT max(def.version)
+                FROM default_instant_launches def
+          )
+          RETURNING instant_launches;
+`
+
+// UpdateLatestDefaults sets a new value for the latest version of the defaults.
+func (a *App) UpdateLatestDefaults(newjson *InstantLaunchMapping) (*InstantLaunchMapping, error) {
+	retval := &InstantLaunchMapping{}
+	err := a.DB.QueryRowx(updateLatestDefaultsQuery, newjson).Scan(retval)
+	return retval, err
+}
+
+const deleteLatestDefaultsQuery = `
+	DELETE FROM ONLY default_instant_launches AS def
+	WHERE version = (
+		SELECT max(def.version)
+		FROM default_instant_launches def
+	);
+`
+
+// DeleteLatestDefaults removes the latest default mappings from the database.
+func (a *App) DeleteLatestDefaults() error {
+	_, err := a.DB.Exec(deleteLatestDefaultsQuery)
+	return err
+}
+
+const createLatestDefaultsQuery = `
+	INSERT INTO default_instant_launches (instant_launches, added_by)
+	VALUES ( $1, ( SELECT u.id FROM users u WHERE username = $2 ) )
+	RETURNING instant_launches;
+`
+
+// AddLatestDefaults adds a new version of the default instant launch mappings.
+func (a *App) AddLatestDefaults(update *InstantLaunchMapping, addedBy string) (*InstantLaunchMapping, error) {
+	newvalue := &InstantLaunchMapping{}
+	err := a.DB.QueryRowx(createLatestDefaultsQuery, update, addedBy).Scan(newvalue)
+	return newvalue, err
+}
+
+const defaultsByVersionQuery = `
+    SELECT def.id,
+           def.version,
+           def.instant_launches as mapping
+      FROM default_instant_launches def
+     WHERE def.version = ?;
+`
+
+// DefaultsByVersion returns a specific version of the default instant launches.
+func (a *App) DefaultsByVersion(version int) (*DefaultInstantLaunchMapping, error) {
+	m := &DefaultInstantLaunchMapping{}
+	err := a.DB.Get(m, defaultsByVersionQuery, version)
+	return m, err
+}
+
+const updateDefaultsByVersionQuery = `
+    UPDATE ONLY default_instant_launches AS def
+            SET def.instant_launches = jsonb_object(?)
+          WHERE def.version = ?
+      RETURNING def.instant_launches;
+`
+
+// UpdateDefaultsByVersion updates the default mapping for a specific version.
+func (a *App) UpdateDefaultsByVersion(newjson *InstantLaunchMapping, version int) (*InstantLaunchMapping, error) {
+	updated := &InstantLaunchMapping{}
+	err := a.DB.QueryRowx(updateDefaultsByVersionQuery, newjson, version).Scan(updated)
+	return updated, err
+}
+
+const deleteDefaultsByVersionQuery = `
+	DELETE FROM ONLY default_instant_launches as def
+	WHERE def.version = ?;
+`
+
+// DeleteDefaultsByVersion removes a default instant launch mapping from the database
+// based on its version.
+func (a *App) DeleteDefaultsByVersion(version int) error {
+	_, err := a.DB.Exec(deleteDefaultsByVersionQuery, version)
+	return err
+}
+
+const listAllDefaultsQuery = `
+    SELECT def.id,
+           def.version,
+           def.instant_launches as mapping
+      FROM default_instant_launches def;
+`
+
+// ListAllDefaults returns a list of all of the default instant launches, including their version.
+func (a *App) ListAllDefaults() (ListAllDefaultsResponse, error) {
+	m := ListAllDefaultsResponse{Defaults: []DefaultInstantLaunchMapping{}}
+	err := a.DB.Select(&m.Defaults, listAllDefaultsQuery)
+	return m, err
+}

--- a/instantlaunches/main.go
+++ b/instantlaunches/main.go
@@ -538,6 +538,8 @@ func New(db *sqlx.DB, group *echo.Group, init *Init) *App {
 	//			default: errorResponse
 	instance.Group.DELETE("/:id", instance.DeleteInstantLaunchHandler)
 
+	instance.Group.GET("/:id/full", instance.FullInstantLaunchHandler)
+
 	instance.Group.GET("/:id/metadata", instance.GetMetadataHandler)
 	instance.Group.POST("/:id/metadata", instance.AddOrUpdateMetadataHandler)
 	instance.Group.PUT("/:id/metadata", instance.SetAllMetadataHandler)

--- a/instantlaunches/main.go
+++ b/instantlaunches/main.go
@@ -58,6 +58,26 @@ type InstantLaunch struct {
 	db      *sqlx.DB
 }
 
+//FullInstantLaunch contains more data about the instant launch, including quick launch
+// info, the submission, and app info.
+type FullInstantLaunch struct {
+	ID                     string `json:"id" db:"id"`
+	AddedBy                string `json:"added_by" db:"added_by"`
+	AddedOn                string `json:"added_on" db:"added_on"`
+	QuickLaunchID          string `json:"quick_launch_id" db:"quick_launch_id"`
+	QuickLaunchName        string `json:"quick_launch_name" db:"ql_name"`
+	QuickLaunchDescription string `json:"quick_launch_description" db:"ql_description"`
+	QuickLaunchCreator     string `json:"quick_launch_creator" db:"ql_creator"`
+	QuickLaunchIsPublic    bool   `json:"is_public" db:"is_public"`
+	Submission             string `json:"submission" db:"submission"`
+	AppID                  string `json:"app_id" db:"app_id"`
+	AppName                string `json:"app_name" db:"app_name"`
+	AppDescription         string `json:"app_description" db:"app_description"`
+	AppDeleted             bool   `json:"app_deleted" db:"app_deleted"`
+	AppDisabled            bool   `json:"app_disabled" db:"app_disabled"`
+	AppIntegrator          string `json:"integrator" db:"integrator"`
+}
+
 // NewInstantLaunchFromJSON instantiates and returns a new *InstantLaunch from the
 // ReadCloser passed in. The ReadCloser is closed as part of this function.
 func NewInstantLaunchFromJSON(r io.ReadCloser) (*InstantLaunch, error) {
@@ -434,6 +454,7 @@ func New(db *sqlx.DB, group *echo.Group, init *Init) *App {
 	instance.Group.DELETE("/mappings/:username/:version", instance.DeleteUserMappingsByVersionHandler)
 
 	instance.Group.GET("/metadata", instance.ListMetadataHandler)
+	instance.Group.GET("/metadata/full", instance.FullListMetadataHandler)
 
 	// swagger.route PUT /instantlaunches/ instantlaunches addInstantLaunch
 	//

--- a/instantlaunches/main.go
+++ b/instantlaunches/main.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/cyverse-de/app-exposer/permissions"
 	"github.com/jmoiron/sqlx"
+	"github.com/jmoiron/sqlx/types"
 	"github.com/labstack/echo/v4"
 )
 
@@ -61,21 +62,21 @@ type InstantLaunch struct {
 //FullInstantLaunch contains more data about the instant launch, including quick launch
 // info, the submission, and app info.
 type FullInstantLaunch struct {
-	ID                     string `json:"id" db:"id"`
-	AddedBy                string `json:"added_by" db:"added_by"`
-	AddedOn                string `json:"added_on" db:"added_on"`
-	QuickLaunchID          string `json:"quick_launch_id" db:"quick_launch_id"`
-	QuickLaunchName        string `json:"quick_launch_name" db:"ql_name"`
-	QuickLaunchDescription string `json:"quick_launch_description" db:"ql_description"`
-	QuickLaunchCreator     string `json:"quick_launch_creator" db:"ql_creator"`
-	QuickLaunchIsPublic    bool   `json:"is_public" db:"is_public"`
-	Submission             string `json:"submission" db:"submission"`
-	AppID                  string `json:"app_id" db:"app_id"`
-	AppName                string `json:"app_name" db:"app_name"`
-	AppDescription         string `json:"app_description" db:"app_description"`
-	AppDeleted             bool   `json:"app_deleted" db:"app_deleted"`
-	AppDisabled            bool   `json:"app_disabled" db:"app_disabled"`
-	AppIntegrator          string `json:"integrator" db:"integrator"`
+	ID                     string         `json:"id" db:"id"`
+	AddedBy                string         `json:"added_by" db:"added_by"`
+	AddedOn                string         `json:"added_on" db:"added_on"`
+	QuickLaunchID          string         `json:"quick_launch_id" db:"quick_launch_id"`
+	QuickLaunchName        string         `json:"quick_launch_name" db:"ql_name"`
+	QuickLaunchDescription string         `json:"quick_launch_description" db:"ql_description"`
+	QuickLaunchCreator     string         `json:"quick_launch_creator" db:"ql_creator"`
+	QuickLaunchIsPublic    bool           `json:"is_public" db:"is_public"`
+	Submission             types.JSONText `json:"submission" db:"submission"`
+	AppID                  string         `json:"app_id" db:"app_id"`
+	AppName                string         `json:"app_name" db:"app_name"`
+	AppDescription         string         `json:"app_description" db:"app_description"`
+	AppDeleted             bool           `json:"app_deleted" db:"app_deleted"`
+	AppDisabled            bool           `json:"app_disabled" db:"app_disabled"`
+	AppIntegrator          string         `json:"integrator" db:"integrator"`
 }
 
 // NewInstantLaunchFromJSON instantiates and returns a new *InstantLaunch from the

--- a/instantlaunches/metadata.go
+++ b/instantlaunches/metadata.go
@@ -110,7 +110,7 @@ FROM instant_launches il
 	JOIN users ilu ON il.added_by = ilu.id
 
 
-WHERE il.id IN $1;
+WHERE il.id = any($1);
 `
 
 // FullListMetadataHandler returns a list of instant launches with the quick launches

--- a/instantlaunches/mgmt.go
+++ b/instantlaunches/mgmt.go
@@ -9,19 +9,6 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
-const addInstantLaunchQuery = `
-	INSERT INTO instant_launches (quick_launch_id, added_by)
-	VALUES ( $1, ( SELECT u.id FROM users u WHERE u.username = $2 ) )
-	RETURNING id, quick_launch_id, added_by, added_on;
-`
-
-// AddInstantLaunch registers a new instant launch in the database.
-func (a *App) AddInstantLaunch(quickLaunchID, username string) (*InstantLaunch, error) {
-	newvalues := &InstantLaunch{}
-	err := a.DB.QueryRowx(addInstantLaunchQuery, quickLaunchID, username).StructScan(newvalues)
-	return newvalues, err
-}
-
 // AddInstantLaunchHandler is the HTTP handler for adding a new instant launch.
 func (a *App) AddInstantLaunchHandler(c echo.Context) error {
 	il, err := NewInstantLaunchFromJSON(c.Request().Body)
@@ -48,19 +35,6 @@ func (a *App) AddInstantLaunchHandler(c echo.Context) error {
 	return c.JSON(http.StatusOK, newil)
 }
 
-const getInstantLaunchQuery = `
-	SELECT i.id, i.quick_launch_id, i.added_by, i.added_on
-	FROM instant_launches i
-	WHERE i.id = $1;
-`
-
-// GetInstantLaunch returns a stored instant launch by ID.
-func (a *App) GetInstantLaunch(id string) (*InstantLaunch, error) {
-	il := &InstantLaunch{}
-	err := a.DB.QueryRowx(getInstantLaunchQuery, id).StructScan(il)
-	return il, err
-}
-
 // GetInstantLaunchHandler is the HTTP handler for getting a specific Instant Launch
 // by its UUID.
 func (a *App) GetInstantLaunchHandler(c echo.Context) error {
@@ -81,46 +55,6 @@ func (a *App) GetInstantLaunchHandler(c echo.Context) error {
 
 }
 
-const fullInstantLaunchQuery = `
-SELECT
-	il.id,
-	ilu.username AS added_by,
-	il.added_on,
-	il.quick_launch_id,
-	ql.name AS ql_name,
-	ql.description AS ql_description,
-	qlu.username AS ql_creator,
-	sub.submission AS submission,
-	ql.app_id,
-	ql.is_public,
-	a.name AS app_name,
-	a.description AS app_description,
-	a.deleted AS app_deleted,
-	a.disabled AS app_disabled,
-	iu.username as integrator
-
-
-FROM instant_launches il
-	JOIN quick_launches ql ON il.quick_launch_id = ql.id
-	JOIN submissions sub ON ql.submission_id = sub.id
-	JOIN apps a ON ql.app_id = a.id
-	JOIN integration_data integ ON a.integration_data_id = integ.id
-	JOIN users iu ON integ.user_id = iu.id
-	JOIN users qlu ON ql.creator = qlu.id
-	JOIN users ilu ON il.added_by = ilu.id
-
-
-WHERE il.id = $1;
-`
-
-// FullInstantLaunch returns an instant launch from the database that
-// includes quick launch, app, and submission information.
-func (a *App) FullInstantLaunch(id string) (*FullInstantLaunch, error) {
-	fil := &FullInstantLaunch{}
-	err := a.DB.QueryRowx(fullInstantLaunchQuery, id).StructScan(fil)
-	return fil, err
-}
-
 // FullInstantLaunchHandler is the HTTP handler for getting a full description of
 // an instant launch, including its quick launch, submission, and basic app info.
 func (a *App) FullInstantLaunchHandler(c echo.Context) error {
@@ -138,20 +72,6 @@ func (a *App) FullInstantLaunchHandler(c echo.Context) error {
 	}
 
 	return c.JSON(http.StatusOK, il)
-}
-
-const updateInstantLaunchQuery = `
-	UPDATE ONLY instant_launches
-	SET quick_launch_id = $1
-	WHERE id = $2
-	RETURNING id, quick_launch_id, added_by, added_by;
-`
-
-// UpdateInstantLaunch updates a stored instant launch with new values.
-func (a *App) UpdateInstantLaunch(id, quickLaunchID string) (*InstantLaunch, error) {
-	il := &InstantLaunch{}
-	err := a.DB.QueryRowx(updateInstantLaunchQuery, quickLaunchID, id).StructScan(il)
-	return il, err
 }
 
 // UpdateInstantLaunchHandler is the HTTP handler for updating an instant launch.
@@ -177,16 +97,6 @@ func (a *App) UpdateInstantLaunchHandler(c echo.Context) error {
 	return c.JSON(http.StatusOK, newvalue)
 }
 
-const deleteInstantLaunchQuery = `
-	DELETE FROM instant_launches WHERE id = $1;
-`
-
-// DeleteInstantLaunch deletes a stored instant launch.
-func (a *App) DeleteInstantLaunch(id string) error {
-	_, err := a.DB.Exec(deleteInstantLaunchQuery, id)
-	return err
-}
-
 // DeleteInstantLaunchHandler is the HTTP handler for deleting an Instant Launch
 // based on its UUID.
 func (a *App) DeleteInstantLaunchHandler(c echo.Context) error {
@@ -198,18 +108,6 @@ func (a *App) DeleteInstantLaunchHandler(c echo.Context) error {
 	err := a.DeleteInstantLaunch(id)
 	return err
 
-}
-
-const listInstantLaunchesQuery = `
-	SELECT i.id, i.quick_launch_id, i.added_by, i.added_on
-	FROM instant_launches i;
-`
-
-// ListInstantLaunches lists all registered instant launches.
-func (a *App) ListInstantLaunches() ([]InstantLaunch, error) {
-	all := []InstantLaunch{}
-	err := a.DB.Select(&all, listInstantLaunchesQuery)
-	return all, err
 }
 
 // ListInstantLaunchesHandler is the HTTP handler for listing all of the

--- a/instantlaunches/users.go
+++ b/instantlaunches/users.go
@@ -10,54 +10,6 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
-const userMappingQuery = `
-    SELECT u.id,
-           u.version,
-           u.instant_launches as mapping
-      FROM user_instant_launches u
-      JOIN users ON u.user_id = users.id
-     WHERE users.username = $1
-  ORDER BY u.version DESC
-     LIMIT 1;
-`
-
-const updateUserMappingQuery = `
-    UPDATE ONLY user_instant_launches
-            SET user_instant_launches.instant_launches = $1
-           FROM users
-          WHERE user_instant_launches.version = (
-              SELECT max(u.version)
-                FROM user_instant_launches u
-          )
-            AND user_id = users.id
-            AND users.username = $2
-          RETURNING user_instant_launches.instant_launches;
-`
-
-const deleteUserMappingQuery = `
-	DELETE FROM ONLY user_instant_launches
-	USING users
-	WHERE user_instant_launches.user_id = users.id
-	  AND users.username = $1
-	  AND user_instant_launches.version = (
-		  SELECT max(u.version)
-		    FROM user_instant_launches u
-	  );
-`
-
-const createUserMappingQuery = `
-	INSERT INTO user_instant_launches (instant_launches, user_id)
-	VALUES ( $1, (SELECT id FROM users WHERE username = $2) )
-	RETURNING instant_launches;
-`
-
-// UserMapping returns the user's instant launch mappings.
-func (a *App) UserMapping(user string) (*UserInstantLaunchMapping, error) {
-	m := &UserInstantLaunchMapping{}
-	err := a.DB.Get(m, userMappingQuery, user)
-	return m, err
-}
-
 // UserMappingHandler is the echo handler for the http API that returns the user's
 // instant launch mappings.
 func (a *App) UserMappingHandler(c echo.Context) error {
@@ -78,14 +30,6 @@ func (a *App) UserMappingHandler(c echo.Context) error {
 		return err
 	}
 	return c.JSON(http.StatusOK, m)
-}
-
-// UpdateUserMapping updates the the latest version of the user's custom
-// instant launch mappings.
-func (a *App) UpdateUserMapping(user string, update *InstantLaunchMapping) (*InstantLaunchMapping, error) {
-	updated := &InstantLaunchMapping{}
-	err := a.DB.QueryRowx(updateUserMappingQuery, update, user).Scan(updated)
-	return updated, err
 }
 
 // UpdateUserMappingHandler is the echo handler for the HTTP API that updates the user's
@@ -116,13 +60,6 @@ func (a *App) UpdateUserMappingHandler(c echo.Context) error {
 	return c.JSON(http.StatusOK, updated)
 }
 
-// DeleteUserMapping is intended as an admin only operation that completely removes
-// the latest mapping for the user.
-func (a *App) DeleteUserMapping(user string) error {
-	_, err := a.DB.Exec(deleteUserMappingQuery, user)
-	return err
-}
-
 // DeleteUserMappingHandler is the handler for the admin-only operation that removes
 // the latest mapping for the user.
 func (a *App) DeleteUserMappingHandler(c echo.Context) error {
@@ -134,16 +71,6 @@ func (a *App) DeleteUserMappingHandler(c echo.Context) error {
 		user = fmt.Sprintf("%s%s", user, a.UserSuffix)
 	}
 	return a.DeleteUserMapping(user)
-}
-
-// AddUserMapping adds a new record to the database for the user's instant launches.
-func (a *App) AddUserMapping(user string, mapping *InstantLaunchMapping) (*InstantLaunchMapping, error) {
-	newvalue := &InstantLaunchMapping{}
-	err := a.DB.QueryRowx(createUserMappingQuery, mapping, user).Scan(newvalue)
-	if err != nil {
-		return nil, err
-	}
-	return newvalue, nil
 }
 
 // AddUserMappingHandler is the HTTP handler for adding a new user mapping to the database.
@@ -170,23 +97,6 @@ func (a *App) AddUserMappingHandler(c echo.Context) error {
 	return c.JSON(http.StatusOK, retval)
 }
 
-const allUserMappingsQuery = `
-  SELECT u.id,
-		 u.version,
-		 u.user_id,
-         u.instant_launches as mapping
-    FROM user_instant_launches u
-    JOIN users ON u.user_id = users.id
-   WHERE users.username = ?;
-`
-
-// AllUserMappings returns all of the user's instant launch mappings regardless of version.
-func (a *App) AllUserMappings(user string) ([]UserInstantLaunchMapping, error) {
-	m := []UserInstantLaunchMapping{}
-	err := a.DB.Select(&m, allUserMappingsQuery, user)
-	return m, err
-}
-
 // AllUserMappingsHandler is the echo handler for the http API that returns the user's
 // instant launch mappings.
 func (a *App) AllUserMappingsHandler(c echo.Context) error {
@@ -208,41 +118,6 @@ func (a *App) AllUserMappingsHandler(c echo.Context) error {
 	}
 
 	return c.JSON(http.StatusOK, m)
-}
-
-const userMappingsByVersionQuery = `
-    SELECT u.id,
-           u.version,
-           u.instant_launches as mapping
-      FROM user_instant_launches u
-      JOIN users ON u.user_id = users.id
-     WHERE users.username = ?
-       AND u.version = ?
-`
-
-const updateUserMappingsByVersionQuery = `
-    UPDATE ONLY user_instant_launches AS def
-            SET def.instant_launches = jsonb_object(?)
-           FROM users
-          WHERE def.version = ?
-            AND def.user_id = users.id
-            AND users.username = ?
-        RETURNING def.instant_launches;
-`
-
-const deleteUserMappingsByVersionQuery = `
-	DELETE FROM ONLY user_instant_launches AS def
-	USING users
-	WHERE def.user_id = users.id
-	  AND users.username = ?
-	  AND def.version = ?;
-`
-
-// UserMappingsByVersion returns a specific version of the user's instant launch mappings.
-func (a *App) UserMappingsByVersion(user string, version int) (UserInstantLaunchMapping, error) {
-	m := UserInstantLaunchMapping{}
-	err := a.DB.Get(&m, userMappingsByVersionQuery, user, version)
-	return m, err
 }
 
 // UserMappingsByVersionHandler is the echo handler for the http API that returns a specific
@@ -271,16 +146,6 @@ func (a *App) UserMappingsByVersionHandler(c echo.Context) error {
 	}
 
 	return c.JSON(http.StatusOK, m)
-}
-
-// UpdateUserMappingsByVersion updates the user's instant launches for a specific version.
-func (a *App) UpdateUserMappingsByVersion(user string, version int, update *InstantLaunchMapping) (*InstantLaunchMapping, error) {
-	retval := &InstantLaunchMapping{}
-	err := a.DB.QueryRowx(updateUserMappingsByVersionQuery, update, version, user).Scan(retval)
-	if err != nil {
-		return nil, err
-	}
-	return retval, nil
 }
 
 // UpdateUserMappingsByVersionHandler is the echo handler for the HTTP API that allows callers
@@ -316,12 +181,6 @@ func (a *App) UpdateUserMappingsByVersionHandler(c echo.Context) error {
 	}
 
 	return c.JSON(http.StatusOK, newversion)
-}
-
-// DeleteUserMappingsByVersion deletes a user's instant launch mappings at a specific version.
-func (a *App) DeleteUserMappingsByVersion(user string, version int) error {
-	_, err := a.DB.Exec(deleteUserMappingsByVersionQuery, user, version)
-	return err
 }
 
 // DeleteUserMappingsByVersionHandler is the echo handler for the HTTP API that allows callers


### PR DESCRIPTION
In this case, I mean actionable to mean that a caller can grab submission, quick launch, and instant launch information in a single request, allowing the caller to submit an instant launch job without having to perform separate requests for each piece of information.

This adds the `/instantlaunches/:id/full` endpoint, which returns the info for a single instant launch, and the `/instantlaunches/metadata/full`, which returns a listing of that info for multiple instant launches based on the metadata passed in.