### PR TITLE
Use an image pull secret name provided from the configuration file to configure imagePullSecrets for VICE deployments

### DIFF
--- a/app.go
+++ b/app.go
@@ -35,6 +35,7 @@ type ExposerAppInit struct {
 	UseCSIDriver                  bool   // Yes to use CSI Driver for data input/output, No to use Vice-file-transfer
 	InputPathListIdentifier       string // Header line for input path lists
 	TicketInputPathListIdentifier string // Header line for ticket input path lists
+	ImagePullSecretName           string // A secret name to add to pods' imagePullSecrets
 	JobStatusURL                  string
 	ViceProxyImage                string
 	CASBaseURL                    string
@@ -64,6 +65,7 @@ func NewExposerApp(init *ExposerAppInit, ingressClass string, cs kubernetes.Inte
 		UseCSIDriver:                  init.UseCSIDriver,
 		InputPathListIdentifier:       init.InputPathListIdentifier,
 		TicketInputPathListIdentifier: init.TicketInputPathListIdentifier,
+		ImagePullSecretName:           init.ImagePullSecretName,
 		ViceProxyImage:                init.ViceProxyImage,
 		CASBaseURL:                    init.CASBaseURL,
 		FrontendBaseURL:               init.FrontendBaseURL,

--- a/internal/deployments.go
+++ b/internal/deployments.go
@@ -486,8 +486,16 @@ func (i *Internal) deploymentContainers(job *model.Job) []apiv1.Container {
 	return output
 }
 
-// imagePullSecrets creates an array of LocalObjectReference that refer to any configured secrets to use for pulling images
+// imagePullSecrets creates an array of LocalObjectReference that refer to any
+// configured secrets to use for pulling images This is passed the job because
+// it may be advantageous, in the future, to add secrets depending on the
+// images actually needed by the job, but at present this uses a static value
 func (i *Internal) imagePullSecrets(_ *model.Job) []apiv1.LocalObjectReference {
+	if i.ImagePullSecretName != "" {
+		return []apiv1.LocalObjectReference{
+			{Name: i.ImagePullSecretName},
+		}
+	}
 	return []apiv1.LocalObjectReference{}
 }
 

--- a/internal/deployments.go
+++ b/internal/deployments.go
@@ -486,6 +486,11 @@ func (i *Internal) deploymentContainers(job *model.Job) []apiv1.Container {
 	return output
 }
 
+// imagePullSecrets creates an array of LocalObjectReference that refer to any configured secrets to use for pulling images
+func (i *Internal) imagePullSecrets(_ *model.Job) []apiv1.LocalObjectReference {
+	return []apiv1.LocalObjectReference{}
+}
+
 // getDeployment assembles and returns the Deployment for the VICE analysis. It does
 // not call the k8s API.
 func (i *Internal) getDeployment(job *model.Job) (*appsv1.Deployment, error) {
@@ -554,6 +559,7 @@ func (i *Internal) getDeployment(job *model.Job) (*appsv1.Deployment, error) {
 					Volumes:                      i.deploymentVolumes(job),
 					InitContainers:               i.initContainers(job),
 					Containers:                   i.deploymentContainers(job),
+					ImagePullSecrets:             i.imagePullSecrets(job),
 					AutomountServiceAccountToken: &autoMount,
 					SecurityContext: &apiv1.PodSecurityContext{
 						RunAsUser:  int64Ptr(int64(job.Steps[0].Component.Container.UID)),

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -68,6 +68,7 @@ type Init struct {
 	UseCSIDriver                  bool
 	InputPathListIdentifier       string
 	TicketInputPathListIdentifier string
+	ImagePullSecretName           string
 	ViceProxyImage                string
 	CASBaseURL                    string
 	FrontendBaseURL               string

--- a/main.go
+++ b/main.go
@@ -202,6 +202,7 @@ func main() {
 		UseCSIDriver:                  cfg.GetBool("vice.use_csi_driver"),
 		InputPathListIdentifier:       cfg.GetString("path_list.file_identifier"),
 		TicketInputPathListIdentifier: cfg.GetString("tickets_path_list.file_identifier"),
+		ImagePullSecretName:           cfg.GetString("vice.image-pull-secret"),
 		JobStatusURL:                  jobStatusURL,
 		ViceProxyImage:                proxyImage,
 		CASBaseURL:                    cfg.GetString("cas.base"),


### PR DESCRIPTION
I think this should work -- pretty sure if it's not configured, it'll just get an empty string and then configure nothing, which is probably what we want.