### PR TITLE
Add guard check for the resource name for overage detection

### DIFF
--- a/internal/limits.go
+++ b/internal/limits.go
@@ -198,7 +198,7 @@ func validateJobLimits(user string, defaultJobLimit, jobCount int, jobLimit *int
 		details := make(map[string]interface{})
 
 		for _, ov := range overages.Overages {
-			if ov.Usage >= ov.Quota {
+			if ov.Usage >= ov.Quota && ov.ResourceName == "cpu.hours" {
 				inOverage = true
 				details[ov.ResourceName] = fmt.Sprintf("quota: %f, usage: %f", ov.Quota, ov.Usage)
 			}


### PR DESCRIPTION
We need to only guard against cpu.hours overages in app-exposer. We don't care about data.size overages here.