### PR TITLE
CORE-1667: data access improvements for VICE with iRODS CSI Driver integration enabled

### DIFF
--- a/app.go
+++ b/app.go
@@ -55,6 +55,7 @@ type ExposerAppInit struct {
 	KeycloakRealm                 string
 	KeycloakClientID              string
 	KeycloakClientSecret          string
+	IRODSZone                     string
 }
 
 // NewExposerApp creates and returns a newly instantiated *ExposerApp.
@@ -83,6 +84,7 @@ func NewExposerApp(init *ExposerAppInit, ingressClass string, cs kubernetes.Inte
 		KeycloakRealm:                 init.KeycloakRealm,
 		KeycloakClientID:              init.KeycloakClientID,
 		KeycloakClientSecret:          init.KeycloakClientSecret,
+		IRODSZone:                     init.IRODSZone,
 	}
 
 	app := &ExposerApp{

--- a/apps/apps.go
+++ b/apps/apps.go
@@ -44,6 +44,7 @@ func NewApps(db *sqlx.DB, userSuffix string) *Apps {
 	}
 }
 
+// Run runs the goroutine for storing millicores reserved for new jobs.
 func (a *Apps) Run() {
 	for {
 		select {
@@ -70,6 +71,7 @@ func (a *Apps) Run() {
 	}
 }
 
+// Finish exits the goroutine for storing millicores reserved for new jobs.
 func (a *Apps) Finish() {
 	a.exit <- true
 }
@@ -227,6 +229,7 @@ func (a *Apps) storeMillicoresInternal(job *model.Job, millicores *apd.Decimal) 
 	return err
 }
 
+// SetMillicoresReserved updates the number of millicores reserved for a single job.
 func (a *Apps) SetMillicoresReserved(job *model.Job, millicores *apd.Decimal) error {
 	newjob := millicoresJob{
 		ID:                 uuid.New(),

--- a/configs/default.yml
+++ b/configs/default.yml
@@ -11,6 +11,9 @@ interapps:
   proxy:
     tag: latest
 
+irods:
+  zone: iplant
+
 k8s:
   frontend:
     base: "https://cyverse.run"

--- a/instantlaunches/db.go
+++ b/instantlaunches/db.go
@@ -175,6 +175,7 @@ FROM instant_launches il
 	JOIN users ilu ON il.added_by = ilu.id
 `
 
+// FullListInstantLaunches returns a full listing of instant launches.
 func (a *App) FullListInstantLaunches() ([]FullInstantLaunch, error) {
 	all := []FullInstantLaunch{}
 	err := a.DB.Select(&all, fullListInstantLaunchesQuery)
@@ -452,6 +453,9 @@ const listPublicQLsQuery = `
 	WHERE u.username = $1 OR ( ql.is_public = true AND a.is_public = true)
 `
 
+// ListViablePublicQuickLaunches returns a listing of quick launches that the user is permitted to run. This list
+// includes quick launches that were created by the authenticated user and public quick launches for which the
+// corresponding app is also public.
 func (a *App) ListViablePublicQuickLaunches(user string) ([]QuickLaunch, error) {
 	l := []QuickLaunch{}
 	err := a.DB.Select(&l, listPublicQLsQuery, user)

--- a/instantlaunches/main.go
+++ b/instantlaunches/main.go
@@ -155,6 +155,7 @@ type UserInstantLaunchMapping struct {
 	Mapping InstantLaunchMapping `json:"mapping" db:"mapping"`
 }
 
+// QuickLaunch describes an app with a set of pre-filled parameter values.
 type QuickLaunch struct {
 	ID          string         `json:"id" db:"id"`
 	Creator     string         `json:"creator" db:"creator"`

--- a/internal/constants.go
+++ b/internal/constants.go
@@ -17,10 +17,16 @@ const (
 	csiDriverOutputVolumeMountPath            = "/output"
 	csiDriverLocalMountPath                   = "/data"
 
+	// The file transfers volume serves as the working directory when IRODS CSI Driver integration is disabled.
 	fileTransfersVolumeName        = "input-files"
 	fileTransfersContainerName     = "input-files"
 	fileTransfersInitContainerName = "input-files-init"
 	fileTransfersInputsMountPath   = "/input-files"
+
+	// The working directory volume serves as the working directory when IRODS CSI Driver integration is enabled.
+	workingDirVolumeName             = "working-dir"
+	workingDirInitContainerName      = "working-dir-init"
+	workingDirInitContainerMountPath = "/working-dir"
 
 	viceProxyContainerName = "vice-proxy"
 	viceProxyPort          = int32(60002)

--- a/internal/deployments.go
+++ b/internal/deployments.go
@@ -296,8 +296,8 @@ func (i *Internal) workingDirPrepContainer(job *model.Job) (apiv1.Container, err
 		"bash",
 		"-c",
 		strings.Join([]string{
-			fmt.Sprintf("ln -s \"%s\" \"%s/\"", csiDriverLocalMountPath, workingDirInitContainerMountPath),
-			fmt.Sprintf("ln -s \"/%s/home\" \"%s/\"", zone, workingDirInitContainerMountPath),
+			fmt.Sprintf("ln -s \"%s\" .", csiDriverLocalMountPath),
+			fmt.Sprintf("ln -s \"/%s/home\" .", zone),
 		}, " && "),
 	}
 
@@ -307,7 +307,7 @@ func (i *Internal) workingDirPrepContainer(job *model.Job) (apiv1.Container, err
 		Image:           fmt.Sprintf("%s:%s", i.PorklockImage, i.PorklockTag),
 		Command:         workingDirInitCommand,
 		ImagePullPolicy: apiv1.PullPolicy(apiv1.PullAlways),
-		WorkingDir:      inputPathListMountPath,
+		WorkingDir:      workingDirInitContainerMountPath,
 		VolumeMounts: []apiv1.VolumeMount{
 			{
 				Name:      workingDirVolumeName,

--- a/internal/deployments.go
+++ b/internal/deployments.go
@@ -303,7 +303,7 @@ func (i *Internal) workingDirPrepContainer(job *model.Job) (apiv1.Container, err
 
 	// Build the init container spec.
 	initContainer := apiv1.Container{
-		Name:            fileTransfersInitContainerName,
+		Name:            workingDirInitContainerName,
 		Image:           fmt.Sprintf("%s:%s", i.PorklockImage, i.PorklockTag),
 		Command:         workingDirInitCommand,
 		ImagePullPolicy: apiv1.PullPolicy(apiv1.PullAlways),

--- a/internal/deployments.go
+++ b/internal/deployments.go
@@ -54,6 +54,14 @@ func (i *Internal) deploymentVolumes(job *model.Job) []apiv1.Volume {
 	}
 
 	if i.UseCSIDriver {
+		output = append(output,
+			apiv1.Volume{
+				Name: workingDirVolumeName,
+				VolumeSource: apiv1.VolumeSource{
+					EmptyDir: &apiv1.EmptyDirVolumeSource{},
+				},
+			},
+		)
 		volumeSources, err := i.getPersistentVolumeSources(job)
 		if err != nil {
 			log.Warn(err)
@@ -229,49 +237,129 @@ func storageRequest(job *model.Job) resourcev1.Quantity {
 	return value
 }
 
+// inputStagingContainer returns the init container to be used for staging input files. This init container
+// is only used when iRODS CSI driver integration is disabled.
+func (i *Internal) inputStagingContainer(job *model.Job) apiv1.Container {
+	return apiv1.Container{
+		Name:            fileTransfersInitContainerName,
+		Image:           fmt.Sprintf("%s:%s", i.PorklockImage, i.PorklockTag),
+		Command:         append(fileTransferCommand(job), "--no-service"),
+		ImagePullPolicy: apiv1.PullPolicy(apiv1.PullAlways),
+		WorkingDir:      inputPathListMountPath,
+		VolumeMounts:    i.fileTransfersVolumeMounts(job),
+		Ports: []apiv1.ContainerPort{
+			{
+				Name:          fileTransfersPortName,
+				ContainerPort: fileTransfersPort,
+				Protocol:      apiv1.Protocol("TCP"),
+			},
+		},
+		SecurityContext: &apiv1.SecurityContext{
+			RunAsUser:  int64Ptr(int64(job.Steps[0].Component.Container.UID)),
+			RunAsGroup: int64Ptr(int64(job.Steps[0].Component.Container.UID)),
+			Capabilities: &apiv1.Capabilities{
+				Drop: []apiv1.Capability{
+					"SETPCAP",
+					"AUDIT_WRITE",
+					"KILL",
+					"SETGID",
+					"SETUID",
+					"NET_BIND_SERVICE",
+					"SYS_CHROOT",
+					"SETFCAP",
+					"FSETID",
+					"NET_RAW",
+					"MKNOD",
+				},
+			},
+		},
+	}
+}
+
+// workingDirPrepContainer returns the init container to be used for preparing the working directory volume
+// for use within the VICE analysis. This init container is only used when iRODS CSI driver integration is
+// enabled.
+//
+// It may seem odd to use the file transfer image to initialize the working directory when no files are actually
+// being transferred, but it works. We use it for a couple of different reasons. First, we need a Unix shell and
+// it has one. Second, it's already set up so that we can configure it in a way that avoids image pull rate limits.
+func (i *Internal) workingDirPrepContainer(job *model.Job) (apiv1.Container, error) {
+
+	// Determine the iRODS zone name.
+	zone, err := i.getIRODSZone(job.UserHome)
+	if err != nil {
+		return apiv1.Container{}, err
+	}
+
+	// Build the command used to initialize the working directory.
+	workingDirInitCommand := []string{
+		"bash",
+		"-c",
+		strings.Join([]string{
+			fmt.Sprintf("ln -s \"%s\" \"%s/\"", csiDriverLocalMountPath, workingDirInitContainerMountPath),
+			fmt.Sprintf("ln -s \"/%s/home\" \"%s/\"", zone, workingDirInitContainerMountPath),
+		}, " && "),
+	}
+
+	// Build the init container spec.
+	initContainer := apiv1.Container{
+		Name:            fileTransfersInitContainerName,
+		Image:           fmt.Sprintf("%s:%s", i.PorklockImage, i.PorklockTag),
+		Command:         workingDirInitCommand,
+		ImagePullPolicy: apiv1.PullPolicy(apiv1.PullAlways),
+		WorkingDir:      inputPathListMountPath,
+		VolumeMounts: []apiv1.VolumeMount{
+			{
+				Name:      workingDirVolumeName,
+				MountPath: workingDirInitContainerMountPath,
+				ReadOnly:  false,
+			},
+		},
+		SecurityContext: &apiv1.SecurityContext{
+			RunAsUser:  int64Ptr(int64(job.Steps[0].Component.Container.UID)),
+			RunAsGroup: int64Ptr(int64(job.Steps[0].Component.Container.UID)),
+			Capabilities: &apiv1.Capabilities{
+				Drop: []apiv1.Capability{
+					"SETPCAP",
+					"AUDIT_WRITE",
+					"KILL",
+					"SETGID",
+					"SETUID",
+					"NET_BIND_SERVICE",
+					"SYS_CHROOT",
+					"SETFCAP",
+					"FSETID",
+					"NET_RAW",
+					"MKNOD",
+				},
+			},
+		},
+	}
+
+	return initContainer, nil
+}
+
+// workingDirMountPath returns the path to the directory containing file inputs.
+func workingDirMountPath(job *model.Job) string {
+	return job.Steps[0].Component.Container.WorkingDirectory()
+}
+
 // initContainers returns a []apiv1.Container used for the InitContainers in
 // the VICE app Deployment resource.
-func (i *Internal) initContainers(job *model.Job) []apiv1.Container {
+func (i *Internal) initContainers(job *model.Job) ([]apiv1.Container, error) {
 	output := []apiv1.Container{}
 
 	if !i.UseCSIDriver {
-		output = append(output, apiv1.Container{
-			Name:            fileTransfersInitContainerName,
-			Image:           fmt.Sprintf("%s:%s", i.PorklockImage, i.PorklockTag),
-			Command:         append(fileTransferCommand(job), "--no-service"),
-			ImagePullPolicy: apiv1.PullPolicy(apiv1.PullAlways),
-			WorkingDir:      inputPathListMountPath,
-			VolumeMounts:    i.fileTransfersVolumeMounts(job),
-			Ports: []apiv1.ContainerPort{
-				{
-					Name:          fileTransfersPortName,
-					ContainerPort: fileTransfersPort,
-					Protocol:      apiv1.Protocol("TCP"),
-				},
-			},
-			SecurityContext: &apiv1.SecurityContext{
-				RunAsUser:  int64Ptr(int64(job.Steps[0].Component.Container.UID)),
-				RunAsGroup: int64Ptr(int64(job.Steps[0].Component.Container.UID)),
-				Capabilities: &apiv1.Capabilities{
-					Drop: []apiv1.Capability{
-						"SETPCAP",
-						"AUDIT_WRITE",
-						"KILL",
-						"SETGID",
-						"SETUID",
-						"NET_BIND_SERVICE",
-						"SYS_CHROOT",
-						"SETFCAP",
-						"FSETID",
-						"NET_RAW",
-						"MKNOD",
-					},
-				},
-			},
-		})
+		output = append(output, i.inputStagingContainer(job))
+	} else {
+		workingDirInitContainer, err := i.workingDirPrepContainer(job)
+		if err != nil {
+			return output, err
+		}
+		output = append(output, workingDirInitContainer)
 	}
 
-	return output
+	return output, nil
 }
 
 func gpuEnabled(job *model.Job) bool {
@@ -342,6 +430,11 @@ func (i *Internal) defineAnalysisContainer(job *model.Job) apiv1.Container {
 
 	volumeMounts := []apiv1.VolumeMount{}
 	if i.UseCSIDriver {
+		volumeMounts = append(volumeMounts, apiv1.VolumeMount{
+			Name:      workingDirVolumeName,
+			MountPath: workingDirMountPath(job),
+			ReadOnly:  false,
+		})
 		persistentVolumeMounts, err := i.getPersistentVolumeMounts(job)
 		if err != nil {
 			log.Warn(err)
@@ -353,7 +446,7 @@ func (i *Internal) defineAnalysisContainer(job *model.Job) apiv1.Container {
 	} else {
 		volumeMounts = append(volumeMounts, apiv1.VolumeMount{
 			Name:      fileTransfersVolumeName,
-			MountPath: fileTransfersMountPath(job),
+			MountPath: workingDirMountPath(job),
 			ReadOnly:  false,
 		})
 	}
@@ -544,6 +637,7 @@ func (i *Internal) getDeployment(job *model.Job) (*appsv1.Deployment, error) {
 
 	autoMount := false
 
+	// Add the tolerations to use by default.
 	tolerations := []apiv1.Toleration{
 		{
 			Key:      viceTolerationKey,
@@ -553,6 +647,7 @@ func (i *Internal) getDeployment(job *model.Job) (*appsv1.Deployment, error) {
 		},
 	}
 
+	// Add the node selector requirements to use by default.
 	nodeSelectorRequirements := []apiv1.NodeSelectorRequirement{
 		{
 			Key:      viceAffinityKey,
@@ -563,6 +658,7 @@ func (i *Internal) getDeployment(job *model.Job) (*appsv1.Deployment, error) {
 		},
 	}
 
+	// Add the tolerations and node selector requirements for jobs that require a GPU.
 	if gpuEnabled(job) {
 		tolerations = append(tolerations, apiv1.Toleration{
 			Key:      gpuTolerationKey,
@@ -578,6 +674,12 @@ func (i *Internal) getDeployment(job *model.Job) (*appsv1.Deployment, error) {
 				gpuAffinityValue,
 			},
 		})
+	}
+
+	// Get the list of init containers.
+	initContainers, err := i.initContainers(job)
+	if err != nil {
+		return nil, err
 	}
 
 	deployment := &appsv1.Deployment{
@@ -600,7 +702,7 @@ func (i *Internal) getDeployment(job *model.Job) (*appsv1.Deployment, error) {
 					Hostname:                     IngressName(job.UserID, job.InvocationID),
 					RestartPolicy:                apiv1.RestartPolicy("Always"),
 					Volumes:                      i.deploymentVolumes(job),
-					InitContainers:               i.initContainers(job),
+					InitContainers:               initContainers,
 					Containers:                   i.deploymentContainers(job),
 					ImagePullSecrets:             i.imagePullSecrets(job),
 					AutomountServiceAccountToken: &autoMount,

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -90,6 +90,7 @@ type Init struct {
 	KeycloakRealm                 string
 	KeycloakClientID              string
 	KeycloakClientSecret          string
+	IRODSZone                     string
 }
 
 // Internal contains information and operations for launching VICE apps inside the

--- a/internal/limits_test.go
+++ b/internal/limits_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/cyverse-de/app-exposer/apps"
 	"github.com/cyverse-de/model"
 	"github.com/jmoiron/sqlx"
 	"github.com/stretchr/testify/assert"
@@ -61,7 +62,9 @@ func setupInternal(t *testing.T, objs []runtime.Object) (*Internal, sqlmock.Sqlm
 
 	client := fake.NewSimpleClientset(objs...)
 
-	internal := New(testConfig, sqlxMockDB, client, nil)
+	apps := apps.NewApps(sqlxMockDB, "@iplantcollaborative.org")
+
+	internal := New(testConfig, sqlxMockDB, client, apps)
 	return internal, mock
 }
 

--- a/internal/transfers.go
+++ b/internal/transfers.go
@@ -43,11 +43,6 @@ type transferResponse struct {
 	Kind   string `json:"kind"`
 }
 
-// fileTransferMountPath returns the path to the directory containing file inputs.
-func fileTransfersMountPath(job *model.Job) string {
-	return job.Steps[0].Component.Container.WorkingDirectory()
-}
-
 // fileTransferCommand returns a []string containing the command to fire up the vice-file-transfers service.
 func fileTransferCommand(job *model.Job) []string {
 	retval := []string{

--- a/internal/volumes.go
+++ b/internal/volumes.go
@@ -16,7 +16,7 @@ var (
 	defaultStorageCapacity, _ = resourcev1.ParseQuantity("5Gi")
 )
 
-// PathMapping ...
+// IRODSFSPathMapping defines a single path mapping that can be used by the iRODS CSI driver to create a mount point.
 type IRODSFSPathMapping struct {
 	IRODSPath      string `yaml:"irods_path" json:"irods_path"`
 	MappingPath    string `yaml:"mapping_path" json:"mapping_path"`

--- a/main.go
+++ b/main.go
@@ -120,6 +120,12 @@ func main() {
 		log.Fatal(errors.Wrap(err, "Can't parse k8s.frontend.base in the config file"))
 	}
 
+	// Make sure that the iRODS zone isn't empty.
+	zone := cfg.GetString("irods.zone")
+	if zone == "" {
+		log.Fatal("The iRODS zone must be specified in the config file")
+	}
+
 	// Print error and exit if *kubeconfig is not empty and doesn't actually
 	// exist. If *kubeconfig is blank, then the app may be running inside the
 	// cluster, so let things proceed.
@@ -215,6 +221,7 @@ func main() {
 		KeycloakRealm:                 cfg.GetString("keycloak.realm"),
 		KeycloakClientID:              cfg.GetString("keycloak.client-id"),
 		KeycloakClientSecret:          cfg.GetString("keycloak.client-secret"),
+		IRODSZone:                     zone,
 	}
 
 	a := apps.NewApps(db, *userSuffix)


### PR DESCRIPTION
The purpose of this change is to address some support requests that we've received since the iRODS CSI driver was moved to production. With the CSI driver enabled, the input data location isn't as intuitive as it was before, so we're hoping that adding symbolic links to the working directory configured in the tool definition for the app will help. The symbolic links will be defined as follows.

| Name | Target | Description |
| ------ | ------ | ------------ |
| data | /data | The parent directory of both the input data folder and the analysis output folder. |
| home | /{zone}/home | The parent directory of the user's home folder and the community data folder in the data store. |
