### PR TITLE
Mark the planned end date read from the database as a local timestamp

### DIFF
--- a/internal/internal.go
+++ b/internal/internal.go
@@ -1004,6 +1004,7 @@ func (i *Internal) getTimeLimit(ctx context.Context, userID, id string) (map[str
 		if err != nil {
 			return nil, errors.Wrapf(err, "error getting time limit for user %s on analysis %s", userID, id)
 		}
+		v = v.(time.Time).Local()
 		outputMap["time_limit"] = fmt.Sprintf("%d", v.(time.Time).Unix())
 	} else {
 		outputMap["time_limit"] = "null"

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -990,6 +990,13 @@ func (i *Internal) AdminGetTimeLimitHandler(c echo.Context) error {
 	return c.JSON(http.StatusOK, outputMap)
 }
 
+func dbTimestampToLocal(t time.Time) time.Time {
+	_, offset := time.Now().Zone()
+	t = t.Local()
+	t = t.Add(time.Duration(offset*-1) * time.Second)
+	return t
+}
+
 func (i *Internal) getTimeLimit(ctx context.Context, userID, id string) (map[string]string, error) {
 	var err error
 
@@ -1004,8 +1011,7 @@ func (i *Internal) getTimeLimit(ctx context.Context, userID, id string) (map[str
 		if err != nil {
 			return nil, errors.Wrapf(err, "error getting time limit for user %s on analysis %s", userID, id)
 		}
-		v = v.(time.Time).Local()
-		outputMap["time_limit"] = fmt.Sprintf("%d", v.(time.Time).Unix())
+		outputMap["time_limit"] = fmt.Sprintf("%d", dbTimestampToLocal(v.(time.Time)).Unix())
 	} else {
 		outputMap["time_limit"] = "null"
 	}
@@ -1038,7 +1044,7 @@ func (i *Internal) updateTimeLimit(ctx context.Context, user, id string) (map[st
 		if err != nil {
 			return nil, errors.Wrapf(err, "error getting new time limit for user %s on analysis %s", userID, id)
 		}
-		outputMap["time_limit"] = fmt.Sprintf("%d", v.(time.Time).Unix())
+		outputMap["time_limit"] = fmt.Sprintf("%d", dbTimestampToLocal(v.(time.Time)).Unix())
 	} else {
 		return nil, errors.Wrapf(err, "the time limit for analysis %s was null after extension", id)
 	}


### PR DESCRIPTION
I think this is the fix for the time-limit endpoint issue. The timestamps in the DB were set correctly, but the way we were reading them in assumed UTC, where they are actually local timestamps. Calling `.Local()` doesn't change timestamps in go, merely marks them as belonging to the local timezone, so this should cause them to start being returned correctly after being converted to unix epoch values.