### PR TITLE
Use go-oidc discovery + x/oauth2 in swagger auth (CORE-2146)

### DIFF
--- a/cmd/vice-operator/app_test.go
+++ b/cmd/vice-operator/app_test.go
@@ -1,12 +1,44 @@
 package main
 
 import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
+	"github.com/coreos/go-oidc/v3/oidc"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/oauth2"
 )
+
+// newFakeOIDCProvider stands up an httptest server that serves a minimal
+// /.well-known/openid-configuration document and returns a real *oidc.Provider
+// pointed at it. This lets tests exercise code paths that take a non-nil
+// provider without hitting a real Keycloak.
+func newFakeOIDCProvider(t *testing.T) *oidc.Provider {
+	t.Helper()
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/.well-known/openid-configuration" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{
+			"issuer": %q,
+			"authorization_endpoint": %q,
+			"token_endpoint": %q,
+			"jwks_uri": %q
+		}`, srv.URL, srv.URL+"/auth", srv.URL+"/token", srv.URL+"/jwks")
+	}))
+	t.Cleanup(srv.Close)
+
+	provider, err := oidc.NewProvider(context.Background(), srv.URL)
+	require.NoError(t, err)
+	return provider
+}
 
 func TestSwaggerAuthConfigEnabled(t *testing.T) {
 	tests := []struct {
@@ -98,6 +130,43 @@ func TestBuildSwaggerAuthConfigNoClientID(t *testing.T) {
 	require.NoError(t, err)
 	assert.False(t, cfg.Enabled())
 	assert.Nil(t, cfg.CookieSecret, "no cookie secret should be generated when client ID is absent")
+}
+
+func TestBuildSwaggerAuthConfigCookieSecret(t *testing.T) {
+	provider := newFakeOIDCProvider(t)
+
+	tests := []struct {
+		name           string
+		cookieSecretIn string
+		assertSecret   func(t *testing.T, got []byte)
+	}{
+		{
+			name:           "auto-generates when empty",
+			cookieSecretIn: "",
+			assertSecret: func(t *testing.T, got []byte) {
+				t.Helper()
+				assert.Len(t, got, 32, "auto-generated cookie secret should be 32 bytes")
+			},
+		},
+		{
+			name:           "uses provided secret as-is",
+			cookieSecretIn: "explicit-secret-value",
+			assertSecret: func(t *testing.T, got []byte) {
+				t.Helper()
+				assert.Equal(t, []byte("explicit-secret-value"), got)
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg, err := buildSwaggerAuthConfig(provider, "swagger-client", "client-secret", tt.cookieSecretIn)
+			require.NoError(t, err)
+			assert.True(t, cfg.Enabled(), "Enabled() must be true when provider and client ID are set")
+			assert.Equal(t, provider.Endpoint().AuthURL, cfg.Endpoint.AuthURL)
+			assert.Equal(t, provider.Endpoint().TokenURL, cfg.Endpoint.TokenURL)
+			tt.assertSecret(t, cfg.CookieSecret)
+		})
+	}
 }
 
 func TestStripBearer(t *testing.T) {

--- a/cmd/vice-operator/app_test.go
+++ b/cmd/vice-operator/app_test.go
@@ -4,7 +4,101 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
 )
+
+func TestSwaggerAuthConfigEnabled(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  SwaggerAuthConfig
+		want bool
+	}{
+		{"empty config", SwaggerAuthConfig{}, false},
+		{"client ID only, no endpoint", SwaggerAuthConfig{ClientID: "c"}, false},
+		{"endpoint only, no client ID", SwaggerAuthConfig{Endpoint: oauth2.Endpoint{AuthURL: "https://idp/auth", TokenURL: "https://idp/token"}}, false},
+		{"both client ID and endpoint", SwaggerAuthConfig{ClientID: "c", Endpoint: oauth2.Endpoint{AuthURL: "https://idp/auth", TokenURL: "https://idp/token"}}, true},
+		{"client ID with partial endpoint (no auth URL)", SwaggerAuthConfig{ClientID: "c", Endpoint: oauth2.Endpoint{TokenURL: "https://idp/token"}}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.cfg.Enabled())
+		})
+	}
+}
+
+func TestGenerateCookieSecret(t *testing.T) {
+	key, err := generateCookieSecret()
+	require.NoError(t, err)
+	assert.Len(t, key, 32, "cookie secret must be 32 bytes")
+
+	// Two calls should produce different values (collision probability negligible).
+	key2, err := generateCookieSecret()
+	require.NoError(t, err)
+	assert.NotEqual(t, key, key2)
+}
+
+func TestSignAndVerifyToken(t *testing.T) {
+	key := []byte("test-secret-key-32-bytes-long!!!")
+	tests := []struct {
+		name      string
+		token     string
+		cookieKey []byte
+		wantErr   bool
+	}{
+		{"valid token", "eyJhbGciOiJSUzI1NiJ9.payload.signature", key, false},
+		{"empty token", "", key, false},
+		{"wrong key", "some.jwt.token", []byte("different-key-32-bytes-long!!!!!"), true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			signed := signToken(tt.token, key)
+			got, err := verifyAndExtractToken(signed, tt.cookieKey)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.token, got)
+			}
+		})
+	}
+}
+
+func TestVerifyAndExtractTokenMalformed(t *testing.T) {
+	key := []byte("test-secret-key-32-bytes-long!!!")
+	tests := []struct {
+		name   string
+		cookie string
+	}{
+		{"no dot separator", "nodot"},
+		{"empty string", ""},
+		{"tampered payload", "dGFtcGVyZWQ.invalidsignature"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := verifyAndExtractToken(tt.cookie, key)
+			assert.Error(t, err)
+		})
+	}
+}
+
+func TestBuildSwaggerAuthConfigNilProvider(t *testing.T) {
+	// When provider is nil (API auth disabled), the Swagger endpoint must
+	// be zero-valued so Enabled() returns false even if a client ID is set.
+	cfg, err := buildSwaggerAuthConfig(nil, "some-client", "secret", "cookie-secret")
+	require.NoError(t, err)
+	assert.False(t, cfg.Enabled(), "Enabled() must be false when provider is nil")
+	assert.Empty(t, cfg.Endpoint.AuthURL)
+	assert.Empty(t, cfg.Endpoint.TokenURL)
+}
+
+func TestBuildSwaggerAuthConfigNoClientID(t *testing.T) {
+	// An empty client ID must disable the login flow regardless of provider.
+	cfg, err := buildSwaggerAuthConfig(nil, "", "", "")
+	require.NoError(t, err)
+	assert.False(t, cfg.Enabled())
+	assert.Nil(t, cfg.CookieSecret, "no cookie secret should be generated when client ID is absent")
+}
 
 func TestStripBearer(t *testing.T) {
 	tests := []struct {

--- a/cmd/vice-operator/main.go
+++ b/cmd/vice-operator/main.go
@@ -313,12 +313,16 @@ func main() {
 		log.Fatalf("failed to construct operator: %v", err)
 	}
 
-	verifier, err := buildAPIVerifier(context.Background(), apiAuthIssuerURL, apiAuthClientID, apiAuth)
+	// One OIDC discovery roundtrip populates both the API token verifier and
+	// the Swagger UI OAuth2 config so all endpoint URLs stay in sync with the
+	// issuer's published metadata.
+	provider, err := buildOIDCProvider(context.Background(), apiAuthIssuerURL, apiAuth)
 	if err != nil {
 		log.Fatalf("%v", err)
 	}
+	verifier := buildAPIVerifier(provider, apiAuthIssuerURL, apiAuthClientID)
 
-	swaggerCfg, err := buildSwaggerAuthConfig(swaggerClientID, swaggerClientSecret, swaggerCookieSecret, apiAuthIssuerURL)
+	swaggerCfg, err := buildSwaggerAuthConfig(provider, swaggerClientID, swaggerClientSecret, swaggerCookieSecret)
 	if err != nil {
 		log.Fatalf("%v", err)
 	}

--- a/cmd/vice-operator/startup.go
+++ b/cmd/vice-operator/startup.go
@@ -189,10 +189,12 @@ func buildEgressConfig(ctx context.Context, clientset kubernetes.Interface, in e
 	return cfg, nil
 }
 
-// buildAPIVerifier returns an OIDC ID-token verifier for API auth, or
-// nil when API auth is disabled. Provider discovery has a bounded 30s
-// timeout so a slow or down issuer can't hang startup forever.
-func buildAPIVerifier(ctx context.Context, issuerURL, clientID string, enabled bool) (*oidc.IDTokenVerifier, error) {
+// buildOIDCProvider performs OIDC discovery against the configured issuer.
+// Discovery has a bounded 30s timeout so a slow or down IdP can't hang startup
+// forever. Returns (nil, nil) when API auth is disabled — the caller treats
+// that as "unauthenticated mode" and skips both the API verifier and the
+// Swagger UI login flow.
+func buildOIDCProvider(ctx context.Context, issuerURL string, enabled bool) (*oidc.Provider, error) {
 	if !enabled {
 		log.Warn("API auth disabled (--api-auth=false); all requests are unauthenticated")
 		return nil, nil
@@ -203,10 +205,19 @@ func buildAPIVerifier(ctx context.Context, issuerURL, clientID string, enabled b
 	if err != nil {
 		return nil, fmt.Errorf("discovering OIDC provider at %q: %w", issuerURL, err)
 	}
-	// Keycloak client-credentials tokens use azp instead of aud, so
-	// disable the built-in audience check.
+	return provider, nil
+}
+
+// buildAPIVerifier extracts an ID-token verifier from an already-discovered
+// OIDC provider. Returns nil when provider is nil (API auth disabled).
+func buildAPIVerifier(provider *oidc.Provider, issuerURL, clientID string) *oidc.IDTokenVerifier {
+	if provider == nil {
+		return nil
+	}
+	// Keycloak client-credentials tokens use azp instead of aud, so disable
+	// the built-in audience check; bearerAuthMiddleware enforces azp/scope.
 	log.Infof("OIDC API auth enabled (issuer=%s, expected_client_id=%s)", issuerURL, clientID)
-	return provider.Verifier(&oidc.Config{SkipClientIDCheck: true}), nil
+	return provider.Verifier(&oidc.Config{SkipClientIDCheck: true})
 }
 
 // buildSwaggerAuthConfig assembles the Swagger UI auth config. When
@@ -214,25 +225,34 @@ func buildAPIVerifier(ctx context.Context, issuerURL, clientID string, enabled b
 // effectively disabling the Swagger login flow. When the cookie secret
 // flag is unset, an ephemeral key is generated and the operator warns
 // that sessions won't survive restarts.
-func buildSwaggerAuthConfig(swaggerClientID, swaggerClientSecret, swaggerCookieSecret, issuerURL string) (*SwaggerAuthConfig, error) {
-	var cookieSecret []byte
-	if swaggerClientID != "" {
-		if swaggerCookieSecret != "" {
-			cookieSecret = []byte(swaggerCookieSecret)
-		} else {
-			generated, err := GenerateCookieSecret()
-			if err != nil {
-				return nil, fmt.Errorf("generating cookie secret: %w", err)
-			}
-			cookieSecret = generated
-			log.Warn("no --swagger-cookie-secret provided; generated an ephemeral key (sessions will not survive restarts)")
-		}
-		log.Infof("Swagger UI login enabled (client_id=%s, issuer=%s)", swaggerClientID, issuerURL)
-	}
-	return &SwaggerAuthConfig{
-		IssuerURL:    issuerURL,
+//
+// The OAuth2 Endpoint is taken from the discovered provider so the
+// auth/token URLs always match the issuer's metadata.
+func buildSwaggerAuthConfig(provider *oidc.Provider, swaggerClientID, swaggerClientSecret, swaggerCookieSecret string) (*SwaggerAuthConfig, error) {
+	cfg := &SwaggerAuthConfig{
 		ClientID:     swaggerClientID,
 		ClientSecret: swaggerClientSecret,
-		CookieSecret: cookieSecret,
-	}, nil
+	}
+	if swaggerClientID == "" {
+		return cfg, nil
+	}
+	if provider == nil {
+		// API auth is disabled, so OIDC discovery didn't run; the Swagger
+		// login flow has no endpoints to use and will be effectively disabled.
+		log.Warn("Swagger client ID is set but API auth is disabled (--api-auth=false); Swagger UI login will not be available")
+		return cfg, nil
+	}
+	cfg.Endpoint = provider.Endpoint()
+	if swaggerCookieSecret != "" {
+		cfg.CookieSecret = []byte(swaggerCookieSecret)
+	} else {
+		generated, err := generateCookieSecret()
+		if err != nil {
+			return nil, fmt.Errorf("generating cookie secret: %w", err)
+		}
+		cfg.CookieSecret = generated
+		log.Warn("no --swagger-cookie-secret provided; generated an ephemeral key (sessions will not survive restarts)")
+	}
+	log.Infof("Swagger UI login enabled (client_id=%s)", swaggerClientID)
+	return cfg, nil
 }

--- a/cmd/vice-operator/swaggerauth.go
+++ b/cmd/vice-operator/swaggerauth.go
@@ -6,64 +6,59 @@ import (
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/base64"
-	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
-	"net/url"
 	"strings"
 	"time"
 
 	"github.com/coreos/go-oidc/v3/oidc"
-	"github.com/cyverse-de/app-exposer/common"
 	"github.com/labstack/echo/v4"
+	"golang.org/x/oauth2"
 )
 
 const (
-	sessionCookieName = "vice-operator-session"
-	stateCookieName   = "vice-operator-oauth-state"
-	stateMaxAge       = 300 // 5 minutes for the CSRF state cookie.
+	sessionCookieName    = "vice-operator-session"
+	stateCookieName      = "vice-operator-oauth-state"
+	stateMaxAge          = 300            // 5 minutes for the CSRF state cookie.
+	tokenExchangeTimeout = 10 * time.Second // Prevents a hung IdP from stalling the callback handler.
 )
 
-// swaggerAuthHTTPClient is used for OAuth token-endpoint calls. The default
+// tokenExchangeHTTPClient is used for OAuth token-endpoint calls. The default
 // http.Client has no timeout, which allows an unresponsive identity provider
 // to hang the callback goroutine indefinitely.
-var swaggerAuthHTTPClient = &http.Client{Timeout: 10 * time.Second}
+var tokenExchangeHTTPClient = &http.Client{Timeout: tokenExchangeTimeout}
 
 // SwaggerAuthConfig holds the OAuth2/OIDC settings for the Swagger UI login flow.
+// Endpoint is populated from OIDC discovery at startup so the auth/token URLs
+// stay in sync with the issuer's metadata.
 type SwaggerAuthConfig struct {
-	IssuerURL    string // OIDC issuer (e.g. https://keycloak.example.com/realms/cyverse).
-	ClientID     string // OAuth2 client ID (authorization code flow).
-	ClientSecret string // OAuth2 client secret.
-	CookieSecret []byte // HMAC key for signing session cookies.
+	Endpoint     oauth2.Endpoint // Auth + token URLs from OIDC discovery.
+	ClientID     string          // OAuth2 client ID (authorization code flow).
+	ClientSecret string          // OAuth2 client secret.
+	CookieSecret []byte          // HMAC key for signing session cookies.
 }
 
 // Enabled returns true when enough configuration is present for the login flow.
 func (c *SwaggerAuthConfig) Enabled() bool {
-	return c.ClientID != "" && c.IssuerURL != ""
+	return c.ClientID != "" && c.Endpoint.AuthURL != ""
 }
 
-// authURL returns the Keycloak authorization endpoint.
-func (c *SwaggerAuthConfig) authURL() string {
-	u, err := url.JoinPath(c.IssuerURL, "protocol", "openid-connect", "auth")
-	if err != nil {
-		log.Errorf("swaggerauth: joiningauth URL from %q: %v", c.IssuerURL, err)
+// oauth2Config returns a fresh OAuth2 config bound to the given redirect URI.
+// The redirect is computed per request because the operator may be reached
+// over different host/scheme combinations, so it can't be baked in once.
+func (c *SwaggerAuthConfig) oauth2Config(redirectURI string) *oauth2.Config {
+	return &oauth2.Config{
+		ClientID:     c.ClientID,
+		ClientSecret: c.ClientSecret,
+		Endpoint:     c.Endpoint,
+		RedirectURL:  redirectURI,
+		Scopes:       []string{oidc.ScopeOpenID},
 	}
-	return u
 }
 
-// tokenURL returns the Keycloak token endpoint. Same caveat as authURL.
-func (c *SwaggerAuthConfig) tokenURL() string {
-	u, err := url.JoinPath(c.IssuerURL, "protocol", "openid-connect", "token")
-	if err != nil {
-		log.Errorf("swaggerauth: joiningtoken URL from %q: %v", c.IssuerURL, err)
-	}
-	return u
-}
-
-// GenerateCookieSecret creates a random 32-byte key for HMAC signing.
-func GenerateCookieSecret() ([]byte, error) {
+// generateCookieSecret creates a random 32-byte key for HMAC signing.
+func generateCookieSecret() ([]byte, error) {
 	key := make([]byte, 32)
 	if _, err := rand.Read(key); err != nil {
 		return nil, fmt.Errorf("generating cookie secret: %w", err)
@@ -135,7 +130,7 @@ func swaggerSessionMiddleware(verifier *oidc.IDTokenVerifier, cfg *SwaggerAuthCo
 	}
 }
 
-// handleLogin serves a simple HTML page with a "Login with Keycloak" button.
+// handleLogin serves the login page with a "Login with Keycloak" button.
 func handleLogin(cfg *SwaggerAuthConfig) echo.HandlerFunc {
 	return func(c echo.Context) error {
 		// Generate a random state parameter for CSRF protection.
@@ -156,16 +151,10 @@ func handleLogin(cfg *SwaggerAuthConfig) echo.HandlerFunc {
 			SameSite: http.SameSiteLaxMode,
 		})
 
-		// Build the Keycloak authorization URL.
-		redirectURI := buildRedirectURI(c)
-		authParams := url.Values{
-			"response_type": {"code"},
-			"client_id":     {cfg.ClientID},
-			"redirect_uri":  {redirectURI},
-			"scope":         {"openid"},
-			"state":         {state},
-		}
-		authLink := cfg.authURL() + "?" + authParams.Encode()
+		// Build the Keycloak authorization URL via the OAuth2 library so the
+		// scope/state/redirect parameters and any future PKCE additions stay
+		// in one place.
+		authLink := cfg.oauth2Config(buildRedirectURI(c)).AuthCodeURL(state)
 
 		return c.HTML(http.StatusOK, loginPage(authLink))
 	}
@@ -202,26 +191,35 @@ func handleCallback(cfg *SwaggerAuthConfig, verifier *oidc.IDTokenVerifier) echo
 			return echo.NewHTTPError(http.StatusBadRequest, "missing authorization code")
 		}
 
-		// Exchange the code for tokens.
-		redirectURI := buildRedirectURI(c)
-		tokenResp, err := exchangeCode(c.Request().Context(), cfg, code, redirectURI)
+		// Exchange the code for tokens. The oauth2 library handles the POST
+		// to the token endpoint, JSON parsing, and per-request cancellation.
+		// Inject a timeout-bounded HTTP client so a slow IdP can't stall the
+		// callback handler indefinitely.
+		ctx := context.WithValue(c.Request().Context(), oauth2.HTTPClient, tokenExchangeHTTPClient)
+		tok, err := cfg.oauth2Config(buildRedirectURI(c)).Exchange(ctx, code)
 		if err != nil {
 			log.Errorf("token exchange failed: %v", err)
 			return echo.NewHTTPError(http.StatusInternalServerError, "token exchange failed")
 		}
 
-		// Verify the access token so we know it's valid before storing.
-		idToken, err := verifier.Verify(c.Request().Context(), tokenResp.AccessToken)
+		// Verify the access token's signature/expiry before storing it. The
+		// token endpoint just returns whatever the IdP says; we trust it only
+		// after go-oidc validates the JWT against the discovered JWKS.
+		idToken, err := verifier.Verify(ctx, tok.AccessToken)
 		if err != nil {
 			log.Errorf("token verification failed after exchange: %v", err)
 			return echo.NewHTTPError(http.StatusInternalServerError, "received invalid token from identity provider")
 		}
 
-		// Compute cookie expiry from the token's exp claim.
+		// Tie the cookie's lifetime to the verified JWT exp claim. Using
+		// idToken.Expiry rather than tok.Expiry guards against IdPs that
+		// omit expires_in from the token response — that would leave
+		// tok.Expiry as the time.Time zero value and produce a no-Max-Age
+		// session cookie that outlives the underlying token.
 		maxAge := max(int(time.Until(idToken.Expiry).Seconds()), 0)
 
 		// Set the signed session cookie.
-		signed := signToken(tokenResp.AccessToken, cfg.CookieSecret)
+		signed := signToken(tok.AccessToken, cfg.CookieSecret)
 		c.SetCookie(&http.Cookie{
 			Name:     sessionCookieName,
 			Value:    signed,
@@ -259,56 +257,6 @@ func clearSessionCookie(c echo.Context) {
 func buildRedirectURI(c echo.Context) string {
 	scheme := c.Scheme()
 	return fmt.Sprintf("%s://%s/docs/callback", scheme, c.Request().Host)
-}
-
-// tokenResponse holds the fields we need from the Keycloak token endpoint.
-type tokenResponse struct {
-	AccessToken string `json:"access_token"`
-}
-
-// exchangeCode performs the OAuth2 authorization code exchange. The caller
-// provides the request context so cancellation composes with the package-level
-// client timeout on swaggerAuthHTTPClient.
-func exchangeCode(ctx context.Context, cfg *SwaggerAuthConfig, code, redirectURI string) (*tokenResponse, error) {
-	data := url.Values{
-		"grant_type":   {"authorization_code"},
-		"code":         {code},
-		"redirect_uri": {redirectURI},
-		"client_id":    {cfg.ClientID},
-	}
-	if cfg.ClientSecret != "" {
-		data.Set("client_secret", cfg.ClientSecret)
-	}
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, cfg.tokenURL(), strings.NewReader(data.Encode()))
-	if err != nil {
-		return nil, fmt.Errorf("building token request: %w", err)
-	}
-	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-
-	resp, err := swaggerAuthHTTPClient.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("POST to token endpoint: %w", err)
-	}
-	defer common.CloseBody(resp)
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("reading token response: %w", err)
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("token endpoint returned %d: %s", resp.StatusCode, string(body))
-	}
-
-	var tokenResp tokenResponse
-	if err := json.Unmarshal(body, &tokenResp); err != nil {
-		return nil, fmt.Errorf("parsing token response: %w", err)
-	}
-	if tokenResp.AccessToken == "" {
-		return nil, errors.New("token response missing access_token")
-	}
-	return &tokenResp, nil
 }
 
 // extractTokenFromCookie reads and verifies the session cookie, returning the


### PR DESCRIPTION
## Summary

- Replace hand-rolled OAuth2 plumbing in `cmd/vice-operator/swaggerauth.go` with `golang.org/x/oauth2` (`AuthCodeURL` / `Exchange`) and `oidc.NewProvider` discovery for endpoints.
- Discovery happens once at startup; the same `*oidc.Provider` feeds both the API verifier and the Swagger UI OAuth2 config (`buildOIDCProvider` + slimmed `buildAPIVerifier` in `startup.go`).
- Cookie expiry stays anchored to the verified JWT `exp` claim — using `idToken.Expiry` rather than `tok.Expiry` guards against IdPs that omit `expires_in` (which would otherwise yield a no-`Max-Age` session cookie that outlives the underlying token).
- Token-exchange HTTP traffic keeps the prior 10s timeout via `context.WithValue(ctx, oauth2.HTTPClient, ...)` — `oauth2.Config.Exchange` would otherwise fall back to `http.DefaultClient`, which has none.
- Tests added for `SwaggerAuthConfig.Enabled`, cookie-secret round-trip helpers, and `buildSwaggerAuthConfig`'s nil-provider / no-client-id branches.

Per the rescoped ticket, this stays on `coreos/go-oidc` rather than swapping to `zitadel/oidc`, so the `*oidc.IDTokenVerifier` type stays stable and CORE-2147 / CORE-2148 (which edit `bearerAuthMiddleware` claim handling) are unaffected.

Net diff: -127 / +193 (the +66 is mostly new tests; runtime code shrinks).

## Test plan

- [x] `go build ./...`
- [x] `go vet ./cmd/vice-operator/...`
- [x] `golangci-lint run ./cmd/vice-operator/...` — 0 issues
- [x] `go test -count=1 ./cmd/vice-operator/...`
- [ ] Manual smoke (author): start vice-operator with --api-auth=true and a real Keycloak issuer, hit `/docs/login`, confirm the redirect URL is built from the discovered authorization endpoint, log in, confirm the session cookie's `Max-Age` matches the JWT `exp` claim.
- [ ] Manual smoke: bearer-auth path still accepts a client_credentials token (no behavior change expected — verifier and middleware claim block are unchanged).
- [ ] Manual smoke: `--api-auth=false` still serves docs unauthenticated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)