### PR TITLE
Add support for data containers as secrets mounted into a batch workflow

### DIFF
--- a/cmd/app-exposer/main.go
+++ b/cmd/app-exposer/main.go
@@ -354,7 +354,7 @@ func main() {
 		Namespace:              *argoWorkflowNS,
 	}
 	enforcer := quota.NewEnforcer(clientset, dbconn, nec, *userSuffix)
-	jexAdapter := adapter.New(jexAdapterInit, a, detector, infoGetter, enforcer)
+	jexAdapter := adapter.New(jexAdapterInit, a, detector, infoGetter, enforcer, clientset)
 
 	// Set the routes for the batch app. Changes the state of the jaGroup
 	// instance at *jaGroup, so there's no return value that we care about.

--- a/cmd/workflow-builder/main.go
+++ b/cmd/workflow-builder/main.go
@@ -38,18 +38,18 @@ func main() {
 		harborPass         = flag.String("harbor-pass", "", "The password for the harbor user.")
 	)
 
-	// if cluster is set, then
-	if cluster := os.Getenv("CLUSTER"); cluster != "" {
-		kubeconfig = flag.String("kubeconfig", "", "absolute path to the kubeconfig file")
+	kubeconfig = flag.String("kubeconfig", "", "absolute path to the kubeconfig file")
+
+	// Prefer the value in the KUBECONFIG env var.
+	// If the value is not set, then check for the HOME directory.
+	// If that is not set, then require the user to specify a path.
+	if kubeconfigEnv := os.Getenv("KUBECONFIG"); kubeconfigEnv != "" {
+		kubeconfig = flag.String("kubeconfig", kubeconfigEnv, "absolute path to the kubeconfig file")
+	} else if home := os.Getenv("HOME"); home != "" {
+		kubeconfig = flag.String("kubeconfig", filepath.Join(home, ".kube", "config"), "(optional) absolute path to the kubeconfig file")
 	} else {
-		// If the home directory exists, then assume that the kube config will be read
-		// from ~/.kube/config.
-		if home := os.Getenv("HOME"); home != "" {
-			kubeconfig = flag.String("kubeconfig", filepath.Join(home, ".kube", "config"), "(optional) absolute path to the kubeconfig file")
-		} else {
-			// If the home directory doesn't exist, then allow the user to specify a path.
-			kubeconfig = flag.String("kubeconfig", "", "absolute path to the kubeconfig file")
-		}
+		// If the home directory doesn't exist, then allow the user to specify a path.
+		kubeconfig = flag.String("kubeconfig", "", "absolute path to the kubeconfig file")
 	}
 
 	flag.Parse()

--- a/cmd/workflow-builder/main.go
+++ b/cmd/workflow-builder/main.go
@@ -6,17 +6,23 @@ import (
 	"flag"
 	"log"
 	"os"
+	"path/filepath"
 
 	"github.com/cyverse-de/app-exposer/batch"
 	"github.com/cyverse-de/app-exposer/imageinfo"
 	"github.com/cyverse-de/model/v7"
+	"github.com/pkg/errors"
 	"gopkg.in/yaml.v3"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
 )
 
 func main() {
 	var (
-		err      error
-		inputJob model.Job
+		err        error
+		kubeconfig *string
+		inputJob   model.Job
 
 		job                = flag.String("job", "", "The file containing the job definition. Required.")
 		transferImage      = flag.String("transfer-image", "harbor.cyverse.org/de/gocmd:latest", "(optional) Image used to transfer files to/from the data store")
@@ -31,6 +37,20 @@ func main() {
 		harborUser         = flag.String("harbor-user", "", "The user for harbor lookups.")
 		harborPass         = flag.String("harbor-pass", "", "The password for the harbor user.")
 	)
+
+	// if cluster is set, then
+	if cluster := os.Getenv("CLUSTER"); cluster != "" {
+		kubeconfig = flag.String("kubeconfig", "", "absolute path to the kubeconfig file")
+	} else {
+		// If the home directory exists, then assume that the kube config will be read
+		// from ~/.kube/config.
+		if home := os.Getenv("HOME"); home != "" {
+			kubeconfig = flag.String("kubeconfig", filepath.Join(home, ".kube", "config"), "(optional) absolute path to the kubeconfig file")
+		} else {
+			// If the home directory doesn't exist, then allow the user to specify a path.
+			kubeconfig = flag.String("kubeconfig", "", "absolute path to the kubeconfig file")
+		}
+	}
 
 	flag.Parse()
 
@@ -48,6 +68,26 @@ func main() {
 
 	if *harborPass == "" {
 		log.Fatal("--harbor-pass must be set")
+	}
+
+	var config *rest.Config
+	if *kubeconfig != "" {
+		config, err = clientcmd.BuildConfigFromFlags("", *kubeconfig)
+		if err != nil {
+			log.Fatal(errors.Wrapf(err, "error building config from flags using kubeconfig %s", *kubeconfig))
+		}
+	} else {
+		// If the home directory doesn't exist and the user doesn't specify a path,
+		// then assume that we're running inside a cluster.
+		config, err = rest.InClusterConfig()
+		if err != nil {
+			log.Fatal(errors.Wrapf(err, "error loading the config inside the cluster"))
+		}
+	}
+
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		log.Fatal(errors.Wrap(err, "error creating clientset from config"))
 	}
 
 	infoGetter, err := imageinfo.NewHarborInfoGetter(*harborURL, *harborUser, *harborPass)
@@ -73,8 +113,11 @@ func main() {
 		ExternalID:             *analysisID,
 	}
 
-	maker := batch.NewWorkflowMaker(infoGetter, &inputJob)
-	workflow := maker.NewWorkflow(&opts)
+	maker := batch.NewWorkflowMaker(infoGetter, &inputJob, clientset)
+	workflow, err := maker.NewWorkflow(context.Background(), &opts)
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	if !*quiet {
 		var outfile *os.File

--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/cyverse-de/p/go/qms v0.1.13
 	github.com/google/go-cmp v0.6.0
 	github.com/google/uuid v1.6.0
-	github.com/gosimple/slug v1.14.0
+	github.com/gosimple/slug v1.15.0
 	github.com/jmoiron/sqlx v1.3.5
 	github.com/knadh/koanf v1.5.0
 	github.com/labstack/echo/v4 v4.11.4

--- a/go.sum
+++ b/go.sum
@@ -371,6 +371,8 @@ github.com/gorilla/websocket v1.5.1 h1:gmztn0JnHVt9JZquRuzLw3g4wouNVzKL15iLr/zn/
 github.com/gorilla/websocket v1.5.1/go.mod h1:x3kM2JMyaluk02fnUJpQuwD2dCS5NDG2ZHL0uE0tcaY=
 github.com/gosimple/slug v1.14.0 h1:RtTL/71mJNDfpUbCOmnf/XFkzKRtD6wL6Uy+3akm4Es=
 github.com/gosimple/slug v1.14.0/go.mod h1:UiRaFH+GEilHstLUmcBgWcI42viBN7mAb818JrYOeFQ=
+github.com/gosimple/slug v1.15.0 h1:wRZHsRrRcs6b0XnxMUBM6WK1U1Vg5B0R7VkIf1Xzobo=
+github.com/gosimple/slug v1.15.0/go.mod h1:UiRaFH+GEilHstLUmcBgWcI42viBN7mAb818JrYOeFQ=
 github.com/gosimple/unidecode v1.0.1 h1:hZzFTMMqSswvf0LBJZCZgThIZrpDHFXux9KeGmn6T/o=
 github.com/gosimple/unidecode v1.0.1/go.mod h1:CP0Cr1Y1kogOtx0bJblKzsVWrqYaqfNOnHzpgWw4Awc=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=


### PR DESCRIPTION
Adds support for data containers as secrets mounted into a batch workflow.

The name prefix stored in the database becomes the name of the volume. 

The names of the secrets are expected to conform to slugification rules, with the exception that underscores are replaced with dashes. 

The mount point of the secret is the data container's container path. 

The path each key is mounted at under the container path is specified in the secret's annotations, with each data key having a corresponding annotation whose value is the path to the file under the mount point.