### PR TITLE
Add replace directives to go.mod for easier fork development

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,18 @@ module github.com/cyverse-de/app-exposer
 
 go 1.12
 
+replace github.com/cyverse-de/app-exposer/apps => ./apps
+
+replace github.com/cyverse-de/app-exposer/common => ./common
+
+replace github.com/cyverse-de/app-exposer/external => ./external
+
+replace github.com/cyverse-de/app-exposer/instantlaunches => ./instantlaunches
+
+replace github.com/cyverse-de/app-exposer/internal => ./internal
+
+replace github.com/cyverse-de/app-exposer/permissions => ./permissions
+
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.0
 	github.com/cyverse-de/configurate v0.0.0-20190318152107-8f767cb828d9


### PR DESCRIPTION
This adds the replace directive to go.mod so that the go tools will look at the local versions of packages rather than pulling the version that's available on GitHub. This should make it easier to work in a fork while also still creating consistent builds. New packages will necessitate new `replace` directives in the go.mod file.