### PR TITLE
Set the millicores_reserved value for each submitted job.

### DIFF
--- a/apps/main.go
+++ b/apps/main.go
@@ -133,3 +133,14 @@ func (a *Apps) GetUserID(username string) (string, error) {
 	err := a.DB.QueryRow(userByUsername, username).Scan(&id)
 	return id, err
 }
+
+const setMillicoresStmt = `
+	UPDATE jobs
+	SET millicores_reserved = $2
+	WHERE id = $1;
+`
+
+func (a *Apps) SetMillicoresReserved(analysisID string, millicores int) error {
+	_, err := a.DB.Exec(setMillicoresStmt, analysisID, millicores)
+	return err
+}

--- a/apps/main.go
+++ b/apps/main.go
@@ -136,11 +136,11 @@ func (a *Apps) GetUserID(username string) (string, error) {
 
 const setMillicoresStmt = `
 	UPDATE jobs
-	SET millicores_reserved = $2
+	SET millicores_reserved = $2::int
 	WHERE id = $1;
 `
 
-func (a *Apps) SetMillicoresReserved(analysisID string, millicores int) error {
+func (a *Apps) SetMillicoresReserved(analysisID string, millicores float64) error {
 	_, err := a.DB.Exec(setMillicoresStmt, analysisID, millicores)
 	return err
 }

--- a/internal/deployments.go
+++ b/internal/deployments.go
@@ -15,7 +15,7 @@ import (
 )
 
 // One gibibyte.
-const gibibyte = 1024 * 1024 * 1024
+//const gibibyte = 1024 * 1024 * 1024
 
 // analysisPorts returns a list of container ports needed by the VICE analysis.
 func analysisPorts(step *model.Step) []apiv1.ContainerPort {

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -314,10 +314,10 @@ func tryForAnalysisID(job *model.Job, maxAttempts int, apps *apps.Apps) (string,
 	return "", fmt.Errorf("failed to find analysis ID after %d attempts", maxAttempts)
 }
 
-func getMillicoresFromDeployment(deployment *appsv1.Deployment) (int, error) {
+func getMillicoresFromDeployment(deployment *appsv1.Deployment) (float64, error) {
 	var (
 		analysisContainer *apiv1.Container
-		millicores        int
+		millicores        float64
 	)
 	containers := deployment.Spec.Template.Spec.Containers
 
@@ -335,7 +335,7 @@ func getMillicoresFromDeployment(deployment *appsv1.Deployment) (int, error) {
 		return 0, errors.New("could not find the analysis container in the deployment")
 	}
 
-	millicores = analysisContainer.Resources.Limits[apiv1.ResourceCPU].ToUnstructured().(int)
+	millicores = analysisContainer.Resources.Limits[apiv1.ResourceCPU].ToUnstructured().(float64)
 
 	log.Debugf("%d millicores reservation found", millicores)
 

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -340,7 +340,6 @@ func getMillicoresFromDeployment(deployment *appsv1.Deployment) (int, error) {
 	log.Debugf("%d millicores reservation found", millicores)
 
 	return millicores, nil
-
 }
 
 // LaunchAppHandler is the HTTP handler that orchestrates the launching of a VICE analysis inside

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -18,6 +18,8 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/cyverse-de/model"
+	appsv1 "k8s.io/api/apps/v1"
+	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes"
@@ -201,12 +203,8 @@ func (i *Internal) UpsertInputPathListConfigMap(job *model.Job) error {
 // UpsertDeployment uses the Job passed in to assemble a Deployment for the
 // VICE analysis. If then uses the k8s API to create the Deployment if it does
 // not already exist or to update it if it does.
-func (i *Internal) UpsertDeployment(job *model.Job) error {
-	deployment, err := i.getDeployment(job)
-	if err != nil {
-		return err
-	}
-
+func (i *Internal) UpsertDeployment(deployment *appsv1.Deployment, job *model.Job) error {
+	var err error
 	ctx := context.TODO()
 	depclient := i.clientset.AppsV1().Deployments(i.ViceNamespace)
 
@@ -304,6 +302,47 @@ func (i *Internal) UpsertDeployment(job *model.Job) error {
 	return nil
 }
 
+func tryForAnalysisID(job *model.Job, maxAttempts int, apps *apps.Apps) (string, error) {
+	for i := 0; i < maxAttempts; i++ {
+		analysisID, err := apps.GetAnalysisIDByExternalID(job.InvocationID)
+		if err != nil {
+			time.Sleep(1 * time.Second)
+		} else {
+			return analysisID, nil
+		}
+	}
+	return "", fmt.Errorf("failed to find analysis ID after %d attempts", maxAttempts)
+}
+
+func getMillicoresFromDeployment(deployment *appsv1.Deployment) (int, error) {
+	var (
+		analysisContainer *apiv1.Container
+		millicores        int
+	)
+	containers := deployment.Spec.Template.Spec.Containers
+
+	found := false
+
+	for _, container := range containers {
+		if container.Name == analysisContainerName {
+			analysisContainer = &container
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		return 0, errors.New("could not find the analysis container in the deployment")
+	}
+
+	millicores = analysisContainer.Resources.Limits[apiv1.ResourceCPU].ToUnstructured().(int)
+
+	log.Debugf("%d millicores reservation found", millicores)
+
+	return millicores, nil
+
+}
+
 // LaunchAppHandler is the HTTP handler that orchestrates the launching of a VICE analysis inside
 // the k8s cluster. This get passed to the router to be associated with a route. The Job
 // is passed in as the body of the request.
@@ -314,6 +353,7 @@ func (i *Internal) LaunchAppHandler(c echo.Context) error {
 	)
 
 	job = &model.Job{}
+	apps := apps.NewApps(i.db, i.UserSuffix)
 
 	if err = c.Bind(job); err != nil {
 		return err
@@ -336,8 +376,27 @@ func (i *Internal) LaunchAppHandler(c echo.Context) error {
 		return err
 	}
 
+	deployment, err := i.getDeployment(job)
+	if err != nil {
+		return err
+	}
+
+	analysisID, err := tryForAnalysisID(job, 15, apps)
+	if err != nil {
+		return err
+	}
+
+	millicores, err := getMillicoresFromDeployment(deployment)
+	if err != nil {
+		return err
+	}
+
+	if err = apps.SetMillicoresReserved(analysisID, millicores); err != nil {
+		return err
+	}
+
 	// Create the deployment for the job.
-	if err = i.UpsertDeployment(job); err != nil {
+	if err = i.UpsertDeployment(deployment, job); err != nil {
 		return err
 	}
 

--- a/internal/volumes.go
+++ b/internal/volumes.go
@@ -186,7 +186,7 @@ func (i *Internal) getPersistentVolumes(job *model.Job) ([]*apiv1.PersistentVolu
 		ioPathMappings = append(ioPathMappings, outputPathMapping)
 
 		// convert pathMappings into json
-		ioPathMappingsJsonBytes, err := json.Marshal(ioPathMappings)
+		ioPathMappingsJSONBytes, err := json.Marshal(ioPathMappings)
 		if err != nil {
 			return nil, err
 		}
@@ -202,7 +202,7 @@ func (i *Internal) getPersistentVolumes(job *model.Job) ([]*apiv1.PersistentVolu
 		sharedPathMapping := i.getSharedPathMapping(job)
 		homePathMappings = append(homePathMappings, sharedPathMapping)
 
-		homePathMappingsJsonBytes, err := json.Marshal(homePathMappings)
+		homePathMappingsJSONBytes, err := json.Marshal(homePathMappings)
 		if err != nil {
 			return nil, err
 		}
@@ -236,7 +236,7 @@ func (i *Internal) getPersistentVolumes(job *model.Job) ([]*apiv1.PersistentVolu
 						VolumeHandle: i.getCSIInputOutputVolumeHandle(job),
 						VolumeAttributes: map[string]string{
 							"client":            "irodsfuse",
-							"path_mapping_json": string(ioPathMappingsJsonBytes),
+							"path_mapping_json": string(ioPathMappingsJSONBytes),
 							// use proxy access
 							"clientUser": job.Submitter,
 							"uid":        fmt.Sprintf("%d", job.Steps[0].Component.Container.UID),
@@ -276,7 +276,7 @@ func (i *Internal) getPersistentVolumes(job *model.Job) ([]*apiv1.PersistentVolu
 							VolumeHandle: i.getCSIHomeVolumeHandle(job),
 							VolumeAttributes: map[string]string{
 								"client":            "irodsfuse",
-								"path_mapping_json": string(homePathMappingsJsonBytes),
+								"path_mapping_json": string(homePathMappingsJSONBytes),
 								// use proxy access
 								"clientUser": job.Submitter,
 								"uid":        fmt.Sprintf("%d", job.Steps[0].Component.Container.UID),


### PR DESCRIPTION
Updates the jobs.millicores_reserved column in the database with the value found in the job submission. Also, refactors some of the code that sets the limits and requests in the deployment so it's a bit easier to follow.