### PR TITLE
Add pod disruption budget for the VICE pods

### DIFF
--- a/incluster/internal.go
+++ b/incluster/internal.go
@@ -443,6 +443,19 @@ func (i *Incluster) doExit(ctx context.Context, externalID string) error {
 		LabelSelector: set.AsSelector().String(),
 	}
 
+	// Delete the pod disruption budget
+	pdbClient := i.clientset.PolicyV1().PodDisruptionBudgets(i.ViceNamespace)
+	pdbList, err := pdbClient.List(ctx, listoptions)
+	if err != nil {
+		return err
+	}
+
+	for _, pdb := range pdbList.Items {
+		if err = pdbClient.Delete(ctx, pdb.Name, metav1.DeleteOptions{}); err != nil {
+			log.Error(err)
+		}
+	}
+
 	// Delete the ingress
 	ingressclient := i.clientset.NetworkingV1().Ingresses(i.ViceNamespace)
 	ingresslist, err := ingressclient.List(ctx, listoptions)

--- a/incluster/internal.go
+++ b/incluster/internal.go
@@ -244,6 +244,20 @@ func (i *Incluster) UpsertDeployment(ctx context.Context, deployment *appsv1.Dep
 		}
 	}
 
+	// Create the pod disruption budget for the job.
+	pdb, err := i.createPodDisruptionBudget(ctx, job)
+	if err != nil {
+		return err
+	}
+	pdbClient := i.clientset.PolicyV1().PodDisruptionBudgets(i.ViceNamespace)
+	_, err = pdbClient.Get(ctx, job.InvocationID, metav1.GetOptions{})
+	if err != nil {
+		_, err = pdbClient.Create(ctx, pdb, metav1.CreateOptions{})
+		if err != nil {
+			return err
+		}
+	}
+
 	// Create the service for the job.
 	svc, err := i.getService(ctx, job)
 	if err != nil {

--- a/incluster/pdb.go
+++ b/incluster/pdb.go
@@ -1,0 +1,37 @@
+package incluster
+
+import (
+	"context"
+
+	"github.com/cyverse-de/model/v7"
+	policyv1 "k8s.io/api/policy/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+func (i *Incluster) createPodDisruptionBudget(ctx context.Context, analysis *model.Analysis) (*policyv1.PodDisruptionBudget, error) {
+	labels, err := i.labelsFromJob(ctx, analysis)
+	if err != nil {
+		return nil, err
+	}
+
+	pdb := policyv1.PodDisruptionBudget{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   analysis.InvocationID,
+			Labels: labels,
+		},
+		Spec: policyv1.PodDisruptionBudgetSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"external-id": analysis.InvocationID,
+				},
+			},
+			MaxUnavailable: &intstr.IntOrString{
+				Type:   intstr.Int,
+				IntVal: 0,
+			},
+		},
+	}
+
+	return &pdb, nil
+}


### PR DESCRIPTION
Adds a pod disruption budget that allows for 0 pods being unavailable. This will hopefully cut down on the number of evictions we see.