### PR TITLE
vice-bundle: subcommands instead of mode flags (CORE-2144)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ local-test-config.yml
 k8s/vice-operator-local.*
 k8s/vice-operator.yml
 k8s/vice-operator-qa.yml
+.claude/settings.local.json
+.claude/*.lock

--- a/cmd/vice-bundle/main.go
+++ b/cmd/vice-bundle/main.go
@@ -1,6 +1,11 @@
 // Package main provides a CLI tool that generates AnalysisBundle JSON by
 // calling app-exposer's dry-run endpoint. Useful for debugging, testing,
 // and manual operator interaction without going through a full launch flow.
+//
+// Two subcommands are exposed:
+//
+//	vice-bundle from-job      Bundle a raw model.Job JSON file.
+//	vice-bundle from-export   Bundle a vice-export JSON file plus runtime launch params.
 package main
 
 import (
@@ -11,8 +16,8 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"net/url"
 	"os"
-	"strings"
 
 	"github.com/cyverse-de/app-exposer/cmd/vicetools"
 	"github.com/cyverse-de/app-exposer/common"
@@ -20,94 +25,154 @@ import (
 	"github.com/cyverse-de/model/v10"
 )
 
+const usage = `Usage: vice-bundle <command> [flags]
+
+Commands:
+  from-job      Bundle a raw model.Job JSON file
+  from-export   Bundle a vice-export JSON file plus runtime launch params
+
+Use "vice-bundle <command> -h" for help on a command.
+`
+
 func main() {
-	jobFile := flag.String("job", "", "Path to JSON file containing a model.Job (mode 1).")
-	exportFile := flag.String("export-file", "", "Path to vice-export JSON file (mode 2).")
-	appExposerURL := flag.String("app-exposer-url", "", "Base URL of app-exposer. Required.")
-	user := flag.String("user", "", "Username for the launch (mode 2).")
-	userID := flag.String(constants.UserIDLabel, "", "User UUID (mode 2).")
-	outputDir := flag.String("output-dir", "", "iRODS output directory (mode 2).")
-	email := flag.String("email", "", "User email (mode 2, optional).")
-	outFile := flag.String("out", "", "Output file path. Defaults to stdout.")
-	validate := flag.Bool("validate", false, "Ask app-exposer to validate the job before building the bundle.")
+	if len(os.Args) < 2 {
+		fmt.Fprint(os.Stderr, usage)
+		os.Exit(1)
+	}
 
-	flag.Parse()
+	subcmd := os.Args[1]
+	args := os.Args[2:]
 
-	if *appExposerURL == "" {
+	switch subcmd {
+	case "from-job":
+		runFromJob(args)
+	case "from-export":
+		runFromExport(args)
+	case "-h", "--help", "help":
+		fmt.Fprint(os.Stdout, usage) //nolint:errcheck // failure to print help is not actionable
+
+	default:
+		fmt.Fprintf(os.Stderr, "unknown command: %s\n", subcmd)
+		fmt.Fprint(os.Stderr, usage)
+		os.Exit(1)
+	}
+}
+
+// runFromJob bundles a pre-built model.Job JSON file.
+func runFromJob(args []string) {
+	fs := flag.NewFlagSet("from-job", flag.ExitOnError)
+	appExposerURL := fs.String("app-exposer-url", "", "Base URL of app-exposer. Required.")
+	jobFile := fs.String("job", "", "Path to JSON file containing a model.Job. Required.")
+	validate := fs.Bool("validate", false, "Ask app-exposer to validate the job before building the bundle.")
+	outFile := fs.String("out", "", "Output file path. Defaults to stdout.")
+	// ExitOnError means Parse calls os.Exit on failure; it never returns a non-nil error.
+	_ = fs.Parse(args) //nolint:errcheck // see comment above
+
+	baseURL := requireBaseURL(*appExposerURL)
+	if *jobFile == "" {
+		log.Fatal("--job must be set.")
+	}
+
+	f, err := os.Open(*jobFile)
+	if err != nil {
+		log.Fatalf("opening job file: %v", err)
+	}
+	defer common.LogClose("job file", f)
+
+	job := &model.Job{}
+	if err := json.NewDecoder(f).Decode(job); err != nil {
+		log.Fatalf("decoding job JSON: %v", err)
+	}
+
+	postBundle(baseURL, *validate, *outFile, job)
+}
+
+// runFromExport bundles a vice-export JSON file combined with runtime launch params.
+func runFromExport(args []string) {
+	fs := flag.NewFlagSet("from-export", flag.ExitOnError)
+	appExposerURL := fs.String("app-exposer-url", "", "Base URL of app-exposer. Required.")
+	exportFile := fs.String("export-file", "", "Path to vice-export JSON file. Required.")
+	user := fs.String("user", "", "Username for the launch. Required.")
+	userID := fs.String(constants.UserIDLabel, "", "User UUID. Required.")
+	outputDir := fs.String("output-dir", "", "iRODS output directory. Required.")
+	email := fs.String("email", "", "User email. Optional.")
+	validate := fs.Bool("validate", false, "Ask app-exposer to validate the job before building the bundle.")
+	outFile := fs.String("out", "", "Output file path. Defaults to stdout.")
+	// ExitOnError means Parse calls os.Exit on failure; it never returns a non-nil error.
+	_ = fs.Parse(args) //nolint:errcheck // see comment above
+
+	baseURL := requireBaseURL(*appExposerURL)
+	if *exportFile == "" {
+		log.Fatal("--export-file must be set.")
+	}
+	if *user == "" {
+		log.Fatal("--user must be set.")
+	}
+	if *userID == "" {
+		log.Fatalf("--%s must be set.", constants.UserIDLabel)
+	}
+	if *outputDir == "" {
+		log.Fatal("--output-dir must be set.")
+	}
+
+	f, err := os.Open(*exportFile)
+	if err != nil {
+		log.Fatalf("opening export file: %v", err)
+	}
+	defer common.LogClose("export file", f)
+
+	var export vicetools.VICEAppExport
+	if err := json.NewDecoder(f).Decode(&export); err != nil {
+		log.Fatalf("decoding export JSON: %v", err)
+	}
+
+	params := vicetools.LaunchParams{
+		User:      *user,
+		UserID:    *userID,
+		OutputDir: *outputDir,
+		Email:     *email,
+	}
+
+	job, err := vicetools.ConvertToJob(&export, params)
+	if err != nil {
+		log.Fatalf("converting export to job: %v", err)
+	}
+
+	postBundle(baseURL, *validate, *outFile, job)
+}
+
+// requireBaseURL parses and validates the --app-exposer-url flag, fataling on
+// missing or malformed input. The result is reused as the base for path-aware
+// URL composition (per CLAUDE.md, parse once and use url.URL.JoinPath).
+func requireBaseURL(raw string) *url.URL {
+	if raw == "" {
 		log.Fatal("--app-exposer-url must be set.")
 	}
-
-	if *jobFile == "" && *exportFile == "" {
-		log.Fatal("Either --job or --export-file must be set.")
+	u, err := url.Parse(raw)
+	if err != nil || u.Scheme == "" || u.Host == "" {
+		log.Fatalf("invalid --app-exposer-url %q", raw)
 	}
-	if *jobFile != "" && *exportFile != "" {
-		log.Fatal("Only one of --job or --export-file may be set, not both.")
-	}
+	return u
+}
 
-	var job *model.Job
-
-	if *jobFile != "" {
-		// Mode 1: Raw job JSON.
-		f, err := os.Open(*jobFile)
-		if err != nil {
-			log.Fatalf("opening job file: %v", err)
-		}
-		defer common.LogClose("job file", f)
-
-		job = &model.Job{}
-		if err := json.NewDecoder(f).Decode(job); err != nil {
-			log.Fatalf("decoding job JSON: %v", err)
-		}
-	} else {
-		// Mode 2: Export file + runtime flags.
-		if *user == "" {
-			log.Fatal("--user must be set in export mode.")
-		}
-		if *userID == "" {
-			log.Fatal("--user-id must be set in export mode.")
-		}
-		if *outputDir == "" {
-			log.Fatal("--output-dir must be set in export mode.")
-		}
-
-		f, err := os.Open(*exportFile)
-		if err != nil {
-			log.Fatalf("opening export file: %v", err)
-		}
-		defer common.LogClose("export file", f)
-
-		var export vicetools.VICEAppExport
-		if err := json.NewDecoder(f).Decode(&export); err != nil {
-			log.Fatalf("decoding export JSON: %v", err)
-		}
-
-		params := vicetools.LaunchParams{
-			User:      *user,
-			UserID:    *userID,
-			OutputDir: *outputDir,
-			Email:     *email,
-		}
-
-		job, err = vicetools.ConvertToJob(&export, params)
-		if err != nil {
-			log.Fatalf("converting export to job: %v", err)
-		}
-	}
-
-	// POST the job to app-exposer's dry-run endpoint.
+// postBundle marshals the job, POSTs it to app-exposer's dry-run endpoint, and
+// pretty-prints the response to outFile (or stdout when outFile is empty).
+func postBundle(baseURL *url.URL, validate bool, outFile string, job *model.Job) {
 	body, err := json.Marshal(job)
 	if err != nil {
 		log.Fatalf("marshaling job: %v", err)
 	}
 
-	url := fmt.Sprintf("%s/vice/dry-run", *appExposerURL)
-	if *validate {
-		url += "?validate=true"
+	endpoint := baseURL.JoinPath("vice", "dry-run")
+	if validate {
+		q := endpoint.Query()
+		q.Set("validate", "true")
+		endpoint.RawQuery = q.Encode()
 	}
 
-	resp, err := http.Post(url, "application/json", bytes.NewReader(body))
+	resp, err := http.Post(endpoint.String(), "application/json", bytes.NewReader(body))
 	if err != nil {
-		log.Fatalf("posting to %s: %v", url, err)
+		log.Fatalf("posting to %s: %v", endpoint, err)
 	}
 	defer common.CloseBody(resp)
 
@@ -118,7 +183,7 @@ func main() {
 
 	if resp.StatusCode >= 400 {
 		if len(respBody) > 0 {
-			log.Fatalf("HTTP %d %s: %s", resp.StatusCode, resp.Status, strings.TrimRight(string(respBody), "\n"))
+			log.Fatalf("HTTP %d %s: %s", resp.StatusCode, resp.Status, bytes.TrimRight(respBody, "\n"))
 		}
 		log.Fatalf("HTTP %d %s", resp.StatusCode, resp.Status)
 	}
@@ -130,9 +195,9 @@ func main() {
 		log.Fatalf("decoding response JSON: %v", err)
 	}
 
-	out := io.Writer(os.Stdout)
-	if *outFile != "" {
-		f, err := os.Create(*outFile)
+	var out io.Writer = os.Stdout
+	if outFile != "" {
+		f, err := os.Create(outFile)
 		if err != nil {
 			log.Fatalf("creating output file: %v", err)
 		}
@@ -146,7 +211,7 @@ func main() {
 		log.Fatalf("encoding JSON: %v", err)
 	}
 
-	if *outFile != "" {
-		fmt.Fprintf(os.Stderr, "Bundle written to %s\n", *outFile)
+	if outFile != "" {
+		fmt.Fprintf(os.Stderr, "Bundle written to %s\n", outFile)
 	}
 }


### PR DESCRIPTION
## Summary
- Replaces vice-bundle's confusing `--job` / `--export-file` mode split with two explicit subcommands: `vice-bundle from-job` and `vice-bundle from-export`. Follows the in-repo subcommand pattern from `cmd/vice-operator-tool`.
- Switches URL composition to `url.URL.JoinPath` per CLAUDE.md, so a trailing slash on `--app-exposer-url` no longer produces `//vice/dry-run`.
- Adds `.claude/settings.local.json` and `.claude/*.lock` to `.gitignore` (narrow form so a future shared `.claude/settings.json` can still be committed).

Resolves [CORE-2144](https://cyverse.atlassian.net/browse/CORE-2144), the deferred follow-up to PR #117 review feedback ([discussion](https://github.com/cyverse-de/app-exposer/pull/117#discussion_r3102815779)).

The old flag form is removed outright. vice-bundle is a dev/debug tool not built into any container image and not referenced in deployment scripts, so blast radius is small.

## Test plan
- [x] `go build ./cmd/vice-bundle && go vet ./cmd/vice-bundle/... && golangci-lint run ./cmd/vice-bundle/...` all clean
- [x] `vice-bundle` (no args) and `vice-bundle bogus` print usage and exit 1
- [x] `vice-bundle help` / `from-job -h` / `from-export -h` print correct per-subcommand help
- [x] URL composition: `--app-exposer-url http://host/` and `--app-exposer-url http://host` both produce `http://host/vice/dry-run?validate=true`
- [ ] Smoke against a reachable app-exposer with a real `model.Job` JSON (`from-job`)
- [ ] Smoke against a reachable app-exposer with a real `vice-export` JSON + runtime flags (`from-export`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CORE-2144]: https://cyverse.atlassian.net/browse/CORE-2144?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ