### PR TITLE
Use batch-exit-handler image, remove flag to disable cleanup

### DIFF
--- a/adapter/adapter.go
+++ b/adapter/adapter.go
@@ -37,7 +37,7 @@ type Init struct {
 	StatusSenderImage      string
 	Namespace              string
 	ImagePullSecretName    string
-	DoWorkflowCleanup      bool
+	BatchExitHandlerImage  string
 }
 
 // New returns a *JEXAdapter
@@ -103,9 +103,10 @@ func (j *JEXAdapter) LaunchWorkflow(ctx context.Context, analysis *model.Analysi
 		StatusSenderImage:      j.StatusSenderImage,
 		ExternalID:             analysis.InvocationID,
 		ImagePullSecretName:    j.ImagePullSecretName,
+		BatchExitHandlerImage:  j.BatchExitHandlerImage,
 	}
 
-	maker := batch.NewWorkflowMaker(j.imageInfoGetter, analysis, j.clientset, j.DoWorkflowCleanup)
+	maker := batch.NewWorkflowMaker(j.imageInfoGetter, analysis, j.clientset)
 	workflow, err := maker.NewWorkflow(ctx, opts)
 
 	if err != nil {

--- a/cmd/app-exposer/main.go
+++ b/cmd/app-exposer/main.go
@@ -116,7 +116,7 @@ func main() {
 		viceProxyStorageResourceLimit        = flag.String("vice-proxy-storage-resource-limit", "100Gi", "The default storage resource limit for the vice proxy.")
 		disableViceProxyStorageResourceLimit = flag.Bool("disable-vice-proxy-storage-resource-limit", true, "Disable storage resource limit for the vice proxy.")
 		logLevel                             = flag.String("log-level", "warn", "One of trace, debug, info, warn, error, fatal, or panic.")
-		doWorkflowCleanup                    = flag.Bool("do-workflow-cleanup", true, "Whether to clean up workflows that are finished.")
+		batchExitHandlerImage                = flag.String("batch-exit-handler-image", "harbor.cyverse.org/de/batch-exit-handler:latest", "The image to use for the exitHandler in batch workflows")
 	)
 
 	var tracerCtx, cancel = context.WithCancel(context.Background())
@@ -329,7 +329,7 @@ func main() {
 		StatusSenderImage:      *statusSenderImage,
 		Namespace:              *argoWorkflowNS,
 		ImagePullSecretName:    imagePullSecretName,
-		DoWorkflowCleanup:      *doWorkflowCleanup,
+		BatchExitHandlerImage:  *batchExitHandlerImage,
 	}
 	enforcer := quota.NewEnforcer(clientset, dbconn, a, nec, *userSuffix)
 	jexAdapter := adapter.New(jexAdapterInit, a, detector, infoGetter, enforcer, clientset)

--- a/cmd/workflow-builder/main.go
+++ b/cmd/workflow-builder/main.go
@@ -36,7 +36,6 @@ func main() {
 		harborURL          = flag.String("harbor-url", "https://harbor.cyverse.org/api/v2.0/", "The base URL for the harbor instance")
 		harborUser         = flag.String("harbor-user", "", "The user for harbor lookups.")
 		harborPass         = flag.String("harbor-pass", "", "The password for the harbor user.")
-		doWorkflowCleanup  = flag.Bool("do-workflow-cleanup", true, "Whether to clean up workflows that are finished.")
 	)
 
 	// Prefer the value in the KUBECONFIG env var.
@@ -112,7 +111,7 @@ func main() {
 		ExternalID:             *analysisID,
 	}
 
-	maker := batch.NewWorkflowMaker(infoGetter, &inputJob, clientset, *doWorkflowCleanup)
+	maker := batch.NewWorkflowMaker(infoGetter, &inputJob, clientset)
 	workflow, err := maker.NewWorkflow(context.Background(), &opts)
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
We're using a new image to implement the logic for the exit handler. It should allow the logic to always send the analysis status even if uploads fail for some reason.