### PR TITLE
Add endpoint to list quicklaunches for public apps

### DIFF
--- a/instantlaunches/db.go
+++ b/instantlaunches/db.go
@@ -436,3 +436,24 @@ func (a *App) ListAllDefaults() (ListAllDefaultsResponse, error) {
 	err := a.DB.Select(&m.Defaults, listAllDefaultsQuery)
 	return m, err
 }
+
+const listPublicQLsQuery = `
+	SELECT ql.id,
+		u.username as creator,
+		ql.app_id,
+		ql.name,
+		ql.description,
+		ql.is_public,
+		s.submission
+	FROM quick_launches ql
+	JOIN app_listing a on ql.app_id = a.id
+	JOIN users u on ql.creator = u.id
+	JOIN submissions s on ql.submission_id = s.id
+	WHERE u.username = $1 OR ( ql.is_public = true AND a.is_public = true)
+`
+
+func (a *App) ListViablePublicQuickLaunches(user string) ([]QuickLaunch, error) {
+	l := []QuickLaunch{}
+	err := a.DB.Select(&l, listPublicQLsQuery, user)
+	return l, err
+}

--- a/instantlaunches/main.go
+++ b/instantlaunches/main.go
@@ -156,6 +156,16 @@ type UserInstantLaunchMapping struct {
 	Mapping InstantLaunchMapping `json:"mapping" db:"mapping"`
 }
 
+type QuickLaunch struct {
+	ID          string         `json:"id" db:"id"`
+	Creator     string         `json:"createor" db:"creator"`
+	AppID       string         `json:"app_id" db:"app_id"`
+	Name        string         `json:"name" db:"name"`
+	Description string         `json:"description" db:"description"`
+	IsPublic    bool           `json:"is_public" db:"is_public"`
+	Submission  types.JSONText `json:"submission" db:"submission"`
+}
+
 // App provides an API for managing instant launches.
 type App struct {
 	DB              *sqlx.DB
@@ -184,6 +194,7 @@ func New(db *sqlx.DB, group *echo.Group, init *Init) *App {
 		},
 	}
 
+	instance.Group.GET("/quicklaunches/public", instance.ListViablePublicQuickLaunchesHandler)
 	instance.Group.GET("/mappings/defaults", instance.ListDefaultsHandler)
 	instance.Group.GET("/mappings/defaults/latest", instance.LatestDefaultsHandler)
 	instance.Group.PUT("/mappings/defaults/latest", instance.AddLatestDefaultsHandler)

--- a/instantlaunches/mgmt.go
+++ b/instantlaunches/mgmt.go
@@ -136,3 +136,22 @@ func (a *App) FullListInstantLaunchesHandler(c echo.Context) error {
 	}
 	return c.JSON(http.StatusOK, list)
 }
+
+// ListViablePublicQuickLaunchesHandler is the HTTP handler for getting a listing
+// of public quick launches that are associated with apps that are currently
+// public. This should help us avoid situations where we accidentally list public
+// quick launches for apps that have been deleted or are otherwise no longer public.
+func (a *App) ListViablePublicQuickLaunchesHandler(c echo.Context) error {
+	user := c.QueryParam("user")
+	if user == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "user must be set")
+	}
+	list, err := a.ListViablePublicQuickLaunches(user)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return echo.NewHTTPError(http.StatusNotFound, err.Error())
+		}
+		return err
+	}
+	return c.JSON(http.StatusOK, list)
+}


### PR DESCRIPTION
Our current quick launch listing endpoint will list all quick launch regardless of whether its app is public or not. This endpoint only lists quick launches if they're public and the app is public.