### PR TITLE
Add handler to kill all running VICE and batch jobs

### DIFF
--- a/constants/constants.go
+++ b/constants/constants.go
@@ -69,5 +69,28 @@ const (
 	ShmDevice = "/dev/shm"
 )
 
+type AnalysisStatus string
+
+const (
+	Running   AnalysisStatus = "Running"
+	Completed AnalysisStatus = "Completed"
+	Failed    AnalysisStatus = "Failed"
+)
+
+// AnalysisKind corresponds to the job types in the database. We've started using the term
+// "analysis" instead of job and type is a reserved word in Go.
+type AnalysisKind string
+
+const (
+	// Interactive analyses are VICE analyses.
+	Interactive AnalysisKind = "interactive"
+
+	// Internal analyses are tools like URL import that aren't accessible directly by the user.
+	Internal AnalysisKind = "internal"
+
+	// Executable analyses are batch analyses.
+	Executable AnalysisKind = "executable"
+)
+
 func Int32Ptr(i int32) *int32 { return &i }
 func Int64Ptr(i int64) *int64 { return &i }

--- a/db/db.go
+++ b/db/db.go
@@ -16,21 +16,13 @@ var log = common.Log
 
 const otelName = "github.com/cyverse-de/jex-adapter/db"
 
-// DatabaseAccessor is an interface for iteracting with a database. Its main
-// reason for existing is to abstract out whether a transaction is being used.
-type DatabaseAccessor interface {
-	QueryRowxContext(context.Context, string, ...interface{}) *sqlx.Row
-	QueryxContext(context.Context, string, ...interface{}) (*sqlx.Rows, error)
-	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
-}
-
 type Database struct {
-	db DatabaseAccessor
+	db *sqlx.DB
 }
 
-func New(db DatabaseAccessor) *Database {
+func New(db *sqlx.DB) *Database {
 	return &Database{
-		db: db,
+		db,
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,8 @@ replace github.com/cyverse-de/quota => ./quota
 
 replace github.com/cyverse-de/common => ./common
 
+replace github.com/cyverse-de/adapter => ./adapter
+
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.0
 	github.com/argoproj/argo-workflows/v3 v3.6.2

--- a/httphandlers/batch.go
+++ b/httphandlers/batch.go
@@ -1,0 +1,101 @@
+package httphandlers
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+
+	"github.com/cyverse-de/model/v7"
+	"github.com/labstack/echo/v4"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+func (h *HTTPHandlers) BatchHomeHandler(c echo.Context) error {
+	return c.String(http.StatusOK, "Welcome to the JEX.\n")
+}
+
+type uuidBody struct {
+	UUID string
+}
+
+func (h *HTTPHandlers) BatchStopByUUID(c echo.Context) error {
+	var (
+		err error
+		b   uuidBody
+	)
+
+	ctx := c.Request().Context()
+
+	if err = json.NewDecoder(c.Request().Body).Decode(&b); err != nil {
+		return err
+	}
+
+	if err = h.batchadapter.StopWorkflow(ctx, b.UUID); err != nil {
+		log.Error(err)
+		return err
+	}
+
+	return c.NoContent(http.StatusOK)
+}
+
+func (h *HTTPHandlers) BatchStopHandler(c echo.Context) error {
+	var err error
+
+	log := log.WithFields(logrus.Fields{"context": "stop app"})
+
+	externalID := c.Param("id")
+	if externalID == "" {
+		err = errors.New("missing external id in URL")
+		log.Error(err)
+		return err
+	}
+
+	log = log.WithFields(logrus.Fields{"external_id": externalID})
+
+	ctx := c.Request().Context()
+
+	if err = h.batchadapter.StopWorkflow(ctx, externalID); err != nil {
+		log.Error(err)
+		return err
+	}
+
+	log.Info("sent stop message")
+
+	return c.NoContent(http.StatusOK)
+}
+
+func (h *HTTPHandlers) BatchLaunchHandler(c echo.Context) error {
+	request := c.Request()
+	ctx := c.Request().Context()
+
+	log := log.WithFields(logrus.Fields{"context": "app launch"})
+
+	log.Debug("reading request body")
+	bodyBytes, err := io.ReadAll(request.Body)
+	if err != nil {
+		log.Error(err)
+		return err
+	}
+	log.Debug("done reading request body")
+
+	log.Debug("parsing request body JSON")
+	acfg := &model.AnalysisConfig{
+		LogPath:     h.batchadapter.LogPath,
+		FilterFiles: h.batchadapter.FilterFiles,
+		IRODSBase:   h.batchadapter.IRODSBase,
+	}
+	analysis, err := model.NewAnalysis(acfg, bodyBytes)
+	if err != nil {
+		log.Error(err)
+		return err
+	}
+	log.Debug("done parsing request body JSON")
+
+	if err = h.batchadapter.LaunchWorkflow(ctx, analysis); err != nil {
+		log.Error(err)
+		return err
+	}
+
+	return c.NoContent(http.StatusOK)
+}

--- a/httphandlers/handlers.go
+++ b/httphandlers/handlers.go
@@ -5,12 +5,15 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/cyverse-de/app-exposer/adapter"
 	"github.com/cyverse-de/app-exposer/apps"
+	"github.com/cyverse-de/app-exposer/common"
 	"github.com/cyverse-de/app-exposer/incluster"
 	"github.com/labstack/echo/v4"
-	"github.com/labstack/gommon/log"
 	"k8s.io/client-go/kubernetes"
 )
+
+var log = common.Log
 
 var otelName = "github.com/cyverse-de/app-exposer/handlers"
 
@@ -18,13 +21,17 @@ type HTTPHandlers struct {
 	incluster *incluster.Incluster
 	apps      *apps.Apps
 	clientset kubernetes.Interface
+	//db           *db.Database
+	batchadapter *adapter.JEXAdapter
 }
 
-func New(incluster *incluster.Incluster, apps *apps.Apps, clientset kubernetes.Interface) *HTTPHandlers {
+func New(incluster *incluster.Incluster, apps *apps.Apps, clientset kubernetes.Interface, batchadapter *adapter.JEXAdapter) *HTTPHandlers {
 	return &HTTPHandlers{
 		incluster,
 		apps,
 		clientset,
+		//db,
+		batchadapter,
 	}
 }
 

--- a/httphandlers/resources.go
+++ b/httphandlers/resources.go
@@ -9,7 +9,6 @@ import (
 	"github.com/cyverse-de/app-exposer/incluster"
 	"github.com/cyverse-de/app-exposer/permissions"
 	"github.com/labstack/echo/v4"
-	"github.com/labstack/gommon/log"
 )
 
 // FilterableDeploymentsHandler lists all of the deployments.

--- a/httphandlers/timelimit.go
+++ b/httphandlers/timelimit.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 
 	"github.com/labstack/echo/v4"
-	"github.com/labstack/gommon/log"
 )
 
 // TimeLimitUpdateHandler handles requests to update the time limit on an already running VICE app.


### PR DESCRIPTION
This does a bit more than it says in the subject. In order to get sane database access I had to move some types around. I moved the HTTP handlers for the batch analyses into httphandlers and adjusted things from there. The main logic for the handler in question is in exit.go.