### PR TITLE
CORE-2026: allocate shared memory if the tool is configured to use it

### DIFF
--- a/internal/constants.go
+++ b/internal/constants.go
@@ -21,6 +21,9 @@ const (
 	fileTransfersInitContainerName = "input-files-init"
 	fileTransfersInputsMountPath   = "/input-files"
 
+	// Constants for shared memory volumes.
+	sharedMemoryVolumeName = "shared-memory"
+
 	// The working directory volume serves as the working directory when IRODS CSI Driver integration is enabled.
 	workingDirVolumeName             = "working-dir"
 	workingDirInitContainerName      = "working-dir-init"

--- a/internal/constants.go
+++ b/internal/constants.go
@@ -71,6 +71,8 @@ const (
 	gpuAffinityValue    = "true"
 
 	userSuffix = "@iplantcollaborative.org"
+
+	shmDevice = "/dev/shm"
 )
 
 func int32Ptr(i int32) *int32 { return &i }

--- a/internal/deployments.go
+++ b/internal/deployments.go
@@ -380,7 +380,7 @@ func sharedMemoryAmount(job *model.Job) *resourcev1.Quantity {
 	var shmAmount resourcev1.Quantity
 	var err error
 	for _, device := range job.Steps[0].Component.Container.Devices {
-		if strings.HasPrefix(strings.ToLower(device.HostPath), "/dev/shm") {
+		if strings.HasPrefix(strings.ToLower(device.HostPath), shmDevice) {
 			shmAmount, err = resourcev1.ParseQuantity(device.ContainerPath)
 			if err != nil {
 				log.Warn(err)
@@ -469,7 +469,7 @@ func (i *Internal) defineAnalysisContainer(job *model.Job) apiv1.Container {
 	if sharedMemoryAmount(job) != nil {
 		volumeMounts = append(volumeMounts, apiv1.VolumeMount{
 			Name:      sharedMemoryVolumeName,
-			MountPath: "/dev/shm",
+			MountPath: shmDevice,
 			ReadOnly:  false,
 		})
 	}

--- a/internal/deployments.go
+++ b/internal/deployments.go
@@ -103,6 +103,21 @@ func (i *Internal) deploymentVolumes(job *model.Job) []apiv1.Volume {
 		},
 	)
 
+	shmSize := sharedMemoryAmount(job)
+	if shmSize != nil {
+		output = append(output,
+			apiv1.Volume{
+				Name: sharedMemoryVolumeName,
+				VolumeSource: apiv1.VolumeSource{
+					EmptyDir: &apiv1.EmptyDirVolumeSource{
+						Medium:    "Memory",
+						SizeLimit: shmSize,
+					},
+				},
+			},
+		)
+	}
+
 	return output
 }
 
@@ -361,6 +376,22 @@ func gpuEnabled(job *model.Job) bool {
 	return gpuEnabled
 }
 
+func sharedMemoryAmount(job *model.Job) *resourcev1.Quantity {
+	var shmAmount resourcev1.Quantity
+	var err error
+	for _, device := range job.Steps[0].Component.Container.Devices {
+		if strings.HasPrefix(strings.ToLower(device.HostPath), "/dev/shm") {
+			shmAmount, err = resourcev1.ParseQuantity(device.ContainerPath)
+			if err != nil {
+				log.Warn(err)
+				return nil
+			}
+			return &shmAmount
+		}
+	}
+	return nil
+}
+
 func (i *Internal) defineAnalysisContainer(job *model.Job) apiv1.Container {
 	analysisEnvironment := []apiv1.EnvVar{}
 	for envKey, envVal := range job.Steps[0].Environment {
@@ -432,6 +463,13 @@ func (i *Internal) defineAnalysisContainer(job *model.Job) apiv1.Container {
 		volumeMounts = append(volumeMounts, apiv1.VolumeMount{
 			Name:      fileTransfersVolumeName,
 			MountPath: workingDirMountPath(job),
+			ReadOnly:  false,
+		})
+	}
+	if sharedMemoryAmount(job) != nil {
+		volumeMounts = append(volumeMounts, apiv1.VolumeMount{
+			Name:      sharedMemoryVolumeName,
+			MountPath: "/dev/shm",
 			ReadOnly:  false,
 		})
 	}


### PR DESCRIPTION
This change allows DE administrators to indicate that an app should have shared memory allocated to it for tools that require shared memory. We provide the shared memory by creating an emptyDir volume with the size limit specified by the tool. (See this [StackOverflow answer](https://stackoverflow.com/a/46434614/299222) for more details.)

This is implemented in a similar way to our GPU integration. To dedicate shared memory to a tool add a container device to the tool with a host path of `/dev/shm` and a container path equal to the amount of shared memory to make available:
![image](https://github.com/user-attachments/assets/e470596d-2177-4d98-91e8-ec2bf4f25924)

It's not a perfect way to indicate how much shared memory should be provided, but implementing it this way allowed us to make this feature available quickly.
