### PR TITLE
CORE-1722: change CSI Driver volume mount points

### DIFF
--- a/instantlaunches/defaults_test.go
+++ b/instantlaunches/defaults_test.go
@@ -2,6 +2,7 @@ package instantlaunches
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -49,7 +50,7 @@ func TestLatestDefaults(t *testing.T) {
 
 	mock.ExpectQuery(latestDefaultsQuery).WillReturnRows(rows)
 
-	mapping, err := app.LatestDefaults()
+	mapping, err := app.LatestDefaults(context.Background())
 	assert.NoError(err, "error from LatestDefaults should be nil")
 	assert.Equal("0", mapping.ID, "id should be 0")
 	assert.Equal("0", mapping.Version, "version should be 0")
@@ -145,7 +146,7 @@ func TestUpdateLatestDefaults(t *testing.T) {
 
 	mock.ExpectQuery("UPDATE ONLY default_instant_launches").WillReturnRows(rows)
 
-	mapping, err := app.UpdateLatestDefaults(expected)
+	mapping, err := app.UpdateLatestDefaults(context.Background(), expected)
 	assert.NoError(err, "error from UpdateLatestDefaults should be nil")
 	assert.True(cmp.Equal(expected, mapping), "mappings should match")
 	assert.NoError(mock.ExpectationsWereMet(), "expectations were not met")
@@ -214,7 +215,7 @@ func TestDeleteLatestDefaults(t *testing.T) {
 
 	mock.ExpectExec("DELETE FROM ONLY default_instant_launches AS def").WillReturnResult(sqlmock.NewResult(0, 1))
 
-	err = app.DeleteLatestDefaults()
+	err = app.DeleteLatestDefaults(context.Background())
 	assert.NoError(err, "delete shouldn't return an error")
 	assert.NoError(mock.ExpectationsWereMet(), "expectations were not met")
 }
@@ -277,7 +278,7 @@ func TestAddLatestDefaults(t *testing.T) {
 		WithArgs(v, testUser).
 		WillReturnRows(rows)
 
-	actual, err := app.AddLatestDefaults(expected, testUser)
+	actual, err := app.AddLatestDefaults(context.Background(), expected, testUser)
 	if assert.NoError(err, "shouldn't be an error") {
 		assert.True(cmp.Equal(expected, actual), "should be equal")
 	}
@@ -374,7 +375,7 @@ func TestDefaultsByVersion(t *testing.T) {
 				AddRow("0", "0", v),
 		)
 
-	actual, err := app.DefaultsByVersion(0)
+	actual, err := app.DefaultsByVersion(context.Background(), 0)
 	if assert.NoError(err) {
 		assert.True(cmp.Equal(expected, actual))
 	}
@@ -469,7 +470,7 @@ func TestUpdateDefaultsByVersion(t *testing.T) {
 				AddRow(v),
 		)
 
-	actual, err := app.UpdateDefaultsByVersion(expected, 0)
+	actual, err := app.UpdateDefaultsByVersion(context.Background(), expected, 0)
 	if assert.NoError(err, "should not error") {
 		assert.True(cmp.Equal(expected, actual), "should be equal")
 	}
@@ -535,7 +536,7 @@ func TestDeleteDefaultsByVersion(t *testing.T) {
 	mock.ExpectExec("DELETE FROM ONLY default_instant_launches as def").
 		WillReturnResult(sqlmock.NewResult(0, 1))
 
-	err = app.DeleteDefaultsByVersion(0)
+	err = app.DeleteDefaultsByVersion(context.Background(), 0)
 	assert.NoError(err, "delete shouldn't return an error")
 	assert.NoError(mock.ExpectationsWereMet(), "expectations were not met")
 }
@@ -582,7 +583,7 @@ func TestListAllDefaults(t *testing.T) {
 				AddRow("1", "1", `{"one":"two"}`),
 		)
 
-	listing, err := app.ListAllDefaults()
+	listing, err := app.ListAllDefaults(context.Background())
 	if assert.NoError(err, "should not return an error") {
 		assert.Equal(2, len(listing.Defaults), "number of rows should be 2")
 		assert.Equal("0", listing.Defaults[0].ID, "ID should be 0")

--- a/instantlaunches/mgmt_test.go
+++ b/instantlaunches/mgmt_test.go
@@ -3,6 +3,7 @@ package instantlaunches
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -27,7 +28,7 @@ func TestAddInstantLaunch(t *testing.T) {
 
 	mock.ExpectQuery("INSERT INTO instant_launches").WillReturnRows(rows)
 
-	actual, err := app.AddInstantLaunch("0", "test@iplantcollaborative.org")
+	actual, err := app.AddInstantLaunch(context.Background(), "0", "test@iplantcollaborative.org")
 	assert.NoError(err, "error should be nil")
 	assert.Equal("0", actual.ID, "id should be 0")
 	assert.Equal("0", actual.QuickLaunchID, "quick_launch_id should be 0")
@@ -93,7 +94,7 @@ func TestGetInstantLaunch(t *testing.T) {
 	mock.ExpectQuery("SELECT i.id, i.quick_launch_id, i.added_by, i.added_on FROM instant_launches i").
 		WillReturnRows(rows)
 
-	actual, err := app.GetInstantLaunch("0")
+	actual, err := app.GetInstantLaunch(context.Background(), "0")
 	assert.NoError(err, "error should be nil")
 	assert.Equal("0", actual.ID, "id should be 0")
 	assert.Equal("0", actual.QuickLaunchID, "quick_launch_id should be 0")
@@ -165,7 +166,7 @@ func TestUpdateInstantLaunch(t *testing.T) {
 	mock.ExpectQuery("UPDATE ONLY instant_launches").
 		WillReturnRows(rows)
 
-	actual, err := app.UpdateInstantLaunch("0", "0")
+	actual, err := app.UpdateInstantLaunch(context.Background(), "0", "0")
 	assert.NoError(err, "error should be nil")
 	assert.Equal("0", actual.ID, "id should be 0")
 	assert.Equal("0", actual.QuickLaunchID, "quick_launch_id should be 0")
@@ -232,7 +233,7 @@ func TestDeleteInstantLaunch(t *testing.T) {
 	mock.ExpectExec("DELETE FROM instant_launches").
 		WillReturnResult(sqlmock.NewResult(0, 1))
 
-	err = app.DeleteInstantLaunch("0")
+	err = app.DeleteInstantLaunch(context.Background(), "0")
 	assert.NoError(err, "error should be nil")
 	assert.NoError(mock.ExpectationsWereMet(), "expectations were not met")
 }
@@ -295,7 +296,7 @@ func TestListInstantLaunches(t *testing.T) {
 	mock.ExpectQuery("SELECT i.id, i.quick_launch_id, i.added_by, i.added_on FROM instant_launches i").
 		WillReturnRows(rows)
 
-	actual, err := app.ListInstantLaunches()
+	actual, err := app.ListInstantLaunches(context.Background())
 	assert.NoError(err, "error should be nil")
 	if assert.True(len(actual) > 0 && len(actual) == len(expected), "length is wrong") {
 		for index := range expected {
@@ -350,6 +351,7 @@ func TestListInstantLaunchesHandler(t *testing.T) {
 
 		actual := []InstantLaunch{}
 		err = json.Unmarshal(rec.Body.Bytes(), &actual)
+		assert.NoError(err, "failed to unmarshal the response body")
 		if assert.True(len(actual) > 0 && len(actual) == len(expected), "length is wrong") {
 			for index := range expected {
 				assert.True(cmp.Equal(expected[index], actual[index]), "should be equal")

--- a/instantlaunches/users_test.go
+++ b/instantlaunches/users_test.go
@@ -3,6 +3,7 @@ package instantlaunches
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -30,7 +31,7 @@ func TestUserMapping(t *testing.T) {
 		WithArgs("test").
 		WillReturnRows(rows)
 
-	actual, err := app.UserMapping("test")
+	actual, err := app.UserMapping(context.Background(), "test")
 	assert.NoError(err, "should not error")
 	assert.Equal("0", actual.ID, "id should be 0")
 	assert.Equal("0", actual.Version, "version should be 0")
@@ -79,6 +80,7 @@ func TestUserMappingHandler(t *testing.T) {
 
 		actual := &UserInstantLaunchMapping{}
 		err = json.Unmarshal(rec.Body.Bytes(), &actual)
+		assert.NoError(err, "failed to unmarshal the response body")
 		assert.Equal("0", actual.ID, "id should be 0")
 		assert.Equal("0", actual.Version, "version should be 0")
 		assert.True(
@@ -128,7 +130,7 @@ func TestUpdateUserMapping(t *testing.T) {
 		WithArgs(v, fmt.Sprintf("test%s", app.UserSuffix)).
 		WillReturnRows(rows)
 
-	actual, err := app.UpdateUserMapping(fmt.Sprintf("test%s", app.UserSuffix), expected)
+	actual, err := app.UpdateUserMapping(context.Background(), fmt.Sprintf("test%s", app.UserSuffix), expected)
 	if assert.NoError(err, "no errors expected") {
 		assert.True(cmp.Equal(expected, actual), "should be equal")
 	}
@@ -182,6 +184,7 @@ func TestUpdateUserMappingHandler(t *testing.T) {
 
 		actual := &InstantLaunchMapping{}
 		err = json.Unmarshal(rec.Body.Bytes(), &actual)
+		assert.NoError(err, "failed to unmarshal the response body")
 		assert.True(cmp.Equal(expected, actual), "should be equal")
 	}
 	assert.NoError(mock.ExpectationsWereMet(), "expectations were not met")
@@ -201,7 +204,7 @@ func TestDeleteUserMapping(t *testing.T) {
 		WithArgs("test").
 		WillReturnResult(sqlmock.NewResult(0, 1))
 
-	err = app.DeleteUserMapping("test")
+	err = app.DeleteUserMapping(context.Background(), "test")
 	assert.NoError(err, "should not error")
 	assert.NoError(mock.ExpectationsWereMet(), "expectations were not met")
 }
@@ -265,7 +268,7 @@ func TestAddUserMapping(t *testing.T) {
 	mock.ExpectQuery("INSERT INTO user_instant_launches").
 		WillReturnRows(rows)
 
-	actual, err := app.AddUserMapping("test", expected)
+	actual, err := app.AddUserMapping(context.Background(), "test", expected)
 	if assert.NoError(err, "should not error") {
 		assert.True(cmp.Equal(expected, actual), "should be equal")
 	}
@@ -318,6 +321,7 @@ func TestAddUserMappingHandler(t *testing.T) {
 
 		actual := &InstantLaunchMapping{}
 		err = json.Unmarshal(rec.Body.Bytes(), &actual)
+		assert.NoError(err, "failed to unmarshal the response body")
 		assert.True(cmp.Equal(expected, actual), "should be equal")
 	}
 	assert.NoError(mock.ExpectationsWereMet(), "expectations were not met")
@@ -362,7 +366,7 @@ func TestAllUserMappings(t *testing.T) {
 		WithArgs("test").
 		WillReturnRows(rows)
 
-	actual, err := app.AllUserMappings("test")
+	actual, err := app.AllUserMappings(context.Background(), "test")
 	if assert.NoError(err, "should not return error") {
 		assert.True(cmp.Equal(expected, actual), "should be equal")
 	}
@@ -425,6 +429,7 @@ func TestAllUserMappingsHandler(t *testing.T) {
 
 		actual := []UserInstantLaunchMapping{}
 		err = json.Unmarshal(rec.Body.Bytes(), &actual)
+		assert.NoError(err, "failed to unmarshal the response body")
 		assert.True(cmp.Equal(expected, actual), "should be equal")
 
 	}
@@ -468,7 +473,7 @@ func TestUserMappingsByVersion(t *testing.T) {
 		WithArgs("test", 0).
 		WillReturnRows(rows)
 
-	actual, err := app.UserMappingsByVersion("test", 0)
+	actual, err := app.UserMappingsByVersion(context.Background(), "test", 0)
 	if assert.NoError(err, "no error expected") {
 		assert.True(cmp.Equal(expected, actual), "should be equal")
 	}
@@ -528,6 +533,7 @@ func TestUserMappingsByVersionHandler(t *testing.T) {
 
 		actual := &UserInstantLaunchMapping{}
 		err = json.Unmarshal(rec.Body.Bytes(), &actual)
+		assert.NoError(err, "failed to unmarshal the response body")
 		assert.True(cmp.Equal(expected, actual), "should be equal")
 
 	}
@@ -564,7 +570,7 @@ func TestUpdateUserMappingsByVersion(t *testing.T) {
 		WithArgs(v, 0, "test").
 		WillReturnRows(rows)
 
-	actual, err := app.UpdateUserMappingsByVersion("test", 0, expected)
+	actual, err := app.UpdateUserMappingsByVersion(context.Background(), "test", 0, expected)
 	if assert.NoError(err, "no error expected") {
 		assert.True(cmp.Equal(expected, actual), "should be equal")
 	}
@@ -616,6 +622,7 @@ func TestUpdateUserMappingsByVersionHandler(t *testing.T) {
 
 		actual := &InstantLaunchMapping{}
 		err = json.Unmarshal(rec.Body.Bytes(), &actual)
+		assert.NoError(err, "failed to unmarshal the response body")
 		assert.True(cmp.Equal(expected, actual), "should be equal")
 	}
 	assert.NoError(mock.ExpectationsWereMet(), "expectations were not met")
@@ -634,7 +641,7 @@ func TestDeleteUserMappingsByVersion(t *testing.T) {
 		WithArgs("test", 0).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 
-	err = app.DeleteUserMappingsByVersion("test", 0)
+	err = app.DeleteUserMappingsByVersion(context.Background(), "test", 0)
 	assert.NoError(err, "no error expected")
 	assert.NoError(mock.ExpectationsWereMet(), "expectations were not met")
 }

--- a/internal/constants.go
+++ b/internal/constants.go
@@ -15,7 +15,7 @@ const (
 	csiDriverHomeVolumeClaimNamePrefix        = "csi-home-volume-claim"
 	csiDriverInputVolumeMountPath             = "/input"
 	csiDriverOutputVolumeMountPath            = "/output"
-	csiDriverLocalMountPath                   = "/data"
+	csiDriverLocalMountPath                   = "/data-store"
 
 	// The file transfers volume serves as the working directory when IRODS CSI Driver integration is disabled.
 	fileTransfersVolumeName        = "input-files"

--- a/internal/deployments.go
+++ b/internal/deployments.go
@@ -292,7 +292,7 @@ func (i *Internal) workingDirPrepContainer(job *model.Job) apiv1.Container {
 		"-c",
 		strings.Join([]string{
 			fmt.Sprintf("ln -s \"%s\" .", csiDriverLocalMountPath),
-			fmt.Sprintf("ln -s \"/%s/home\" .", i.IRODSZone),
+			fmt.Sprintf("ln -s \"%s/home\" .", i.getZoneMountPath()),
 		}, " && "),
 	}
 

--- a/internal/limits_test.go
+++ b/internal/limits_test.go
@@ -1,6 +1,7 @@
 package internal
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -298,7 +299,7 @@ func TestLimitChecks(t *testing.T) {
 			registerDefaultLimitQuery(mock, test.defaultLimit)
 
 			// Run the limit check.
-			status, err := internal.validateJob(createTestSubmission(test.username))
+			status, err := internal.validateJob(context.Background(), createTestSubmission(test.username))
 			expectedError := expectedLimitError(test.username, test.defaultLimit, len(test.analyses), test.limit)
 			if expectedError == nil {
 				assert.Equalf(http.StatusOK, status, "the status code should be %d", http.StatusOK)

--- a/internal/volumes.go
+++ b/internal/volumes.go
@@ -27,6 +27,10 @@ type IRODSFSPathMapping struct {
 	IgnoreNotExist bool   `yaml:"ignore_not_exist" json:"ignore_not_exist"`
 }
 
+func (i *Internal) getZoneMountPath() string {
+	return fmt.Sprintf("%s/%s", csiDriverLocalMountPath, i.IRODSZone)
+}
+
 func (i *Internal) getCSIInputOutputVolumeHandle(job *model.Job) string {
 	return fmt.Sprintf("%s-handle-%s", csiDriverInputOutputVolumeNamePrefix, job.InvocationID)
 }
@@ -112,7 +116,7 @@ func (i *Internal) getOutputPathMapping(job *model.Job) IRODSFSPathMapping {
 
 func (i *Internal) getHomePathMapping(job *model.Job) IRODSFSPathMapping {
 	// mount a single collection for home
-	userHome := strings.TrimPrefix(job.UserHome, fmt.Sprintf("/%s", i.IRODSZone))
+	userHome := strings.TrimPrefix(job.UserHome, i.getZoneMountPath())
 	userHome = strings.TrimSuffix(userHome, "/")
 
 	return IRODSFSPathMapping{
@@ -127,7 +131,7 @@ func (i *Internal) getHomePathMapping(job *model.Job) IRODSFSPathMapping {
 
 func (i *Internal) getSharedPathMapping(job *model.Job) IRODSFSPathMapping {
 	// mount a single collection for shared data
-	sharedHomeFullPath := fmt.Sprintf("/%s/home/shared", i.IRODSZone)
+	sharedHomeFullPath := fmt.Sprintf("%s/home/shared", i.getZoneMountPath())
 	sharedHome := "/home/shared"
 
 	return IRODSFSPathMapping{
@@ -408,7 +412,7 @@ func (i *Internal) getPersistentVolumeMounts(job *model.Job) []*apiv1.VolumeMoun
 
 		homeVolumeMount := &apiv1.VolumeMount{
 			Name:      i.getCSIHomeVolumeClaimName(job),
-			MountPath: fmt.Sprintf("/%s", i.IRODSZone),
+			MountPath: i.getZoneMountPath(),
 		}
 		volumeMounts = append(volumeMounts, homeVolumeMount)
 


### PR DESCRIPTION
We've encountered several cases in which the name of the CSI driver mount points has collided with existing directories within app containers. The purpose of this change is to reduce the likelihood of such collisions by renaming the mount points. The following changes are being made:

* The input files and folders will now be mounted underneath `/data-store/input` rather than `/data/input`.
* The output folder will now be mounted to `/data-store/output` rather than `/data/output`.
* The user home and community data folders will now be mounted underneath `/data-store/<zone-name>` rather than `/<zone-name>`.

The symbolic links in the default working directory for the app will retain their current names (`data` and `home`) and will be updated to point to the new locations.

I must confess that I haven't tested this because testing with skaffold on a laptop with an ARM processor won't work. I'll submit another PR if any bugs pop up after the updates have been deployed in QA.