### PR TITLE
Refer to operators by ID rather than name

### DIFF
--- a/apps/apps.go
+++ b/apps/apps.go
@@ -253,34 +253,22 @@ const setOperatorIDStmt = `
 	WHERE id = $1;
 `
 
-// GetOperatorIDByName returns the UUID for an operator by its unique name.
-func (a *Apps) GetOperatorIDByName(ctx context.Context, name string) (uuid.UUID, error) {
-	var id uuid.UUID
-	const query = "SELECT id FROM operators WHERE name = $1"
-	err := a.DB.GetContext(ctx, &id, query, name)
-	return id, err
-}
-
-// SetOperatorName records which operator is running an analysis by mapping its
-// name to an operator_id and updating the jobs row. It retries briefly because
-// the jobs row may not be visible yet if the caller's database transaction
-// hasn't committed. The launch handler returns early to unblock that commit,
-// so the row typically appears within a few seconds.
+// SetOperatorID records which operator is running an analysis by writing
+// jobs.operator_id directly. It retries briefly because the jobs row may
+// not be visible yet if the caller's database transaction hasn't
+// committed. The launch handler returns early to unblock that commit, so
+// the row typically appears within a few seconds.
 //
-// The wait between attempts doubles each round, starting at initialBackoff and
-// capping at maxBackoff, so a healthy DB that commits quickly sees nearly no
-// delay while a slow DB sheds load gracefully across the 10-attempt budget.
-func (a *Apps) SetOperatorName(ctx context.Context, analysisID constants.AnalysisID, operatorName string) error {
+// The wait between attempts doubles each round, starting at
+// initialBackoff and capping at maxBackoff, so a healthy DB that commits
+// quickly sees nearly no delay while a slow DB sheds load gracefully
+// across the 10-attempt budget.
+func (a *Apps) SetOperatorID(ctx context.Context, analysisID constants.AnalysisID, operatorID uuid.UUID) error {
 	const (
 		maxRetries     = 10
 		initialBackoff = 100 * time.Millisecond
 		maxBackoff     = 5 * time.Second
 	)
-
-	operatorID, err := a.GetOperatorIDByName(ctx, operatorName)
-	if err != nil {
-		return fmt.Errorf("resolving operator %q to ID: %w", operatorName, err)
-	}
 
 	backoff := initialBackoff
 	for attempt := range maxRetries {
@@ -293,7 +281,7 @@ func (a *Apps) SetOperatorName(ctx context.Context, analysisID constants.Analysi
 			return err
 		}
 		if rows > 0 {
-			log.Infof("set operator_id %s (name %q) for analysis %s (attempt %d)", operatorID, operatorName, analysisID, attempt+1)
+			log.Infof("set operator_id %s for analysis %s (attempt %d)", operatorID, analysisID, attempt+1)
 			return nil
 		}
 
@@ -349,28 +337,28 @@ func (a *Apps) GetJobDebugInfo(ctx context.Context, analysisID constants.Analysi
 	return &info, nil
 }
 
-const getOperatorNameQuery = `
-	SELECT o.name
-	FROM jobs j
-	JOIN operators o ON j.operator_id = o.id
-	WHERE j.id = $1
+const getOperatorIDQuery = `
+	SELECT operator_id
+	FROM jobs
+	WHERE id = $1
 `
 
-// GetOperatorName returns the name of the operator running an analysis,
-// or an empty string if none is set or no row exists. sql.NullString's zero
-// value has String == "" when the column is NULL, so we can return it
-// directly without checking .Valid.
-func (a *Apps) GetOperatorName(ctx context.Context, analysisID constants.AnalysisID) (string, error) {
-	var name sql.NullString
-	err := a.DB.QueryRowContext(ctx, getOperatorNameQuery, analysisID).Scan(&name)
+// GetOperatorID returns the UUID of the operator running an analysis, or
+// uuid.Nil if no row exists or operator_id is NULL. uuid.UUID's Scan
+// implementation tolerates NULL by leaving the value as uuid.Nil, so the
+// "no operator yet" case (legacy launch, mid-launch before SetOperatorID
+// commits, or unknown analysis) is represented uniformly.
+func (a *Apps) GetOperatorID(ctx context.Context, analysisID constants.AnalysisID) (uuid.UUID, error) {
+	var id uuid.UUID
+	err := a.DB.QueryRowContext(ctx, getOperatorIDQuery, analysisID).Scan(&id)
 	if errors.Is(err, sql.ErrNoRows) {
-		// The analysis doesn't exist in the database or has no operator; treat as none.
-		return "", nil
+		// The analysis doesn't exist in the database; treat as none.
+		return uuid.Nil, nil
 	}
 	if err != nil {
-		return "", err
+		return uuid.Nil, err
 	}
-	return name.String, nil
+	return id, nil
 }
 
 const externalIDsByStatusQuery = `

--- a/apps/interfaces.go
+++ b/apps/interfaces.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/cyverse-de/app-exposer/constants"
+	"github.com/google/uuid"
 )
 
 // AnalysisStatusLookup is the narrow subset of *Apps used by the quota
@@ -17,18 +18,18 @@ type AnalysisStatusLookup interface {
 	GetAnalysisStatus(ctx context.Context, analysisID constants.AnalysisID) (string, error)
 }
 
-// OperatorNameLookup is the narrow subset of *Apps used by the reconciler
-// to back-fill missing operator_name records. Defined here so the
-// reconciler can be unit-tested with a fake. *Apps satisfies this
+// OperatorLookup is the narrow subset of *Apps used by the reconciler to
+// back-fill missing operator_id records on the jobs table. Defined here
+// so the reconciler can be unit-tested with a fake. *Apps satisfies this
 // interface structurally.
-type OperatorNameLookup interface {
-	// GetOperatorName returns the operator name currently recorded for
-	// the analysis, or "" with nil error if no row exists or the column
+type OperatorLookup interface {
+	// GetOperatorID returns the operator UUID currently recorded for the
+	// analysis, or uuid.Nil with nil error if no row exists or the column
 	// is NULL.
-	GetOperatorName(ctx context.Context, analysisID constants.AnalysisID) (string, error)
+	GetOperatorID(ctx context.Context, analysisID constants.AnalysisID) (uuid.UUID, error)
 
-	// SetOperatorName records the operator running the analysis.
-	// Internally retries a handful of times if the jobs row isn't yet
-	// visible (handles the launch/commit race).
-	SetOperatorName(ctx context.Context, analysisID constants.AnalysisID, operatorName string) error
+	// SetOperatorID records the operator running the analysis. Internally
+	// retries a handful of times if the jobs row isn't yet visible
+	// (handles the launch/commit race).
+	SetOperatorID(ctx context.Context, analysisID constants.AnalysisID, operatorID uuid.UUID) error
 }

--- a/cmd/app-exposer/app.go
+++ b/cmd/app-exposer/app.go
@@ -144,19 +144,12 @@ func NewExposerApp(init *ExposerAppInit, apps *apps.Apps, conn *nats.EncodedConn
 		handlers:   httphandlers.New(incluster, apps, init.ClientSet, init.batchadapter, init.dbase, init.MaxConcurrentLaunches),
 	}
 
-	// Configure operator scheduler. Try config first for backward compatibility,
-	// but the reconciler will later overwrite this from the database.
-	var operatorConfigs []operatorclient.OperatorConfig
-	if err := c.Unmarshal("vice.operators", &operatorConfigs); err != nil {
-		log.Warnf("could not parse operators config: %v", err)
-	}
-
-	scheduler, err := operatorclient.NewScheduler(operatorConfigs, nil)
-	if err != nil {
-		log.Fatalf("error creating operator scheduler: %v", err)
-	}
+	// Operator scheduler starts empty; the reconciler's initial
+	// SyncOperators call (in main.go) populates it from the operators
+	// table, which is the source of truth for operator configuration.
+	scheduler := operatorclient.NewScheduler(nil)
 	app.handlers.SetScheduler(scheduler)
-	log.Infof("operator scheduler configured with %d operators from config", len(operatorConfigs))
+	log.Info("operator scheduler initialized; awaiting initial DB sync")
 
 	app.router.Use(otelecho.Middleware("app-exposer"))
 
@@ -230,7 +223,8 @@ func NewExposerApp(init *ExposerAppInit, apps *apps.Apps, conn *nats.EncodedConn
 	viceadmin.GET("/operators", app.handlers.AdminOperatorsHandler)
 	viceadmin.POST("/operators", app.handlers.CreateOperatorHandler)
 	viceadmin.GET("/operators/capacities", app.handlers.AdminOperatorCapacitiesHandler)
-	viceadmin.DELETE("/operators/name/:name", app.handlers.DeleteOperatorHandler)
+	viceadmin.DELETE("/operators/id/:id", app.handlers.DeleteOperatorHandler)
+	viceadmin.PATCH("/operators/id/:id", app.handlers.UpdateOperatorHandler)
 	viceadmin.GET("/listing", app.handlers.AdminFilterableResourcesHandler)
 	viceadmin.GET("/operator-listing", app.handlers.AdminOperatorListingHandler)
 	viceadmin.POST("/terminate-all", app.handlers.TerminateAllAnalysesHandler)

--- a/cmd/app-exposer/main.go
+++ b/cmd/app-exposer/main.go
@@ -416,7 +416,7 @@ func main() {
 
 	// Initialize and start the status reconciliation worker. The apps
 	// handle is passed so the reconciler can back-fill missing
-	// operator_name records on each cycle (see r.backfillOperatorName).
+	// operator_id records on each cycle (see r.backfillOperatorID).
 	reconciler := reconciler.New(dbase, a, app.handlers.GetScheduler(), tokenSource)
 	go reconciler.Run(context.Background())
 

--- a/cmd/vice-operator-tool/client.go
+++ b/cmd/vice-operator-tool/client.go
@@ -92,21 +92,13 @@ func (c *OperatorClient) ListOperators(ctx context.Context) ([]operatorclient.Op
 	return ops, nil
 }
 
-// UpdateOperatorRequest is the wire-shape for PATCH
-// /vice/admin/operators/id/{id}. Pointer fields encode partial updates:
-// nil means "leave this column unchanged."
-type UpdateOperatorRequest struct {
-	Name          *string `json:"name,omitempty"`
-	URL           *string `json:"url,omitempty"`
-	TLSSkipVerify *bool   `json:"tls_skip_verify,omitempty"`
-	Priority      *int    `json:"priority,omitempty"`
-}
-
 // UpdateOperator partially updates the operator with the given id via
 // PATCH /vice/admin/operators/id/{id}. Only fields with non-nil pointers
 // in req are sent (json:omitempty handles the omission), matching the
-// server's COALESCE-based partial-update semantics.
-func (c *OperatorClient) UpdateOperator(ctx context.Context, id uuid.UUID, req *UpdateOperatorRequest) (*operatorclient.OperatorConfig, error) {
+// server's COALESCE-based partial-update semantics. The response carries
+// the row's id alongside the updated fields so callers can confirm the
+// post-update state without a follow-up list call.
+func (c *OperatorClient) UpdateOperator(ctx context.Context, id uuid.UUID, req *operatorclient.UpdateOperatorRequest) (*operatorclient.OperatorAdminSummary, error) {
 	body, err := json.Marshal(req)
 	if err != nil {
 		return nil, fmt.Errorf("marshaling request: %w", err)
@@ -129,7 +121,7 @@ func (c *OperatorClient) UpdateOperator(ctx context.Context, id uuid.UUID, req *
 		return nil, readError(resp)
 	}
 
-	var summary operatorclient.OperatorConfig
+	var summary operatorclient.OperatorAdminSummary
 	if err := json.NewDecoder(resp.Body).Decode(&summary); err != nil {
 		return nil, fmt.Errorf("decoding response: %w", err)
 	}

--- a/cmd/vice-operator-tool/client.go
+++ b/cmd/vice-operator-tool/client.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/cyverse-de/app-exposer/common"
 	"github.com/cyverse-de/app-exposer/operatorclient"
+	"github.com/google/uuid"
 )
 
 // OperatorClient talks to the app-exposer operator admin API using
@@ -31,8 +32,10 @@ func NewOperatorClient(baseURL *url.URL, httpClient *http.Client) *OperatorClien
 	}
 }
 
-// AddOperator creates a new operator via POST /vice/admin/operators.
-func (c *OperatorClient) AddOperator(ctx context.Context, req *operatorclient.OperatorConfig) (*operatorclient.OperatorConfig, error) {
+// AddOperator creates a new operator via POST /vice/admin/operators. The
+// returned summary includes the server-assigned UUID, so callers can
+// PATCH/DELETE the row by id without an extra list call.
+func (c *OperatorClient) AddOperator(ctx context.Context, req *operatorclient.OperatorConfig) (*operatorclient.OperatorAdminSummary, error) {
 	body, err := json.Marshal(req)
 	if err != nil {
 		return nil, fmt.Errorf("marshaling request: %w", err)
@@ -55,15 +58,17 @@ func (c *OperatorClient) AddOperator(ctx context.Context, req *operatorclient.Op
 		return nil, readError(resp)
 	}
 
-	var summary operatorclient.OperatorConfig
+	var summary operatorclient.OperatorAdminSummary
 	if err := json.NewDecoder(resp.Body).Decode(&summary); err != nil {
 		return nil, fmt.Errorf("decoding response: %w", err)
 	}
 	return &summary, nil
 }
 
-// ListOperators fetches all operators via GET /vice/admin/operators.
-func (c *OperatorClient) ListOperators(ctx context.Context) ([]operatorclient.OperatorConfig, error) {
+// ListOperators fetches all operators via GET /vice/admin/operators. The
+// admin endpoint returns each operator's UUID alongside the public config
+// fields so the CLI can resolve a user-supplied name to an id for PATCH.
+func (c *OperatorClient) ListOperators(ctx context.Context) ([]operatorclient.OperatorAdminSummary, error) {
 	u := c.baseURL.JoinPath("vice", "admin", "operators")
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
 	if err != nil {
@@ -80,16 +85,63 @@ func (c *OperatorClient) ListOperators(ctx context.Context) ([]operatorclient.Op
 		return nil, readError(resp)
 	}
 
-	var ops []operatorclient.OperatorConfig
+	var ops []operatorclient.OperatorAdminSummary
 	if err := json.NewDecoder(resp.Body).Decode(&ops); err != nil {
 		return nil, fmt.Errorf("decoding response: %w", err)
 	}
 	return ops, nil
 }
 
-// DeleteOperator removes an operator by name via DELETE /vice/admin/operators/name/{name}.
-func (c *OperatorClient) DeleteOperator(ctx context.Context, name string) error {
-	u := c.baseURL.JoinPath("vice", "admin", "operators", "name", name)
+// UpdateOperatorRequest is the wire-shape for PATCH
+// /vice/admin/operators/id/{id}. Pointer fields encode partial updates:
+// nil means "leave this column unchanged."
+type UpdateOperatorRequest struct {
+	Name          *string `json:"name,omitempty"`
+	URL           *string `json:"url,omitempty"`
+	TLSSkipVerify *bool   `json:"tls_skip_verify,omitempty"`
+	Priority      *int    `json:"priority,omitempty"`
+}
+
+// UpdateOperator partially updates the operator with the given id via
+// PATCH /vice/admin/operators/id/{id}. Only fields with non-nil pointers
+// in req are sent (json:omitempty handles the omission), matching the
+// server's COALESCE-based partial-update semantics.
+func (c *OperatorClient) UpdateOperator(ctx context.Context, id uuid.UUID, req *UpdateOperatorRequest) (*operatorclient.OperatorConfig, error) {
+	body, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling request: %w", err)
+	}
+
+	u := c.baseURL.JoinPath("vice", "admin", "operators", "id", id.String())
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPatch, u.String(), bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("building request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.http.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("sending request: %w", err)
+	}
+	defer common.CloseBody(resp)
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, readError(resp)
+	}
+
+	var summary operatorclient.OperatorConfig
+	if err := json.NewDecoder(resp.Body).Decode(&summary); err != nil {
+		return nil, fmt.Errorf("decoding response: %w", err)
+	}
+	return &summary, nil
+}
+
+// DeleteOperator removes an operator by id via DELETE
+// /vice/admin/operators/id/{id}. The endpoint is idempotent: deleting a
+// non-existent UUID returns 200 silently. The CLI typically resolves a
+// user-supplied name to an id by calling ListOperators first.
+func (c *OperatorClient) DeleteOperator(ctx context.Context, id uuid.UUID) error {
+	u := c.baseURL.JoinPath("vice", "admin", "operators", "id", id.String())
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodDelete, u.String(), nil)
 	if err != nil {
 		return fmt.Errorf("building request: %w", err)

--- a/cmd/vice-operator-tool/client_test.go
+++ b/cmd/vice-operator-tool/client_test.go
@@ -114,11 +114,8 @@ func TestAddOperator(t *testing.T) {
 					// Echo the request fields back as the admin summary
 					// (id + four config fields) so the client can decode it.
 					_ = json.NewEncoder(w).Encode(operatorclient.OperatorAdminSummary{ //nolint:errcheck // test server write
-						ID:            createdID,
-						Name:          tt.req.Name,
-						URL:           tt.req.URL,
-						TLSSkipVerify: tt.req.TLSSkipVerify,
-						Priority:      tt.req.Priority,
+						ID:             createdID,
+						OperatorConfig: *tt.req,
 					})
 				}
 			})
@@ -213,19 +210,19 @@ func TestUpdateOperator(t *testing.T) {
 
 	tests := []struct {
 		name       string
-		req        *UpdateOperatorRequest
+		req        *operatorclient.UpdateOperatorRequest
 		statusCode int
 		respBody   string
 		wantErr    bool
 		// validate inspects the decoded request body so individual cases can
 		// assert on which fields were sent (omitted nil pointers should not
 		// appear in the JSON thanks to omitempty).
-		validate func(t *testing.T, raw []byte, decoded UpdateOperatorRequest)
+		validate func(t *testing.T, raw []byte, decoded operatorclient.UpdateOperatorRequest)
 	}{
 		{
 			name: "single-field rename",
-			req:  &UpdateOperatorRequest{Name: &newName},
-			validate: func(t *testing.T, raw []byte, decoded UpdateOperatorRequest) {
+			req:  &operatorclient.UpdateOperatorRequest{Name: &newName},
+			validate: func(t *testing.T, raw []byte, decoded operatorclient.UpdateOperatorRequest) {
 				t.Helper()
 				require.NotNil(t, decoded.Name)
 				assert.Equal(t, "renamed", *decoded.Name)
@@ -237,17 +234,17 @@ func TestUpdateOperator(t *testing.T) {
 				assert.NotContains(t, string(raw), "priority")
 			},
 			statusCode: http.StatusOK,
-			respBody:   `{"name":"renamed","url":"https://orig.example.com","tls_skip_verify":false,"priority":0}`,
+			respBody:   `{"id":"aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa","name":"renamed","url":"https://orig.example.com","tls_skip_verify":false,"priority":0}`,
 		},
 		{
 			name: "all fields",
-			req: &UpdateOperatorRequest{
+			req: &operatorclient.UpdateOperatorRequest{
 				Name:          &newName,
 				URL:           &newURL,
 				TLSSkipVerify: &newSkip,
 				Priority:      &newPriority,
 			},
-			validate: func(t *testing.T, raw []byte, decoded UpdateOperatorRequest) {
+			validate: func(t *testing.T, raw []byte, decoded operatorclient.UpdateOperatorRequest) {
 				t.Helper()
 				require.NotNil(t, decoded.Name)
 				require.NotNil(t, decoded.URL)
@@ -259,25 +256,25 @@ func TestUpdateOperator(t *testing.T) {
 				assert.Equal(t, 7, *decoded.Priority)
 			},
 			statusCode: http.StatusOK,
-			respBody:   `{"name":"renamed","url":"https://new.example.com","tls_skip_verify":true,"priority":7}`,
+			respBody:   `{"id":"aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa","name":"renamed","url":"https://new.example.com","tls_skip_verify":true,"priority":7}`,
 		},
 		{
 			name:       "404 not found",
-			req:        &UpdateOperatorRequest{Priority: &newPriority},
+			req:        &operatorclient.UpdateOperatorRequest{Priority: &newPriority},
 			statusCode: http.StatusNotFound,
 			respBody:   `{"message":"operator not found"}`,
 			wantErr:    true,
 		},
 		{
 			name:       "409 conflict on rename collision",
-			req:        &UpdateOperatorRequest{Name: &newName},
+			req:        &operatorclient.UpdateOperatorRequest{Name: &newName},
 			statusCode: http.StatusConflict,
 			respBody:   `{"message":"operator with that name or url already exists"}`,
 			wantErr:    true,
 		},
 		{
 			name:       "400 bad request on validation failure",
-			req:        &UpdateOperatorRequest{URL: strPtr("not-a-url")},
+			req:        &operatorclient.UpdateOperatorRequest{URL: strPtr("not-a-url")},
 			statusCode: http.StatusBadRequest,
 			respBody:   `{"message":"url must be a valid HTTP(S) URL"}`,
 			wantErr:    true,
@@ -296,7 +293,7 @@ func TestUpdateOperator(t *testing.T) {
 				if tt.validate != nil {
 					raw, err := readAllAndRestore(r)
 					require.NoError(t, err)
-					var decoded UpdateOperatorRequest
+					var decoded operatorclient.UpdateOperatorRequest
 					require.NoError(t, json.Unmarshal(raw, &decoded))
 					tt.validate(t, raw, decoded)
 				}
@@ -316,7 +313,12 @@ func TestUpdateOperator(t *testing.T) {
 				assert.Nil(t, summary)
 			} else {
 				require.NoError(t, err)
-				assert.NotNil(t, summary)
+				require.NotNil(t, summary)
+				// Confirm the response carries the row's id, not just
+				// the OperatorConfig fields — the asymmetric "create
+				// returns id, update doesn't" bug from the prior PR is
+				// what motivated the response-shape change.
+				assert.Equal(t, id, summary.ID)
 			}
 		})
 	}

--- a/cmd/vice-operator-tool/client_test.go
+++ b/cmd/vice-operator-tool/client_test.go
@@ -1,14 +1,17 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"testing"
 
 	"github.com/cyverse-de/app-exposer/operatorclient"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -23,6 +26,8 @@ func testClient(t *testing.T, handler http.Handler) *OperatorClient {
 }
 
 func TestAddOperator(t *testing.T) {
+	createdID := uuid.MustParse("33333333-3333-3333-3333-333333333333")
+
 	tests := []struct {
 		name       string
 		req        *operatorclient.OperatorConfig
@@ -30,6 +35,7 @@ func TestAddOperator(t *testing.T) {
 		respBody   string
 		wantErr    bool
 		wantName   string
+		wantID     uuid.UUID
 		// validate is called with the decoded request body when provided,
 		// allowing individual cases to assert on fields sent to the server.
 		validate func(t *testing.T, got operatorclient.OperatorConfig)
@@ -41,8 +47,9 @@ func TestAddOperator(t *testing.T) {
 				URL:  "https://op-a.example.com",
 			},
 			statusCode: http.StatusCreated,
-			respBody:   `{"name":"cluster-a","url":"https://op-a.example.com","tls_skip_verify":false,"priority":0}`,
+			respBody:   `{"id":"33333333-3333-3333-3333-333333333333","name":"cluster-a","url":"https://op-a.example.com","tls_skip_verify":false,"priority":0}`,
 			wantName:   "cluster-a",
+			wantID:     createdID,
 		},
 		{
 			// Verify that all fields (including TLSSkipVerify) are sent correctly in the request body.
@@ -56,6 +63,7 @@ func TestAddOperator(t *testing.T) {
 			statusCode: http.StatusCreated,
 			// The handler echos back the decoded request, so respBody is built dynamically via validate.
 			wantName: "op-1",
+			wantID:   createdID,
 			validate: func(t *testing.T, got operatorclient.OperatorConfig) {
 				t.Helper()
 				assert.Equal(t, "op-1", got.Name)
@@ -103,11 +111,14 @@ func TestAddOperator(t *testing.T) {
 				if tt.respBody != "" {
 					_, _ = w.Write([]byte(tt.respBody)) //nolint:errcheck // test server write
 				} else if tt.validate != nil {
-					// Echo the request fields back as the summary so the client can decode it.
-					_ = json.NewEncoder(w).Encode(operatorclient.OperatorConfig{ //nolint:errcheck // test server write
+					// Echo the request fields back as the admin summary
+					// (id + four config fields) so the client can decode it.
+					_ = json.NewEncoder(w).Encode(operatorclient.OperatorAdminSummary{ //nolint:errcheck // test server write
+						ID:            createdID,
 						Name:          tt.req.Name,
 						URL:           tt.req.URL,
 						TLSSkipVerify: tt.req.TLSSkipVerify,
+						Priority:      tt.req.Priority,
 					})
 				}
 			})
@@ -121,24 +132,36 @@ func TestAddOperator(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 				assert.Equal(t, tt.wantName, summary.Name)
+				assert.Equal(t, tt.wantID, summary.ID)
 			}
 		})
 	}
 }
 
 func TestListOperators(t *testing.T) {
+	idA := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	idB := uuid.MustParse("22222222-2222-2222-2222-222222222222")
+
 	tests := []struct {
 		name       string
 		statusCode int
 		respBody   string
 		wantErr    bool
 		wantLen    int
+		// validate runs on the decoded slice when no error is expected,
+		// allowing per-case assertions (e.g., that id decodes correctly).
+		validate func(t *testing.T, ops []operatorclient.OperatorAdminSummary)
 	}{
 		{
-			name:       "populated list",
+			name:       "populated list with ids",
 			statusCode: http.StatusOK,
-			respBody:   `[{"name":"a","url":"https://a.example.com","tls_skip_verify":false,"priority":0},{"name":"b","url":"https://b.example.com","tls_skip_verify":true,"priority":10}]`,
+			respBody:   `[{"id":"11111111-1111-1111-1111-111111111111","name":"a","url":"https://a.example.com","tls_skip_verify":false,"priority":0},{"id":"22222222-2222-2222-2222-222222222222","name":"b","url":"https://b.example.com","tls_skip_verify":true,"priority":10}]`,
 			wantLen:    2,
+			validate: func(t *testing.T, ops []operatorclient.OperatorAdminSummary) {
+				t.Helper()
+				assert.Equal(t, idA, ops[0].ID)
+				assert.Equal(t, idB, ops[1].ID)
+			},
 		},
 		{
 			name:       "empty list",
@@ -173,47 +196,191 @@ func TestListOperators(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 				assert.Len(t, ops, tt.wantLen)
+				if tt.validate != nil {
+					tt.validate(t, ops)
+				}
 			}
 		})
 	}
 }
 
-func TestDeleteOperator(t *testing.T) {
+func TestUpdateOperator(t *testing.T) {
+	id := uuid.MustParse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+	newName := "renamed"
+	newURL := "https://new.example.com"
+	newSkip := true
+	newPriority := 7
+
 	tests := []struct {
 		name       string
-		opName     string
+		req        *UpdateOperatorRequest
 		statusCode int
 		respBody   string
 		wantErr    bool
-		wantPath   string
+		// validate inspects the decoded request body so individual cases can
+		// assert on which fields were sent (omitted nil pointers should not
+		// appear in the JSON thanks to omitempty).
+		validate func(t *testing.T, raw []byte, decoded UpdateOperatorRequest)
+	}{
+		{
+			name: "single-field rename",
+			req:  &UpdateOperatorRequest{Name: &newName},
+			validate: func(t *testing.T, raw []byte, decoded UpdateOperatorRequest) {
+				t.Helper()
+				require.NotNil(t, decoded.Name)
+				assert.Equal(t, "renamed", *decoded.Name)
+				assert.Nil(t, decoded.URL)
+				assert.Nil(t, decoded.TLSSkipVerify)
+				assert.Nil(t, decoded.Priority)
+				assert.NotContains(t, string(raw), "url")
+				assert.NotContains(t, string(raw), "tls_skip_verify")
+				assert.NotContains(t, string(raw), "priority")
+			},
+			statusCode: http.StatusOK,
+			respBody:   `{"name":"renamed","url":"https://orig.example.com","tls_skip_verify":false,"priority":0}`,
+		},
+		{
+			name: "all fields",
+			req: &UpdateOperatorRequest{
+				Name:          &newName,
+				URL:           &newURL,
+				TLSSkipVerify: &newSkip,
+				Priority:      &newPriority,
+			},
+			validate: func(t *testing.T, raw []byte, decoded UpdateOperatorRequest) {
+				t.Helper()
+				require.NotNil(t, decoded.Name)
+				require.NotNil(t, decoded.URL)
+				require.NotNil(t, decoded.TLSSkipVerify)
+				require.NotNil(t, decoded.Priority)
+				assert.Equal(t, "renamed", *decoded.Name)
+				assert.Equal(t, "https://new.example.com", *decoded.URL)
+				assert.True(t, *decoded.TLSSkipVerify)
+				assert.Equal(t, 7, *decoded.Priority)
+			},
+			statusCode: http.StatusOK,
+			respBody:   `{"name":"renamed","url":"https://new.example.com","tls_skip_verify":true,"priority":7}`,
+		},
+		{
+			name:       "404 not found",
+			req:        &UpdateOperatorRequest{Priority: &newPriority},
+			statusCode: http.StatusNotFound,
+			respBody:   `{"message":"operator not found"}`,
+			wantErr:    true,
+		},
+		{
+			name:       "409 conflict on rename collision",
+			req:        &UpdateOperatorRequest{Name: &newName},
+			statusCode: http.StatusConflict,
+			respBody:   `{"message":"operator with that name or url already exists"}`,
+			wantErr:    true,
+		},
+		{
+			name:       "400 bad request on validation failure",
+			req:        &UpdateOperatorRequest{URL: strPtr("not-a-url")},
+			statusCode: http.StatusBadRequest,
+			respBody:   `{"message":"url must be a valid HTTP(S) URL"}`,
+			wantErr:    true,
+		},
+	}
+
+	wantPath := "/vice/admin/operators/id/" + id.String()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, http.MethodPatch, r.Method)
+				assert.Equal(t, wantPath, r.URL.Path)
+				assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+
+				if tt.validate != nil {
+					raw, err := readAllAndRestore(r)
+					require.NoError(t, err)
+					var decoded UpdateOperatorRequest
+					require.NoError(t, json.Unmarshal(raw, &decoded))
+					tt.validate(t, raw, decoded)
+				}
+
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(tt.statusCode)
+				if tt.respBody != "" {
+					_, _ = w.Write([]byte(tt.respBody)) //nolint:errcheck // test server write
+				}
+			})
+
+			client := testClient(t, handler)
+			summary, err := client.UpdateOperator(context.Background(), id, tt.req)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Nil(t, summary)
+			} else {
+				require.NoError(t, err)
+				assert.NotNil(t, summary)
+			}
+		})
+	}
+}
+
+// strPtr returns a pointer to the given string. Used to build pointer-typed
+// fields concisely in test table entries.
+func strPtr(s string) *string { return &s }
+
+// readAllAndRestore drains r.Body so the test can both inspect the raw
+// JSON and decode it. The body is replaced with a fresh reader so any
+// subsequent reader sees the same bytes.
+func readAllAndRestore(r *http.Request) ([]byte, error) {
+	buf, err := io.ReadAll(r.Body)
+	if err != nil {
+		return nil, err
+	}
+	_ = r.Body.Close() //nolint:errcheck // test request body
+	r.Body = io.NopCloser(bytes.NewReader(buf))
+	return buf, nil
+}
+
+func TestDeleteOperator(t *testing.T) {
+	idA := uuid.MustParse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+	idMissing := uuid.MustParse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+	idFKBlocked := uuid.MustParse("cccccccc-cccc-cccc-cccc-cccccccccccc")
+
+	tests := []struct {
+		name       string
+		id         uuid.UUID
+		statusCode int
+		respBody   string
+		wantErr    bool
 	}{
 		{
 			name:       "success",
-			opName:     "cluster-a",
+			id:         idA,
 			statusCode: http.StatusOK,
-			wantPath:   "/vice/admin/operators/name/cluster-a",
 		},
 		{
+			// The DELETE endpoint stays idempotent at the API layer:
+			// deleting a non-existent UUID returns 200. The CLI prevents
+			// missing-name calls earlier (resolveOperatorID errors), but
+			// programmatic clients calling DeleteOperator directly with
+			// a stale id still see the silent-success behavior.
 			name:       "idempotent delete of missing operator",
-			opName:     "nonexistent",
+			id:         idMissing,
 			statusCode: http.StatusOK,
-			wantPath:   "/vice/admin/operators/name/nonexistent",
 		},
 		{
-			name:       "server error",
-			opName:     "cluster-b",
+			name:       "server error (FK constraint blocks delete)",
+			id:         idFKBlocked,
 			statusCode: http.StatusInternalServerError,
-			respBody:   `{"message":"FK constraint"}`,
+			respBody:   `{"message":"failed to delete operator"}`,
 			wantErr:    true,
-			wantPath:   "/vice/admin/operators/name/cluster-b",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			wantPath := "/vice/admin/operators/id/" + tt.id.String()
 			handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				assert.Equal(t, http.MethodDelete, r.Method)
-				assert.Equal(t, tt.wantPath, r.URL.Path)
+				assert.Equal(t, wantPath, r.URL.Path)
 
 				w.WriteHeader(tt.statusCode)
 				if tt.respBody != "" {
@@ -222,7 +389,7 @@ func TestDeleteOperator(t *testing.T) {
 			})
 
 			client := testClient(t, handler)
-			err := client.DeleteOperator(context.Background(), tt.opName)
+			err := client.DeleteOperator(context.Background(), tt.id)
 
 			if tt.wantErr {
 				assert.Error(t, err)

--- a/cmd/vice-operator-tool/main.go
+++ b/cmd/vice-operator-tool/main.go
@@ -175,7 +175,7 @@ func runUpdate(baseURLStr string, args []string) {
 	// flag.Visit reports only flags the user passed on the command line;
 	// untouched flags map to nil pointers so the server's COALESCE leaves
 	// those columns unchanged.
-	req := &UpdateOperatorRequest{}
+	req := &operatorclient.UpdateOperatorRequest{}
 	fs.Visit(func(f *flag.Flag) {
 		switch f.Name {
 		case "new-name":
@@ -211,8 +211,18 @@ func runUpdate(baseURLStr string, args []string) {
 		os.Exit(1)
 	}
 
-	fmt.Printf("Operator %q updated successfully (name=%s, url=%s, priority=%d, tls_skip_verify=%v)\n",
-		*name, summary.Name, summary.URL, summary.Priority, summary.TLSSkipVerify)
+	// summary.Name reads the *new* name through the embedded OperatorConfig,
+	// so when this is a rename the printed line shows the post-rename
+	// state. *name (from the flag) is the lookup key; we print both as
+	// "old → new" only when they differ to keep the steady-state path
+	// terse.
+	if *name != summary.Name {
+		fmt.Printf("Operator %q → %q updated successfully (id=%s, url=%s, priority=%d, tls_skip_verify=%v)\n",
+			*name, summary.Name, summary.ID, summary.URL, summary.Priority, summary.TLSSkipVerify)
+	} else {
+		fmt.Printf("Operator %q updated successfully (id=%s, url=%s, priority=%d, tls_skip_verify=%v)\n",
+			summary.Name, summary.ID, summary.URL, summary.Priority, summary.TLSSkipVerify)
+	}
 }
 
 func runDelete(baseURLStr string, args []string) {

--- a/cmd/vice-operator-tool/main.go
+++ b/cmd/vice-operator-tool/main.go
@@ -10,6 +10,7 @@ import (
 	"text/tabwriter"
 
 	"github.com/cyverse-de/app-exposer/operatorclient"
+	"github.com/google/uuid"
 )
 
 const usage = `Usage: vice-operator-tool [--app-exposer-url URL] <command> [flags]
@@ -17,6 +18,7 @@ const usage = `Usage: vice-operator-tool [--app-exposer-url URL] <command> [flag
 Commands:
   add      Add a new operator
   list     List configured operators
+  update   Update an existing operator (partial update by name)
   delete   Delete an operator by name
 
 Use "vice-operator-tool <command> -h" for help on a command.
@@ -47,6 +49,8 @@ func main() {
 		runAdd(*appExposerURL, subcmdArgs)
 	case "list":
 		runList(*appExposerURL, subcmdArgs)
+	case "update":
+		runUpdate(*appExposerURL, subcmdArgs)
 	case "delete":
 		runDelete(*appExposerURL, subcmdArgs)
 	default:
@@ -99,8 +103,25 @@ func runAdd(baseURLStr string, args []string) {
 		os.Exit(1)
 	}
 
-	fmt.Printf("Operator %q added successfully (url=%s, priority=%d, tls_skip_verify=%v)\n",
-		summary.Name, summary.URL, summary.Priority, summary.TLSSkipVerify)
+	fmt.Printf("Operator %q added successfully (id=%s, url=%s, priority=%d, tls_skip_verify=%v)\n",
+		summary.Name, summary.ID, summary.URL, summary.Priority, summary.TLSSkipVerify)
+}
+
+// resolveOperatorID looks up an operator by name and returns its UUID.
+// Used by the update and delete subcommands so admins identify operators
+// by their human-readable name while the API endpoints take stable ids.
+// Returns a clear "no operator named X" message if no match is found.
+func resolveOperatorID(client *OperatorClient, name string) (uuid.UUID, error) {
+	ops, err := client.ListOperators(context.Background())
+	if err != nil {
+		return uuid.Nil, fmt.Errorf("listing operators: %w", err)
+	}
+	for i := range ops {
+		if ops[i].Name == name {
+			return ops[i].ID, nil
+		}
+	}
+	return uuid.Nil, fmt.Errorf("no operator found with name %q", name)
 }
 
 func runList(baseURLStr string, args []string) {
@@ -123,13 +144,75 @@ func runList(baseURLStr string, args []string) {
 	}
 
 	w := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
-	fmt.Fprintln(w, "NAME\tURL\tPRIORITY\tTLS_SKIP_VERIFY") //nolint:errcheck
+	fmt.Fprintln(w, "ID\tNAME\tURL\tPRIORITY\tTLS_SKIP_VERIFY") //nolint:errcheck
 	for _, op := range ops {
-		fmt.Fprintf(w, "%s\t%s\t%d\t%v\n", op.Name, op.URL, op.Priority, op.TLSSkipVerify) //nolint:errcheck
+		fmt.Fprintf(w, "%s\t%s\t%s\t%d\t%v\n", op.ID, op.Name, op.URL, op.Priority, op.TLSSkipVerify) //nolint:errcheck
 	}
 	if err := w.Flush(); err != nil {
 		fmt.Fprintf(os.Stderr, "error: flushing tabwriter: %v\n", err)
 	}
+}
+
+func runUpdate(baseURLStr string, args []string) {
+	u := requireBaseURL(baseURLStr)
+
+	fs := flag.NewFlagSet("update", flag.ExitOnError)
+	name := fs.String("name", "", "Current operator name (required, used to look up the row)")
+	newName := fs.String("new-name", "", "New operator name (rename)")
+	opURL := fs.String("url", "", "New operator URL")
+	tlsSkip := fs.Bool("tls-skip-verify", false, "Set TLS skip-verify flag")
+	priority := fs.Int("priority", 0, "Set scheduling priority")
+	// ExitOnError means Parse calls os.Exit on failure; it never returns a non-nil error.
+	_ = fs.Parse(args) //nolint:errcheck // see comment above
+
+	if *name == "" {
+		fmt.Fprintln(os.Stderr, "error: --name is required")
+		fs.Usage()
+		os.Exit(1)
+	}
+
+	// Build the partial-update body from flags that were explicitly set.
+	// flag.Visit reports only flags the user passed on the command line;
+	// untouched flags map to nil pointers so the server's COALESCE leaves
+	// those columns unchanged.
+	req := &UpdateOperatorRequest{}
+	fs.Visit(func(f *flag.Flag) {
+		switch f.Name {
+		case "new-name":
+			req.Name = newName
+		case "url":
+			req.URL = opURL
+		case "tls-skip-verify":
+			req.TLSSkipVerify = tlsSkip
+		case "priority":
+			req.Priority = priority
+		}
+	})
+
+	if req.Name == nil && req.URL == nil && req.TLSSkipVerify == nil && req.Priority == nil {
+		fmt.Fprintln(os.Stderr, "error: at least one of --new-name, --url, --tls-skip-verify, --priority must be set")
+		os.Exit(1)
+	}
+
+	client := NewOperatorClient(u, http.DefaultClient)
+
+	// Resolve --name to an id. The PATCH endpoint identifies the row by
+	// UUID so that a concurrent rename can't redirect the update to a
+	// different row.
+	id, err := resolveOperatorID(client, *name)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+
+	summary, err := client.UpdateOperator(context.Background(), id, req)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("Operator %q updated successfully (name=%s, url=%s, priority=%d, tls_skip_verify=%v)\n",
+		*name, summary.Name, summary.URL, summary.Priority, summary.TLSSkipVerify)
 }
 
 func runDelete(baseURLStr string, args []string) {
@@ -146,10 +229,21 @@ func runDelete(baseURLStr string, args []string) {
 	name := fs.Arg(0)
 
 	client := NewOperatorClient(u, http.DefaultClient)
-	if err := client.DeleteOperator(context.Background(), name); err != nil {
+
+	// The DELETE endpoint takes a UUID; resolve the human-readable name
+	// to an id via the listing. This is one extra round-trip versus a
+	// name-keyed delete, but it keeps all admin endpoints id-keyed which
+	// is safer in the presence of concurrent renames.
+	id, err := resolveOperatorID(client, name)
+	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(1)
 	}
 
-	fmt.Printf("Operator %q deleted.\n", name)
+	if err := client.DeleteOperator(context.Background(), id); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("Operator %q (id=%s) deleted.\n", name, id)
 }

--- a/db/operators.go
+++ b/db/operators.go
@@ -52,6 +52,21 @@ func (o *Operator) ToOperatorConfig() operatorclient.OperatorConfig {
 	}
 }
 
+// ToOperatorAdminSummary projects the DB's full Operator row down to the
+// admin-facing summary shape (id plus the four public config fields). Used
+// by handlers that return a single row's identity to admin clients —
+// notably create, where the caller needs the new row's id without an
+// extra list call.
+func (o *Operator) ToOperatorAdminSummary() operatorclient.OperatorAdminSummary {
+	return operatorclient.OperatorAdminSummary{
+		ID:            o.ID,
+		Name:          o.Name,
+		URL:           o.URL,
+		TLSSkipVerify: o.TLSSkipVerify,
+		Priority:      o.Priority,
+	}
+}
+
 // ListOperators returns all operators from the database, ordered by priority
 // (lower values first) with creation time as tiebreaker.
 func (d *Database) ListOperators(ctx context.Context) ([]Operator, error) {
@@ -66,17 +81,15 @@ func (d *Database) ListOperators(ctx context.Context) ([]Operator, error) {
 	return ops, err
 }
 
-// ListOperatorSummaries returns the public (non-sensitive) fields of every
-// operator, ordered by priority (lower values first) with creation time as
-// tiebreaker. The returned type is operatorclient.OperatorConfig rather
-// than a db-local struct because that type already carries the same four
-// fields and serves as the canonical public shape; having a second struct
-// here would invite drift. sqlx can scan directly into OperatorConfig via
-// its db struct tags.
-func (d *Database) ListOperatorSummaries(ctx context.Context) ([]operatorclient.OperatorConfig, error) {
-	ops := make([]operatorclient.OperatorConfig, 0)
+// ListOperatorAdminSummaries returns the admin-listing fields of every
+// operator (id plus the four public config fields), ordered by priority
+// (lower values first) with creation time as tiebreaker. Including id lets
+// admin clients address an operator by its stable UUID rather than by name,
+// which is important for PATCH where the operator may be renamed.
+func (d *Database) ListOperatorAdminSummaries(ctx context.Context) ([]operatorclient.OperatorAdminSummary, error) {
+	ops := make([]operatorclient.OperatorAdminSummary, 0)
 	const query = `
-		SELECT name, url, tls_skip_verify, priority
+		SELECT id, name, url, tls_skip_verify, priority
 		FROM operators
 		ORDER BY priority ASC, created_at ASC
 	`
@@ -101,14 +114,59 @@ func (d *Database) InsertOperator(ctx context.Context, op *Operator) (*Operator,
 	return &created, nil
 }
 
-// DeleteOperatorByName deletes the operator with the given name. It is
+// DeleteOperatorByID deletes the operator with the given UUID. It is
 // idempotent for operators with no associated jobs: deleting a non-existent
-// operator succeeds silently. Deleting an operator that still has jobs
-// referencing it will fail due to a foreign key constraint.
-func (d *Database) DeleteOperatorByName(ctx context.Context, name string) error {
-	const query = `DELETE FROM operators WHERE name = $1`
-	_, err := d.db.ExecContext(ctx, query, name)
+// operator succeeds silently because DELETE simply affects zero rows.
+// Deleting an operator that still has jobs referencing it will fail due to
+// the jobs.operator_id FK with ON DELETE RESTRICT.
+func (d *Database) DeleteOperatorByID(ctx context.Context, id uuid.UUID) error {
+	const query = `DELETE FROM operators WHERE id = $1`
+	_, err := d.db.ExecContext(ctx, query, id)
 	return err
+}
+
+// OperatorUpdate carries the optional fields for a partial-update of an
+// operator row. A nil pointer leaves the column unchanged. Only fields that
+// the AFTER UPDATE NOTIFY trigger covers (name, url, tls_skip_verify,
+// priority) are exposed here; reconciliation columns are intentionally
+// reconciler-only.
+type OperatorUpdate struct {
+	Name          *string
+	URL           *string
+	TLSSkipVerify *bool
+	Priority      *int
+}
+
+// UpdateOperatorByID applies a partial update to the operator row identified
+// by id and returns the resulting row. Unset (nil) fields in upd are left
+// unchanged via COALESCE on typed-NULL parameters. updated_at is maintained
+// by a BEFORE UPDATE trigger on the table, so the SQL does not set it.
+//
+// Returns sql.ErrNoRows if no operator with the given id exists. Returns
+// the underlying *pq.Error (with Code 23505) on UNIQUE collisions for name
+// or url so the handler layer can map it to 409 Conflict.
+//
+// The AFTER UPDATE OF (name, url, tls_skip_verify, priority) trigger on
+// the operators table fires NOTIFY operator_changed automatically, which
+// the reconciler's pq.Listener picks up to drive an immediate scheduler
+// resync — no explicit pg_notify call is required here.
+func (d *Database) UpdateOperatorByID(ctx context.Context, id uuid.UUID, upd OperatorUpdate) (*Operator, error) {
+	const query = `
+		UPDATE operators
+		SET name            = COALESCE($2, name),
+		    url             = COALESCE($3, url),
+		    tls_skip_verify = COALESCE($4, tls_skip_verify),
+		    priority        = COALESCE($5, priority)
+		WHERE id = $1
+		RETURNING id, name, url, tls_skip_verify, priority,
+		          last_reconciled_at, reconciled_by, created_at, updated_at
+	`
+	var updated Operator
+	err := d.db.QueryRowxContext(ctx, query, id, upd.Name, upd.URL, upd.TLSSkipVerify, upd.Priority).StructScan(&updated)
+	if err != nil {
+		return nil, err
+	}
+	return &updated, nil
 }
 
 // ClaimAndReconcile atomically claims an operator that hasn't been reconciled

--- a/db/operators.go
+++ b/db/operators.go
@@ -53,17 +53,15 @@ func (o *Operator) ToOperatorConfig() operatorclient.OperatorConfig {
 }
 
 // ToOperatorAdminSummary projects the DB's full Operator row down to the
-// admin-facing summary shape (id plus the four public config fields). Used
-// by handlers that return a single row's identity to admin clients —
-// notably create, where the caller needs the new row's id without an
-// extra list call.
+// admin-facing summary shape (id plus the four public config fields).
+// Reuses ToOperatorConfig for the embedded config so the projection stays
+// in lock-step if OperatorConfig gains a new field. Used by handlers that
+// return a single row's identity to admin clients — notably create and
+// update, where the caller needs the row's id without an extra list call.
 func (o *Operator) ToOperatorAdminSummary() operatorclient.OperatorAdminSummary {
 	return operatorclient.OperatorAdminSummary{
-		ID:            o.ID,
-		Name:          o.Name,
-		URL:           o.URL,
-		TLSSkipVerify: o.TLSSkipVerify,
-		Priority:      o.Priority,
+		ID:             o.ID,
+		OperatorConfig: o.ToOperatorConfig(),
 	}
 }
 

--- a/db/operators_test.go
+++ b/db/operators_test.go
@@ -1,0 +1,188 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/google/uuid"
+	"github.com/jmoiron/sqlx"
+	"github.com/lib/pq"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestDB returns a *Database backed by sqlmock so query-shape and
+// argument-binding can be asserted without a live PostgreSQL instance.
+// QueryMatcherEqual is used (after whitespace normalization) so SQL drift
+// fails the test rather than being papered over by a regex matcher.
+func newTestDB(t *testing.T) (*Database, sqlmock.Sqlmock) {
+	t.Helper()
+	rawDB, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = rawDB.Close() })
+	sqlxDB := sqlx.NewDb(rawDB, "postgres")
+	return New(sqlxDB, ""), mock
+}
+
+// whitespaceRE collapses runs of whitespace so multi-line SQL literals
+// match the production query's own multi-line layout.
+var whitespaceRE = regexp.MustCompile(`\s+`)
+
+func normalizeSQL(s string) string {
+	return whitespaceRE.ReplaceAllString(s, " ")
+}
+
+func TestDeleteOperatorByID(t *testing.T) {
+	id := uuid.MustParse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+	const expectedSQL = `DELETE FROM operators WHERE id = $1`
+
+	tests := []struct {
+		name        string
+		execErr     error
+		rowsCount   int64
+		wantErrText string
+	}{
+		{
+			name:      "deletes existing row",
+			rowsCount: 1,
+		},
+		{
+			// DELETE is idempotent: a missing UUID returns no error and
+			// zero rows affected. Callers should not treat this as a 404.
+			name:      "missing id is silent (zero rows)",
+			rowsCount: 0,
+		},
+		{
+			name:        "FK violation surfaces from driver",
+			execErr:     &pq.Error{Code: "23503", Message: "violates foreign key constraint"},
+			wantErrText: "violates foreign key constraint",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d, mock := newTestDB(t)
+			expect := mock.ExpectExec(expectedSQL).WithArgs(id.String())
+			if tt.execErr != nil {
+				expect.WillReturnError(tt.execErr)
+			} else {
+				expect.WillReturnResult(sqlmock.NewResult(0, tt.rowsCount))
+			}
+
+			err := d.DeleteOperatorByID(context.Background(), id)
+
+			if tt.wantErrText != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErrText)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.NoError(t, mock.ExpectationsWereMet())
+		})
+	}
+}
+
+func TestUpdateOperatorByID(t *testing.T) {
+	id := uuid.MustParse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+	now := time.Now()
+
+	const expectedSQL = `UPDATE operators SET name = COALESCE($2, name), url = COALESCE($3, url), tls_skip_verify = COALESCE($4, tls_skip_verify), priority = COALESCE($5, priority) WHERE id = $1 RETURNING id, name, url, tls_skip_verify, priority, last_reconciled_at, reconciled_by, created_at, updated_at`
+
+	// returnedColumns matches the RETURNING list so StructScan can populate
+	// the *Operator struct on the success path.
+	returnedColumns := []string{
+		"id", "name", "url", "tls_skip_verify", "priority",
+		"last_reconciled_at", "reconciled_by", "created_at", "updated_at",
+	}
+
+	strPtr := func(s string) *string { return &s }
+	boolPtr := func(b bool) *bool { return &b }
+	intPtr := func(i int) *int { return &i }
+
+	tests := []struct {
+		name string
+		upd  OperatorUpdate
+		// wantArgs is the argument slice in the order the production query
+		// binds them: [id, name, url, tls_skip_verify, priority]. Any
+		// driver.Value here is matched literally; nil represents SQL NULL.
+		wantArgs []driver.Value
+		// dbErr is what sqlmock returns; nil means "succeed and return a row".
+		dbErr error
+	}{
+		{
+			name:     "single field — priority only",
+			upd:      OperatorUpdate{Priority: intPtr(7)},
+			wantArgs: []driver.Value{id.String(), nil, nil, nil, int64(7)},
+		},
+		{
+			name:     "rename only",
+			upd:      OperatorUpdate{Name: strPtr("renamed")},
+			wantArgs: []driver.Value{id.String(), "renamed", nil, nil, nil},
+		},
+		{
+			name: "all four fields",
+			upd: OperatorUpdate{
+				Name:          strPtr("a"),
+				URL:           strPtr("https://a.example.com"),
+				TLSSkipVerify: boolPtr(true),
+				Priority:      intPtr(2),
+			},
+			wantArgs: []driver.Value{id.String(), "a", "https://a.example.com", true, int64(2)},
+		},
+		{
+			name:     "no row matches — surfaces sql.ErrNoRows from RETURNING",
+			upd:      OperatorUpdate{Priority: intPtr(1)},
+			wantArgs: []driver.Value{id.String(), nil, nil, nil, int64(1)},
+			dbErr:    sql.ErrNoRows,
+		},
+		{
+			name:     "unique violation — surfaces *pq.Error 23505",
+			upd:      OperatorUpdate{Name: strPtr("dup")},
+			wantArgs: []driver.Value{id.String(), "dup", nil, nil, nil},
+			dbErr:    &pq.Error{Code: "23505", Message: "duplicate key value violates unique constraint"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d, mock := newTestDB(t)
+
+			expect := mock.ExpectQuery(normalizeSQL(expectedSQL)).
+				WithArgs(tt.wantArgs...)
+
+			if tt.dbErr != nil {
+				expect.WillReturnError(tt.dbErr)
+			} else {
+				rows := sqlmock.NewRows(returnedColumns).
+					AddRow(id, "n", "https://u", false, 0, sql.NullTime{}, sql.NullString{}, now, now)
+				expect.WillReturnRows(rows)
+			}
+
+			got, err := d.UpdateOperatorByID(context.Background(), id, tt.upd)
+
+			switch {
+			case errors.Is(tt.dbErr, sql.ErrNoRows):
+				assert.ErrorIs(t, err, sql.ErrNoRows)
+				assert.Nil(t, got)
+			case tt.dbErr != nil:
+				require.Error(t, err)
+				var pqErr *pq.Error
+				assert.True(t, errors.As(err, &pqErr), "error should be a *pq.Error")
+				assert.Equal(t, pq.ErrorCode("23505"), pqErr.Code)
+				assert.Nil(t, got)
+			default:
+				require.NoError(t, err)
+				require.NotNil(t, got)
+				assert.Equal(t, id, got.ID)
+			}
+
+			assert.NoError(t, mock.ExpectationsWereMet())
+		})
+	}
+}

--- a/db/operators_test.go
+++ b/db/operators_test.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"errors"
-	"regexp"
 	"testing"
 	"time"
 
@@ -19,8 +18,10 @@ import (
 
 // newTestDB returns a *Database backed by sqlmock so query-shape and
 // argument-binding can be asserted without a live PostgreSQL instance.
-// QueryMatcherEqual is used (after whitespace normalization) so SQL drift
-// fails the test rather than being papered over by a regex matcher.
+// QueryMatcherEqual normalizes whitespace on both expected and actual
+// statements internally, so multi-line SQL constants match without manual
+// pre-processing — and a regex match that could mask unintended SQL
+// drift is avoided.
 func newTestDB(t *testing.T) (*Database, sqlmock.Sqlmock) {
 	t.Helper()
 	rawDB, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
@@ -28,14 +29,6 @@ func newTestDB(t *testing.T) (*Database, sqlmock.Sqlmock) {
 	t.Cleanup(func() { _ = rawDB.Close() })
 	sqlxDB := sqlx.NewDb(rawDB, "postgres")
 	return New(sqlxDB, ""), mock
-}
-
-// whitespaceRE collapses runs of whitespace so multi-line SQL literals
-// match the production query's own multi-line layout.
-var whitespaceRE = regexp.MustCompile(`\s+`)
-
-func normalizeSQL(s string) string {
-	return whitespaceRE.ReplaceAllString(s, " ")
 }
 
 func TestDeleteOperatorByID(t *testing.T) {
@@ -153,7 +146,7 @@ func TestUpdateOperatorByID(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			d, mock := newTestDB(t)
 
-			expect := mock.ExpectQuery(normalizeSQL(expectedSQL)).
+			expect := mock.ExpectQuery(expectedSQL).
 				WithArgs(tt.wantArgs...)
 
 			if tt.dbErr != nil {

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -645,7 +645,7 @@ const docTemplate = `{
                 }
             },
             "patch": {
-                "description": "Partial update of an operator identified by UUID. Only fields supplied in the body are changed.",
+                "description": "Partial update of an operator identified by UUID. Only fields supplied in the body are changed. The response carries the row's id alongside the updated fields, mirroring the create endpoint.",
                 "consumes": [
                     "application/json"
                 ],
@@ -668,7 +668,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/httphandlers.UpdateOperatorRequest"
+                            "$ref": "#/definitions/operatorclient.UpdateOperatorRequest"
                         }
                     }
                 ],
@@ -676,7 +676,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/operatorclient.OperatorConfig"
+                            "$ref": "#/definitions/operatorclient.OperatorAdminSummary"
                         }
                     },
                     "400": {
@@ -2047,23 +2047,6 @@ const docTemplate = `{
                 }
             }
         },
-        "httphandlers.UpdateOperatorRequest": {
-            "type": "object",
-            "properties": {
-                "name": {
-                    "type": "string"
-                },
-                "priority": {
-                    "type": "integer"
-                },
-                "tls_skip_verify": {
-                    "type": "boolean"
-                },
-                "url": {
-                    "type": "string"
-                }
-            }
-        },
         "httphandlers.uuidBody": {
             "type": "object",
             "properties": {
@@ -3036,6 +3019,23 @@ const docTemplate = `{
                 },
                 "ready": {
                     "type": "boolean"
+                }
+            }
+        },
+        "operatorclient.UpdateOperatorRequest": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "priority": {
+                    "type": "integer"
+                },
+                "tls_skip_verify": {
+                    "type": "boolean"
+                },
+                "url": {
+                    "type": "string"
                 }
             }
         },

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -512,7 +512,7 @@ const docTemplate = `{
         },
         "/vice/admin/operators": {
             "get": {
-                "description": "Returns the name, URL, and tls_skip_verify flag for all operators in the database.",
+                "description": "Returns id, name, URL, tls_skip_verify, and priority for all operators in the database.",
                 "produces": [
                     "application/json"
                 ],
@@ -524,7 +524,7 @@ const docTemplate = `{
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/operatorclient.OperatorConfig"
+                                "$ref": "#/definitions/operatorclient.OperatorAdminSummary"
                             }
                         }
                     },
@@ -537,7 +537,7 @@ const docTemplate = `{
                 }
             },
             "post": {
-                "description": "Adds a new operator to the database.",
+                "description": "Adds a new operator to the database. Returns the new row including its server-assigned UUID.",
                 "consumes": [
                     "application/json"
                 ],
@@ -561,11 +561,17 @@ const docTemplate = `{
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/operatorclient.OperatorConfig"
+                            "$ref": "#/definitions/operatorclient.OperatorAdminSummary"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/common.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
                         "schema": {
                             "$ref": "#/definitions/common.ErrorResponse"
                         }
@@ -606,16 +612,16 @@ const docTemplate = `{
                 }
             }
         },
-        "/vice/admin/operators/name/{name}": {
+        "/vice/admin/operators/id/{id}": {
             "delete": {
-                "description": "Removes the named operator from the database. Succeeds silently if the operator does not exist. Fails if jobs still reference the operator.",
-                "summary": "Deletes an operator by name",
+                "description": "Removes the operator with the given UUID. Succeeds silently if the operator does not exist. Fails if jobs still reference the operator.",
+                "summary": "Deletes an operator by id",
                 "operationId": "admin-delete-operator",
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "Operator name",
-                        "name": "name",
+                        "description": "Operator UUID",
+                        "name": "id",
                         "in": "path",
                         "required": true
                     }
@@ -626,6 +632,67 @@ const docTemplate = `{
                     },
                     "400": {
                         "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/common.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/common.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "patch": {
+                "description": "Partial update of an operator identified by UUID. Only fields supplied in the body are changed.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "summary": "Updates an operator",
+                "operationId": "admin-update-operator",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Operator UUID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Fields to update",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/httphandlers.UpdateOperatorRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/operatorclient.OperatorConfig"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/common.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/common.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
                         "schema": {
                             "$ref": "#/definitions/common.ErrorResponse"
                         }
@@ -1980,6 +2047,23 @@ const docTemplate = `{
                 }
             }
         },
+        "httphandlers.UpdateOperatorRequest": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "priority": {
+                    "type": "integer"
+                },
+                "tls_skip_verify": {
+                    "type": "boolean"
+                },
+                "url": {
+                    "type": "string"
+                }
+            }
+        },
         "httphandlers.uuidBody": {
             "type": "object",
             "properties": {
@@ -2904,6 +2988,26 @@ const docTemplate = `{
                 "usedMemory": {
                     "description": "bytes",
                     "type": "integer"
+                }
+            }
+        },
+        "operatorclient.OperatorAdminSummary": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "priority": {
+                    "type": "integer"
+                },
+                "tls_skip_verify": {
+                    "type": "boolean"
+                },
+                "url": {
+                    "type": "string"
                 }
             }
         },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -639,7 +639,7 @@
                 }
             },
             "patch": {
-                "description": "Partial update of an operator identified by UUID. Only fields supplied in the body are changed.",
+                "description": "Partial update of an operator identified by UUID. Only fields supplied in the body are changed. The response carries the row's id alongside the updated fields, mirroring the create endpoint.",
                 "consumes": [
                     "application/json"
                 ],
@@ -662,7 +662,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/httphandlers.UpdateOperatorRequest"
+                            "$ref": "#/definitions/operatorclient.UpdateOperatorRequest"
                         }
                     }
                 ],
@@ -670,7 +670,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/operatorclient.OperatorConfig"
+                            "$ref": "#/definitions/operatorclient.OperatorAdminSummary"
                         }
                     },
                     "400": {
@@ -2041,23 +2041,6 @@
                 }
             }
         },
-        "httphandlers.UpdateOperatorRequest": {
-            "type": "object",
-            "properties": {
-                "name": {
-                    "type": "string"
-                },
-                "priority": {
-                    "type": "integer"
-                },
-                "tls_skip_verify": {
-                    "type": "boolean"
-                },
-                "url": {
-                    "type": "string"
-                }
-            }
-        },
         "httphandlers.uuidBody": {
             "type": "object",
             "properties": {
@@ -3030,6 +3013,23 @@
                 },
                 "ready": {
                     "type": "boolean"
+                }
+            }
+        },
+        "operatorclient.UpdateOperatorRequest": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "priority": {
+                    "type": "integer"
+                },
+                "tls_skip_verify": {
+                    "type": "boolean"
+                },
+                "url": {
+                    "type": "string"
                 }
             }
         },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -506,7 +506,7 @@
         },
         "/vice/admin/operators": {
             "get": {
-                "description": "Returns the name, URL, and tls_skip_verify flag for all operators in the database.",
+                "description": "Returns id, name, URL, tls_skip_verify, and priority for all operators in the database.",
                 "produces": [
                     "application/json"
                 ],
@@ -518,7 +518,7 @@
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/operatorclient.OperatorConfig"
+                                "$ref": "#/definitions/operatorclient.OperatorAdminSummary"
                             }
                         }
                     },
@@ -531,7 +531,7 @@
                 }
             },
             "post": {
-                "description": "Adds a new operator to the database.",
+                "description": "Adds a new operator to the database. Returns the new row including its server-assigned UUID.",
                 "consumes": [
                     "application/json"
                 ],
@@ -555,11 +555,17 @@
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "$ref": "#/definitions/operatorclient.OperatorConfig"
+                            "$ref": "#/definitions/operatorclient.OperatorAdminSummary"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/common.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
                         "schema": {
                             "$ref": "#/definitions/common.ErrorResponse"
                         }
@@ -600,16 +606,16 @@
                 }
             }
         },
-        "/vice/admin/operators/name/{name}": {
+        "/vice/admin/operators/id/{id}": {
             "delete": {
-                "description": "Removes the named operator from the database. Succeeds silently if the operator does not exist. Fails if jobs still reference the operator.",
-                "summary": "Deletes an operator by name",
+                "description": "Removes the operator with the given UUID. Succeeds silently if the operator does not exist. Fails if jobs still reference the operator.",
+                "summary": "Deletes an operator by id",
                 "operationId": "admin-delete-operator",
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "Operator name",
-                        "name": "name",
+                        "description": "Operator UUID",
+                        "name": "id",
                         "in": "path",
                         "required": true
                     }
@@ -620,6 +626,67 @@
                     },
                     "400": {
                         "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/common.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/common.ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "patch": {
+                "description": "Partial update of an operator identified by UUID. Only fields supplied in the body are changed.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "summary": "Updates an operator",
+                "operationId": "admin-update-operator",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Operator UUID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Fields to update",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/httphandlers.UpdateOperatorRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/operatorclient.OperatorConfig"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/common.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/common.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
                         "schema": {
                             "$ref": "#/definitions/common.ErrorResponse"
                         }
@@ -1974,6 +2041,23 @@
                 }
             }
         },
+        "httphandlers.UpdateOperatorRequest": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "priority": {
+                    "type": "integer"
+                },
+                "tls_skip_verify": {
+                    "type": "boolean"
+                },
+                "url": {
+                    "type": "string"
+                }
+            }
+        },
         "httphandlers.uuidBody": {
             "type": "object",
             "properties": {
@@ -2898,6 +2982,26 @@
                 "usedMemory": {
                     "description": "bytes",
                     "type": "integer"
+                }
+            }
+        },
+        "operatorclient.OperatorAdminSummary": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "priority": {
+                    "type": "integer"
+                },
+                "tls_skip_verify": {
+                    "type": "boolean"
+                },
+                "url": {
+                    "type": "string"
                 }
             }
         },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -239,6 +239,17 @@ definitions:
           type: string
         type: array
     type: object
+  httphandlers.UpdateOperatorRequest:
+    properties:
+      name:
+        type: string
+      priority:
+        type: integer
+      tls_skip_verify:
+        type: boolean
+      url:
+        type: string
+    type: object
   httphandlers.uuidBody:
     properties:
       uuid:
@@ -917,6 +928,19 @@ definitions:
       usedMemory:
         description: bytes
         type: integer
+    type: object
+  operatorclient.OperatorAdminSummary:
+    properties:
+      id:
+        type: string
+      name:
+        type: string
+      priority:
+        type: integer
+      tls_skip_verify:
+        type: boolean
+      url:
+        type: string
     type: object
   operatorclient.OperatorConfig:
     properties:
@@ -12116,7 +12140,7 @@ paths:
       summary: Lists running analyses across all operators
   /vice/admin/operators:
     get:
-      description: Returns the name, URL, and tls_skip_verify flag for all operators
+      description: Returns id, name, URL, tls_skip_verify, and priority for all operators
         in the database.
       operationId: admin-list-operators
       produces:
@@ -12126,7 +12150,7 @@ paths:
           description: OK
           schema:
             items:
-              $ref: '#/definitions/operatorclient.OperatorConfig'
+              $ref: '#/definitions/operatorclient.OperatorAdminSummary'
             type: array
         "500":
           description: Internal Server Error
@@ -12136,7 +12160,8 @@ paths:
     post:
       consumes:
       - application/json
-      description: Adds a new operator to the database.
+      description: Adds a new operator to the database. Returns the new row including
+        its server-assigned UUID.
       operationId: admin-create-operator
       parameters:
       - description: Operator to create
@@ -12151,9 +12176,13 @@ paths:
         "201":
           description: Created
           schema:
-            $ref: '#/definitions/operatorclient.OperatorConfig'
+            $ref: '#/definitions/operatorclient.OperatorAdminSummary'
         "400":
           description: Bad Request
+          schema:
+            $ref: '#/definitions/common.ErrorResponse'
+        "409":
+          description: Conflict
           schema:
             $ref: '#/definitions/common.ErrorResponse'
         "500":
@@ -12180,15 +12209,15 @@ paths:
           schema:
             $ref: '#/definitions/common.ErrorResponse'
       summary: Returns operator capacities
-  /vice/admin/operators/name/{name}:
+  /vice/admin/operators/id/{id}:
     delete:
-      description: Removes the named operator from the database. Succeeds silently
-        if the operator does not exist. Fails if jobs still reference the operator.
+      description: Removes the operator with the given UUID. Succeeds silently if
+        the operator does not exist. Fails if jobs still reference the operator.
       operationId: admin-delete-operator
       parameters:
-      - description: Operator name
+      - description: Operator UUID
         in: path
-        name: name
+        name: id
         required: true
         type: string
       responses:
@@ -12202,7 +12231,49 @@ paths:
           description: Internal Server Error
           schema:
             $ref: '#/definitions/common.ErrorResponse'
-      summary: Deletes an operator by name
+      summary: Deletes an operator by id
+    patch:
+      consumes:
+      - application/json
+      description: Partial update of an operator identified by UUID. Only fields supplied
+        in the body are changed.
+      operationId: admin-update-operator
+      parameters:
+      - description: Operator UUID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Fields to update
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/httphandlers.UpdateOperatorRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/operatorclient.OperatorConfig'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/common.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/common.ErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/common.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/common.ErrorResponse'
+      summary: Updates an operator
   /vice/admin/terminate-all:
     post:
       description: |-

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -239,17 +239,6 @@ definitions:
           type: string
         type: array
     type: object
-  httphandlers.UpdateOperatorRequest:
-    properties:
-      name:
-        type: string
-      priority:
-        type: integer
-      tls_skip_verify:
-        type: boolean
-      url:
-        type: string
-    type: object
   httphandlers.uuidBody:
     properties:
       uuid:
@@ -959,6 +948,17 @@ definitions:
         type: string
       ready:
         type: boolean
+    type: object
+  operatorclient.UpdateOperatorRequest:
+    properties:
+      name:
+        type: string
+      priority:
+        type: integer
+      tls_skip_verify:
+        type: boolean
+      url:
+        type: string
     type: object
   operatorclient.UpdatePermissionsRequest:
     properties:
@@ -12236,7 +12236,8 @@ paths:
       consumes:
       - application/json
       description: Partial update of an operator identified by UUID. Only fields supplied
-        in the body are changed.
+        in the body are changed. The response carries the row's id alongside the updated
+        fields, mirroring the create endpoint.
       operationId: admin-update-operator
       parameters:
       - description: Operator UUID
@@ -12249,14 +12250,14 @@ paths:
         name: body
         required: true
         schema:
-          $ref: '#/definitions/httphandlers.UpdateOperatorRequest'
+          $ref: '#/definitions/operatorclient.UpdateOperatorRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/operatorclient.OperatorConfig'
+            $ref: '#/definitions/operatorclient.OperatorAdminSummary'
         "400":
           description: Bad Request
           schema:

--- a/httphandlers/handlers.go
+++ b/httphandlers/handlers.go
@@ -611,19 +611,6 @@ func (h *HTTPHandlers) CreateOperatorHandler(c echo.Context) error {
 	return c.JSON(http.StatusCreated, created.ToOperatorAdminSummary())
 }
 
-// UpdateOperatorRequest is the body for PATCH /vice/admin/operators/id/:id.
-// All fields are optional; only the fields whose pointers are non-nil are
-// applied. Pointer types let us distinguish "client omitted this field"
-// from "client wants to set it to the zero value" (a value-typed shape
-// would silently force priority=0 / tls_skip_verify=false on every PATCH
-// that omitted them).
-type UpdateOperatorRequest struct {
-	Name          *string `json:"name,omitempty"`
-	URL           *string `json:"url,omitempty"`
-	TLSSkipVerify *bool   `json:"tls_skip_verify,omitempty"`
-	Priority      *int    `json:"priority,omitempty"`
-}
-
 // UpdateOperatorHandler applies a partial update to the operator with the
 // given UUID. The path identifies the row by id rather than name so that
 // renames don't break the path semantics: PATCH targets the same row even
@@ -631,12 +618,12 @@ type UpdateOperatorRequest struct {
 //
 //	@ID				admin-update-operator
 //	@Summary		Updates an operator
-//	@Description	Partial update of an operator identified by UUID. Only fields supplied in the body are changed.
+//	@Description	Partial update of an operator identified by UUID. Only fields supplied in the body are changed. The response carries the row's id alongside the updated fields, mirroring the create endpoint.
 //	@Accept			json
 //	@Produce		json
-//	@Param			id		path		string					true	"Operator UUID"
-//	@Param			body	body		UpdateOperatorRequest	true	"Fields to update"
-//	@Success		200		{object}	operatorclient.OperatorConfig
+//	@Param			id		path		string									true	"Operator UUID"
+//	@Param			body	body		operatorclient.UpdateOperatorRequest	true	"Fields to update"
+//	@Success		200		{object}	operatorclient.OperatorAdminSummary
 //	@Failure		400		{object}	common.ErrorResponse
 //	@Failure		404		{object}	common.ErrorResponse
 //	@Failure		409		{object}	common.ErrorResponse
@@ -651,7 +638,7 @@ func (h *HTTPHandlers) UpdateOperatorHandler(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, "id must be a valid UUID")
 	}
 
-	var req UpdateOperatorRequest
+	var req operatorclient.UpdateOperatorRequest
 	if err := c.Bind(&req); err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
@@ -677,7 +664,7 @@ func (h *HTTPHandlers) UpdateOperatorHandler(c echo.Context) error {
 		return operatorWriteError("update", idStr, err)
 	}
 
-	return c.JSON(http.StatusOK, updated.ToOperatorConfig())
+	return c.JSON(http.StatusOK, updated.ToOperatorAdminSummary())
 }
 
 // DeleteOperatorHandler deletes an operator by UUID. The operation is

--- a/httphandlers/handlers.go
+++ b/httphandlers/handlers.go
@@ -19,7 +19,9 @@ import (
 	"github.com/cyverse-de/app-exposer/operatorclient"
 	"github.com/cyverse-de/app-exposer/reporting"
 	"github.com/cyverse-de/model/v10"
+	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
+	"github.com/lib/pq"
 	"k8s.io/client-go/kubernetes"
 )
 
@@ -81,9 +83,9 @@ func (h *HTTPHandlers) GetScheduler() *operatorclient.Scheduler {
 
 // operatorClientForAnalysis looks up which operator is running an analysis
 // and returns the corresponding client. Uses a three-step strategy:
-//  1. Fast path: check the DB for a recorded operator name.
-//  2. Search path: if no name is recorded or the named operator isn't found,
-//     search all operators in parallel via HasAnalysis.
+//  1. Fast path: check the DB for a recorded operator id.
+//  2. Search path: if no id is recorded or the operator with that id isn't
+//     in the scheduler, search all operators in parallel via HasAnalysis.
 //  3. Return (nil, nil) only when no operator has the analysis.
 //
 // A non-nil error indicates the lookup could not be completed (e.g. a
@@ -92,25 +94,25 @@ func (h *HTTPHandlers) GetScheduler() *operatorclient.Scheduler {
 // treat nil-client-with-nil-error as "not found". Callers answering an
 // "exists?" question may use nil-with-nil-error as "no".
 func (h *HTTPHandlers) operatorClientForAnalysis(ctx context.Context, analysisID constants.AnalysisID) (*operatorclient.Client, error) {
-	// Fast path: check the DB for a recorded operator name. GetOperatorName
-	// normalizes sql.ErrNoRows to ("", nil); a non-nil error here signals a
-	// real DB fault, which we must surface instead of silently falling through
-	// to fan-out search. Under burst traffic (e.g. workshop launches), a brief
-	// DB blip otherwise amplifies into an operator fan-out storm.
-	operatorName, err := h.apps.GetOperatorName(ctx, analysisID)
+	// Fast path: check the DB for a recorded operator id. GetOperatorID
+	// normalizes sql.ErrNoRows to (uuid.Nil, nil); a non-nil error here
+	// signals a real DB fault, which we must surface instead of silently
+	// falling through to fan-out search. Under burst traffic (e.g. workshop
+	// launches), a brief DB blip otherwise amplifies into a fan-out storm.
+	operatorID, err := h.apps.GetOperatorID(ctx, analysisID)
 	if err != nil {
 		return nil, fmt.Errorf("looking up operator for analysis %s: %w", analysisID, err)
 	}
 
-	if operatorName != "" {
-		client := h.scheduler.ClientByName(operatorName)
+	if operatorID != uuid.Nil {
+		client := h.scheduler.ClientByID(operatorID)
 		if client != nil {
-			log.Debugf("analysis %s routed to operator %q (fast path)", analysisID, operatorName)
+			log.Debugf("analysis %s routed to operator %q (id=%s, fast path)", analysisID, client.Name(), operatorID)
 			return client, nil
 		}
-		log.Warnf("operator %q not found in scheduler for analysis %s, searching all operators", operatorName, analysisID)
+		log.Warnf("operator id %s not found in scheduler for analysis %s, searching all operators", operatorID, analysisID)
 	} else {
-		log.Debugf("no operator name recorded for analysis %s, searching all operators", analysisID)
+		log.Debugf("no operator id recorded for analysis %s, searching all operators", analysisID)
 	}
 
 	// Search path: ask every operator in parallel whether it has this analysis.
@@ -128,11 +130,11 @@ func (h *HTTPHandlers) operatorClientForAnalysis(ctx context.Context, analysisID
 	}
 
 	// Update the DB so future lookups use the fast path.
-	if err := h.apps.SetOperatorName(ctx, analysisID, client.Name()); err != nil {
-		log.Errorf("failed to record operator %q for analysis %s: %v", client.Name(), analysisID, err)
+	if err := h.apps.SetOperatorID(ctx, analysisID, client.ID()); err != nil {
+		log.Errorf("failed to record operator %q (id=%s) for analysis %s: %v", client.Name(), client.ID(), analysisID, err)
 	}
 
-	log.Infof("analysis %s found on operator %q (search path)", analysisID, client.Name())
+	log.Infof("analysis %s found on operator %q (id=%s, search path)", analysisID, client.Name(), client.ID())
 	return client, nil
 }
 
@@ -451,19 +453,21 @@ func (h *HTTPHandlers) AsyncDataHandler(c echo.Context) error {
 }
 
 // AdminOperatorsHandler lists all operators registered in the database,
-// returning only their name, URL, and TLS skip-verify flag.
+// returning each operator's id, name, URL, TLS skip-verify flag, and
+// priority. The id is included so admin clients can address an operator by
+// its stable UUID for PATCH/DELETE operations.
 //
 //	@ID				admin-list-operators
 //	@Summary		Lists registered operators
-//	@Description	Returns the name, URL, and tls_skip_verify flag for all operators in the database.
+//	@Description	Returns id, name, URL, tls_skip_verify, and priority for all operators in the database.
 //	@Produce		json
-//	@Success		200	{array}		operatorclient.OperatorConfig
+//	@Success		200	{array}		operatorclient.OperatorAdminSummary
 //	@Failure		500	{object}	common.ErrorResponse
 //	@Router			/vice/admin/operators [get]
 func (h *HTTPHandlers) AdminOperatorsHandler(c echo.Context) error {
 	ctx := c.Request().Context()
 
-	ops, err := h.db.ListOperatorSummaries(ctx)
+	ops, err := h.db.ListOperatorAdminSummaries(ctx)
 	if err != nil {
 		log.Errorf("failed to list operators: %v", err)
 		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
@@ -520,38 +524,74 @@ func (h *HTTPHandlers) AdminOperatorCapacitiesHandler(c echo.Context) error {
 	return c.JSON(http.StatusOK, results)
 }
 
-// CreateOperatorHandler adds a new operator to the database.
+// validateOperatorFields validates the optional name and url for an
+// operator request. nil pointers indicate the field is absent (a valid
+// state for a partial update); non-nil pointers are validated against the
+// same rules the operators table's CHECK and UNIQUE constraints enforce —
+// non-whitespace text, and for url an HTTP(S) URL with a host. Uniqueness
+// is checked at the DB layer rather than here.
+func validateOperatorFields(name, urlStr *string) error {
+	if name != nil && strings.TrimSpace(*name) == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "name must not be empty or whitespace")
+	}
+	if urlStr != nil {
+		if strings.TrimSpace(*urlStr) == "" {
+			return echo.NewHTTPError(http.StatusBadRequest, "url must not be empty or whitespace")
+		}
+		parsed, err := url.Parse(*urlStr)
+		if err != nil || (parsed.Scheme != "http" && parsed.Scheme != "https") || parsed.Host == "" {
+			return echo.NewHTTPError(http.StatusBadRequest, "url must be a valid HTTP(S) URL")
+		}
+	}
+	return nil
+}
+
+// operatorWriteError maps an InsertOperator/UpdateOperatorByID error to the
+// appropriate HTTP status. UNIQUE-constraint violations (SQLSTATE 23505)
+// from name- or url-collisions become 409 Conflict; everything else is a
+// 500. Callers handle sql.ErrNoRows separately because only update can
+// return it.
+func operatorWriteError(operation string, identifier string, err error) error {
+	var pqErr *pq.Error
+	if errors.As(err, &pqErr) && pqErr.Code == "23505" {
+		log.Warnf("%s operator %q rejected by unique constraint: %v", operation, identifier, err)
+		return echo.NewHTTPError(http.StatusConflict, "operator with that name or url already exists")
+	}
+	log.Errorf("failed to %s operator %q: %v", operation, identifier, err)
+	return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+}
+
+// CreateOperatorHandler adds a new operator to the database. The response
+// echoes the persisted row's id alongside the public config fields so
+// callers can address the new operator by id (e.g., for a follow-up PATCH
+// or DELETE) without a separate list call.
 //
 //	@ID				admin-create-operator
 //	@Summary		Creates a new operator
-//	@Description	Adds a new operator to the database.
+//	@Description	Adds a new operator to the database. Returns the new row including its server-assigned UUID.
 //	@Accept			json
 //	@Produce		json
 //	@Param			body	body		operatorclient.OperatorConfig	true	"Operator to create"
-//	@Success		201		{object}	operatorclient.OperatorConfig
+//	@Success		201		{object}	operatorclient.OperatorAdminSummary
 //	@Failure		400		{object}	common.ErrorResponse
+//	@Failure		409		{object}	common.ErrorResponse
 //	@Failure		500		{object}	common.ErrorResponse
 //	@Router			/vice/admin/operators [post]
 func (h *HTTPHandlers) CreateOperatorHandler(c echo.Context) error {
 	ctx := c.Request().Context()
 
-	// The request body has the same shape as the response — both are
-	// operatorclient.OperatorConfig. A separate request type would only
-	// invite the two to drift.
+	// The request body uses operatorclient.OperatorConfig because clients
+	// don't supply an id at create time — id is server-assigned. The
+	// response shape (OperatorAdminSummary) carries the new id back.
 	var req operatorclient.OperatorConfig
 	if err := c.Bind(&req); err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
 
-	if strings.TrimSpace(req.Name) == "" {
-		return echo.NewHTTPError(http.StatusBadRequest, "name is required")
-	}
-	if strings.TrimSpace(req.URL) == "" {
-		return echo.NewHTTPError(http.StatusBadRequest, "url is required")
-	}
-	parsedURL, parseErr := url.Parse(req.URL)
-	if parseErr != nil || (parsedURL.Scheme != "http" && parsedURL.Scheme != "https") || parsedURL.Host == "" {
-		return echo.NewHTTPError(http.StatusBadRequest, "url must be a valid HTTP(S) URL")
+	// Both fields are required at create time, so pass them as non-nil to
+	// reuse the same validator the update path uses for present-fields.
+	if err := validateOperatorFields(&req.Name, &req.URL); err != nil {
+		return err
 	}
 
 	op := &db.Operator{
@@ -563,38 +603,107 @@ func (h *HTTPHandlers) CreateOperatorHandler(c echo.Context) error {
 
 	created, err := h.db.InsertOperator(ctx, op)
 	if err != nil {
-		log.Errorf("failed to insert operator %q: %v", req.Name, err)
-		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+		return operatorWriteError("insert", req.Name, err)
 	}
 
-	// Return only the public fields — drop timestamps, IDs, and
-	// reconciliation state. ToOperatorConfig performs that projection.
-	return c.JSON(http.StatusCreated, created.ToOperatorConfig())
+	// Project to the admin-summary shape: id plus the four public config
+	// fields. Drops timestamps and reconciliation state.
+	return c.JSON(http.StatusCreated, created.ToOperatorAdminSummary())
 }
 
-// DeleteOperatorHandler deletes an operator by name. The operation is
+// UpdateOperatorRequest is the body for PATCH /vice/admin/operators/id/:id.
+// All fields are optional; only the fields whose pointers are non-nil are
+// applied. Pointer types let us distinguish "client omitted this field"
+// from "client wants to set it to the zero value" (a value-typed shape
+// would silently force priority=0 / tls_skip_verify=false on every PATCH
+// that omitted them).
+type UpdateOperatorRequest struct {
+	Name          *string `json:"name,omitempty"`
+	URL           *string `json:"url,omitempty"`
+	TLSSkipVerify *bool   `json:"tls_skip_verify,omitempty"`
+	Priority      *int    `json:"priority,omitempty"`
+}
+
+// UpdateOperatorHandler applies a partial update to the operator with the
+// given UUID. The path identifies the row by id rather than name so that
+// renames don't break the path semantics: PATCH targets the same row even
+// if the name field is being changed in the body.
+//
+//	@ID				admin-update-operator
+//	@Summary		Updates an operator
+//	@Description	Partial update of an operator identified by UUID. Only fields supplied in the body are changed.
+//	@Accept			json
+//	@Produce		json
+//	@Param			id		path		string					true	"Operator UUID"
+//	@Param			body	body		UpdateOperatorRequest	true	"Fields to update"
+//	@Success		200		{object}	operatorclient.OperatorConfig
+//	@Failure		400		{object}	common.ErrorResponse
+//	@Failure		404		{object}	common.ErrorResponse
+//	@Failure		409		{object}	common.ErrorResponse
+//	@Failure		500		{object}	common.ErrorResponse
+//	@Router			/vice/admin/operators/id/{id} [patch]
+func (h *HTTPHandlers) UpdateOperatorHandler(c echo.Context) error {
+	ctx := c.Request().Context()
+
+	idStr := c.Param("id")
+	id, err := uuid.Parse(idStr)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "id must be a valid UUID")
+	}
+
+	var req UpdateOperatorRequest
+	if err := c.Bind(&req); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
+	}
+
+	if req.Name == nil && req.URL == nil && req.TLSSkipVerify == nil && req.Priority == nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "request body must update at least one field")
+	}
+
+	if err := validateOperatorFields(req.Name, req.URL); err != nil {
+		return err
+	}
+
+	updated, err := h.db.UpdateOperatorByID(ctx, id, db.OperatorUpdate{
+		Name:          req.Name,
+		URL:           req.URL,
+		TLSSkipVerify: req.TLSSkipVerify,
+		Priority:      req.Priority,
+	})
+	if errors.Is(err, sql.ErrNoRows) {
+		return echo.NewHTTPError(http.StatusNotFound, "operator not found")
+	}
+	if err != nil {
+		return operatorWriteError("update", idStr, err)
+	}
+
+	return c.JSON(http.StatusOK, updated.ToOperatorConfig())
+}
+
+// DeleteOperatorHandler deletes an operator by UUID. The operation is
 // idempotent for operators with no associated jobs: deleting a non-existent
 // operator returns 200. Deleting an operator that still has jobs referencing
-// it will fail due to a foreign key constraint.
+// it will fail due to the jobs.operator_id ON DELETE RESTRICT FK.
 //
 //	@ID				admin-delete-operator
-//	@Summary		Deletes an operator by name
-//	@Description	Removes the named operator from the database. Succeeds silently if the operator does not exist. Fails if jobs still reference the operator.
-//	@Param			name	path	string	true	"Operator name"
+//	@Summary		Deletes an operator by id
+//	@Description	Removes the operator with the given UUID. Succeeds silently if the operator does not exist. Fails if jobs still reference the operator.
+//	@Param			id	path	string	true	"Operator UUID"
 //	@Success		200
 //	@Failure		400	{object}	common.ErrorResponse
 //	@Failure		500	{object}	common.ErrorResponse
-//	@Router			/vice/admin/operators/name/{name} [delete]
+//	@Router			/vice/admin/operators/id/{id} [delete]
 func (h *HTTPHandlers) DeleteOperatorHandler(c echo.Context) error {
 	ctx := c.Request().Context()
 
-	name := c.Param("name")
-	if name == "" {
-		return echo.NewHTTPError(http.StatusBadRequest, "name is required")
+	idStr := c.Param("id")
+	id, err := uuid.Parse(idStr)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "id must be a valid UUID")
 	}
 
-	if err := h.db.DeleteOperatorByName(ctx, name); err != nil {
-		log.Errorf("failed to delete operator %q: %v", name, err)
+	if err := h.db.DeleteOperatorByID(ctx, id); err != nil {
+		log.Errorf("failed to delete operator %q: %v", idStr, err)
 		return echo.NewHTTPError(http.StatusInternalServerError, "failed to delete operator")
 	}
 

--- a/httphandlers/launch.go
+++ b/httphandlers/launch.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cyverse-de/app-exposer/operatorclient"
 	"github.com/cyverse-de/app-exposer/permissions"
 	"github.com/cyverse-de/model/v10"
+	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
 )
 
@@ -52,17 +53,17 @@ func (h *HTTPHandlers) LaunchAppHandler(c echo.Context) error {
 	// every operator and get "not found" from all of them — wasted work that
 	// becomes a problem during workshops with many concurrent launches.
 	//
-	// GetOperatorName normalizes sql.ErrNoRows to ("", nil); a non-nil error
-	// here is a real DB fault. Treating it as "not running" would silently
-	// drop the idempotency guard and can cause double-launches during
-	// concurrent-launch bursts when the DB briefly blips.
-	name, err := h.apps.GetOperatorName(ctx, constants.AnalysisID(job.ID))
+	// GetOperatorID normalizes sql.ErrNoRows to (uuid.Nil, nil); a non-nil
+	// error here is a real DB fault. Treating it as "not running" would
+	// silently drop the idempotency guard and can cause double-launches
+	// during concurrent-launch bursts when the DB briefly blips.
+	operatorID, err := h.apps.GetOperatorID(ctx, constants.AnalysisID(job.ID))
 	if err != nil {
 		log.Errorf("idempotency lookup failed for analysis %s: %v", job.ID, err)
 		return echo.NewHTTPError(http.StatusServiceUnavailable, "idempotency check unavailable")
 	}
-	if name != "" {
-		if client := h.scheduler.ClientByName(name); client != nil {
+	if operatorID != uuid.Nil {
+		if client := h.scheduler.ClientByID(operatorID); client != nil {
 			log.Infof("analysis %s already running on operator %s, returning success", job.ID, client.Name())
 			return c.NoContent(http.StatusOK)
 		}
@@ -77,7 +78,7 @@ func (h *HTTPHandlers) LaunchAppHandler(c echo.Context) error {
 
 	// Validation passed — accept the job and do the heavy lifting in the
 	// background. Returning early lets the caller commit its DB transaction,
-	// which makes the jobs row visible for SetOperatorName below.
+	// which makes the jobs row visible for SetOperatorID below.
 	//
 	// Gate the background goroutine on launchSemaphore so a workshop-scale
 	// burst can't spawn thousands of 2-minute-lifetime goroutines each
@@ -161,8 +162,10 @@ func (h *HTTPHandlers) launchAsync(job *model.Job) {
 		return
 	}
 
-	// Route the bundle to an available operator.
-	operatorName, err := h.scheduler.LaunchAnalysis(ctx, bundle)
+	// Route the bundle to an available operator. The scheduler returns
+	// both the id (used for the DB write below) and the name (used in
+	// human-readable log lines).
+	operatorID, operatorName, err := h.scheduler.LaunchAnalysis(ctx, bundle)
 	if err != nil {
 		log.Errorf("async launch %s: failed to launch analysis: %v", job.ID, err)
 		h.failLaunch(ctx, job, fmt.Sprintf("failed to schedule analysis on operator: %v", err))
@@ -175,30 +178,30 @@ func (h *HTTPHandlers) launchAsync(job *model.Job) {
 	// amplify a brief DB blip into sustained load on every operator. Retry
 	// a few times to ride out transient blips before giving up; the
 	// reconciler's per-pod back-fill closes any hole that remains.
-	if err := h.setOperatorNameWithRetry(ctx, constants.AnalysisID(job.ID), operatorName); err != nil {
-		log.Errorf("async launch %s: failed to set operator name after retries: %v", job.ID, err)
+	if err := h.setOperatorIDWithRetry(ctx, constants.AnalysisID(job.ID), operatorID); err != nil {
+		log.Errorf("async launch %s: failed to set operator id after retries: %v", job.ID, err)
 	}
 
-	log.Infof("async launch %s: successfully launched on operator %s", job.ID, operatorName)
+	log.Infof("async launch %s: successfully launched on operator %s (id=%s)", job.ID, operatorName, operatorID)
 }
 
-// setOperatorNameWithRetry records which operator is running an analysis,
-// retrying a few times to survive transient DB blips. SetOperatorName
+// setOperatorIDWithRetry records which operator is running an analysis,
+// retrying a few times to survive transient DB blips. SetOperatorID
 // already retries internally for the "jobs row not yet visible" case;
 // this wrapper layers a small additional retry on top to handle
 // connection-level failures that bypass the inner loop. When the outer
 // retry also exhausts, the reconciler's back-fill will eventually close
 // the hole within ~30 s.
-func (h *HTTPHandlers) setOperatorNameWithRetry(ctx context.Context, analysisID constants.AnalysisID, operatorName string) error {
+func (h *HTTPHandlers) setOperatorIDWithRetry(ctx context.Context, analysisID constants.AnalysisID, operatorID uuid.UUID) error {
 	const attempts = 3
 	var lastErr error
 	for attempt := 1; attempt <= attempts; attempt++ {
-		lastErr = h.apps.SetOperatorName(ctx, analysisID, operatorName)
+		lastErr = h.apps.SetOperatorID(ctx, analysisID, operatorID)
 		if lastErr == nil {
 			return nil
 		}
 		if attempt < attempts {
-			log.Warnf("async launch %s: SetOperatorName attempt %d/%d failed, retrying: %v", analysisID, attempt, attempts, lastErr)
+			log.Warnf("async launch %s: SetOperatorID attempt %d/%d failed, retrying: %v", analysisID, attempt, attempts, lastErr)
 			select {
 			case <-ctx.Done():
 				return ctx.Err()

--- a/httphandlers/operators_test.go
+++ b/httphandlers/operators_test.go
@@ -1,0 +1,115 @@
+package httphandlers
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestValidateOperatorFields covers the present/absent matrix for the
+// validation helper used by both create and update. Empty/whitespace and
+// non-HTTP(S) URLs must return 400; nil pointers must short-circuit so a
+// PATCH that omits a field doesn't fabricate a validation error.
+func TestValidateOperatorFields(t *testing.T) {
+	strPtr := func(s string) *string { return &s }
+
+	tests := []struct {
+		name    string
+		nameArg *string
+		urlArg  *string
+		wantErr bool
+		// wantStatus is checked only when wantErr is true.
+		wantStatus int
+	}{
+		{
+			name:    "both nil short-circuits (partial update with neither field)",
+			nameArg: nil,
+			urlArg:  nil,
+			wantErr: false,
+		},
+		{
+			name:    "valid name only",
+			nameArg: strPtr("cluster-a"),
+			urlArg:  nil,
+			wantErr: false,
+		},
+		{
+			name:    "valid url only",
+			nameArg: nil,
+			urlArg:  strPtr("https://op.example.com"),
+			wantErr: false,
+		},
+		{
+			name:    "valid name and url",
+			nameArg: strPtr("cluster-a"),
+			urlArg:  strPtr("https://op.example.com"),
+			wantErr: false,
+		},
+		{
+			name:       "empty name rejected",
+			nameArg:    strPtr(""),
+			urlArg:     nil,
+			wantErr:    true,
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "whitespace name rejected (matches table CHECK constraint)",
+			nameArg:    strPtr("   "),
+			urlArg:     nil,
+			wantErr:    true,
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "empty url rejected",
+			nameArg:    nil,
+			urlArg:     strPtr(""),
+			wantErr:    true,
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "whitespace url rejected",
+			nameArg:    nil,
+			urlArg:     strPtr("   "),
+			wantErr:    true,
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "non-HTTP scheme rejected",
+			nameArg:    nil,
+			urlArg:     strPtr("ftp://op.example.com"),
+			wantErr:    true,
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "missing host rejected",
+			nameArg:    nil,
+			urlArg:     strPtr("https://"),
+			wantErr:    true,
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:    "http scheme accepted",
+			nameArg: nil,
+			urlArg:  strPtr("http://op.example.com"),
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateOperatorFields(tt.nameArg, tt.urlArg)
+			if tt.wantErr {
+				if assert.Error(t, err) {
+					httpErr, ok := err.(*echo.HTTPError)
+					if assert.True(t, ok, "expected *echo.HTTPError, got %T", err) {
+						assert.Equal(t, tt.wantStatus, httpErr.Code)
+					}
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/operatorclient/client.go
+++ b/operatorclient/client.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/cyverse-de/app-exposer/common"
 	"github.com/cyverse-de/app-exposer/reporting"
+	"github.com/google/uuid"
 	"github.com/sirupsen/logrus"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"golang.org/x/oauth2"
@@ -48,30 +49,32 @@ func (e *HTTPStatusError) Transient() bool {
 
 // Client communicates with a single vice-operator instance via HTTP.
 type Client struct {
+	id      uuid.UUID
 	name    string
 	baseURL *url.URL
 	http    *http.Client
 }
 
-// NewClient creates a new operator Client from an OperatorConfig. When ts is
-// non-nil, an oauth2.Transport is inserted into the transport chain so that
-// every request carries a Bearer token (automatically refreshed). When
-// cfg.TLSSkipVerify is true, TLS certificate verification is skipped — use
-// only for development/testing with self-signed certs.
-func NewClient(cfg OperatorConfig, ts oauth2.TokenSource) (*Client, error) {
-	u, err := url.Parse(cfg.URL)
+// NewClient creates a new operator Client from an OperatorAdminSummary
+// (the DB-backed shape that carries the operator's UUID). When ts is
+// non-nil, an oauth2.Transport is inserted into the transport chain so
+// that every request carries a Bearer token (automatically refreshed).
+// When summary.TLSSkipVerify is true, TLS certificate verification is
+// skipped — use only for development/testing with self-signed certs.
+func NewClient(summary OperatorAdminSummary, ts oauth2.TokenSource) (*Client, error) {
+	u, err := url.Parse(summary.URL)
 	if err != nil {
-		return nil, fmt.Errorf("parsing operator URL %q: %w", cfg.URL, err)
+		return nil, fmt.Errorf("parsing operator URL %q: %w", summary.URL, err)
 	}
 
 	transport := http.RoundTripper(http.DefaultTransport)
-	if cfg.TLSSkipVerify {
+	if summary.TLSSkipVerify {
 		// Clone DefaultTransport to preserve connection pooling, timeouts, and
 		// proxy settings — only override the TLS verification.
 		dt := http.DefaultTransport.(*http.Transport).Clone()
 		dt.TLSClientConfig.InsecureSkipVerify = true //nolint:gosec // intentional for dev/testing
 		transport = dt
-		log.Warnf("operator %q: TLS certificate verification disabled (tls_skip_verify)", cfg.Name)
+		log.Warnf("operator %q: TLS certificate verification disabled (tls_skip_verify)", summary.Name)
 	}
 
 	// When a token source is provided, wrap the transport so every outgoing
@@ -82,7 +85,8 @@ func NewClient(cfg OperatorConfig, ts oauth2.TokenSource) (*Client, error) {
 	}
 
 	return &Client{
-		name:    cfg.Name,
+		id:      summary.ID,
+		name:    summary.Name,
 		baseURL: u,
 		http: &http.Client{
 			Transport: otelhttp.NewTransport(transport),
@@ -118,6 +122,13 @@ func checkStatus(resp *http.Response, label string) error {
 // Name returns the operator's configured name.
 func (c *Client) Name() string {
 	return c.name
+}
+
+// ID returns the operator's UUID. Stable across renames — callers that
+// need to identify the same operator across config refreshes should index
+// by id rather than name.
+func (c *Client) ID() uuid.UUID {
+	return c.id
 }
 
 // Capacity queries the operator for its current cluster capacity.

--- a/operatorclient/client_test.go
+++ b/operatorclient/client_test.go
@@ -25,7 +25,10 @@ func newTestClient(t *testing.T, handler http.Handler) (*Client, *httptest.Serve
 	t.Helper()
 	srv := httptest.NewServer(handler)
 	t.Cleanup(srv.Close)
-	client, err := NewClient(OperatorAdminSummary{ID: uuid.New(), Name: "test-op", URL: srv.URL}, nil)
+	client, err := NewClient(OperatorAdminSummary{
+		ID:             uuid.New(),
+		OperatorConfig: OperatorConfig{Name: "test-op", URL: srv.URL},
+	}, nil)
 	require.NoError(t, err)
 	return client, srv
 }
@@ -38,12 +41,18 @@ func TestNewClient(t *testing.T) {
 		wantErrSubstr string
 	}{
 		{
-			name:    "valid URL",
-			summary: OperatorAdminSummary{ID: uuid.New(), Name: "op-a", URL: "http://op-a.example.invalid"},
+			name: "valid URL",
+			summary: OperatorAdminSummary{
+				ID:             uuid.New(),
+				OperatorConfig: OperatorConfig{Name: "op-a", URL: "http://op-a.example.invalid"},
+			},
 		},
 		{
-			name:          "invalid URL",
-			summary:       OperatorAdminSummary{ID: uuid.New(), Name: "op-bad", URL: "://nope"},
+			name: "invalid URL",
+			summary: OperatorAdminSummary{
+				ID:             uuid.New(),
+				OperatorConfig: OperatorConfig{Name: "op-bad", URL: "://nope"},
+			},
 			wantErr:       true,
 			wantErrSubstr: "parsing operator URL",
 		},
@@ -52,8 +61,11 @@ func TestNewClient(t *testing.T) {
 			// Exercising the actual InsecureSkipVerify flag would require
 			// introspecting the otelhttp-wrapped transport, which offers no
 			// stable public API for unwrapping in the version in use here.
-			name:    "TLS skip verify constructs successfully",
-			summary: OperatorAdminSummary{ID: uuid.New(), Name: "op-skip", URL: "https://op.example.invalid", TLSSkipVerify: true},
+			name: "TLS skip verify constructs successfully",
+			summary: OperatorAdminSummary{
+				ID:             uuid.New(),
+				OperatorConfig: OperatorConfig{Name: "op-skip", URL: "https://op.example.invalid", TLSSkipVerify: true},
+			},
 		},
 	}
 

--- a/operatorclient/client_test.go
+++ b/operatorclient/client_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/cyverse-de/app-exposer/constants"
 	"github.com/cyverse-de/app-exposer/reporting"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -24,7 +25,7 @@ func newTestClient(t *testing.T, handler http.Handler) (*Client, *httptest.Serve
 	t.Helper()
 	srv := httptest.NewServer(handler)
 	t.Cleanup(srv.Close)
-	client, err := NewClient(OperatorConfig{Name: "test-op", URL: srv.URL}, nil)
+	client, err := NewClient(OperatorAdminSummary{ID: uuid.New(), Name: "test-op", URL: srv.URL}, nil)
 	require.NoError(t, err)
 	return client, srv
 }
@@ -32,17 +33,17 @@ func newTestClient(t *testing.T, handler http.Handler) (*Client, *httptest.Serve
 func TestNewClient(t *testing.T) {
 	tests := []struct {
 		name          string
-		cfg           OperatorConfig
+		summary       OperatorAdminSummary
 		wantErr       bool
 		wantErrSubstr string
 	}{
 		{
-			name: "valid URL",
-			cfg:  OperatorConfig{Name: "op-a", URL: "http://op-a.example.invalid"},
+			name:    "valid URL",
+			summary: OperatorAdminSummary{ID: uuid.New(), Name: "op-a", URL: "http://op-a.example.invalid"},
 		},
 		{
 			name:          "invalid URL",
-			cfg:           OperatorConfig{Name: "op-bad", URL: "://nope"},
+			summary:       OperatorAdminSummary{ID: uuid.New(), Name: "op-bad", URL: "://nope"},
 			wantErr:       true,
 			wantErrSubstr: "parsing operator URL",
 		},
@@ -51,14 +52,14 @@ func TestNewClient(t *testing.T) {
 			// Exercising the actual InsecureSkipVerify flag would require
 			// introspecting the otelhttp-wrapped transport, which offers no
 			// stable public API for unwrapping in the version in use here.
-			name: "TLS skip verify constructs successfully",
-			cfg:  OperatorConfig{Name: "op-skip", URL: "https://op.example.invalid", TLSSkipVerify: true},
+			name:    "TLS skip verify constructs successfully",
+			summary: OperatorAdminSummary{ID: uuid.New(), Name: "op-skip", URL: "https://op.example.invalid", TLSSkipVerify: true},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c, err := NewClient(tt.cfg, nil)
+			c, err := NewClient(tt.summary, nil)
 			if tt.wantErr {
 				require.Error(t, err)
 				if tt.wantErrSubstr != "" {
@@ -67,7 +68,8 @@ func TestNewClient(t *testing.T) {
 				return
 			}
 			require.NoError(t, err)
-			assert.Equal(t, tt.cfg.Name, c.Name())
+			assert.Equal(t, tt.summary.Name, c.Name())
+			assert.Equal(t, tt.summary.ID, c.ID())
 			assert.NotNil(t, c.http, "http client must be initialized")
 			assert.Equal(t, 30*time.Second, c.http.Timeout)
 		})

--- a/operatorclient/scheduler.go
+++ b/operatorclient/scheduler.go
@@ -9,6 +9,7 @@ import (
 	"slices"
 	"sync"
 
+	"github.com/google/uuid"
 	"golang.org/x/oauth2"
 )
 
@@ -84,21 +85,12 @@ type Scheduler struct {
 	tokenSource oauth2.TokenSource
 }
 
-// NewScheduler creates a Scheduler from operator configs. The token source is
-// used to authenticate requests to all operators; pass nil to disable auth.
-// Operators are tried in the order they appear in the configs slice
-// (config order = priority order).
-func NewScheduler(configs []OperatorConfig, ts oauth2.TokenSource) (*Scheduler, error) {
-	clients := make([]*Client, 0, len(configs))
-	for _, cfg := range configs {
-		c, err := NewClient(cfg, ts)
-		if err != nil {
-			return nil, fmt.Errorf("creating client for operator %q: %w", cfg.Name, err)
-		}
-		clients = append(clients, c)
-	}
-
-	return &Scheduler{operators: clients, tokenSource: ts}, nil
+// NewScheduler creates an empty Scheduler. The reconciler's first
+// SyncOperators call populates it from the database, which is the source
+// of truth for operator configuration. The token source is used to
+// authenticate requests to all operators; pass nil to disable auth.
+func NewScheduler(ts oauth2.TokenSource) *Scheduler {
+	return &Scheduler{tokenSource: ts}
 }
 
 // SetTokenSource updates the token source used for authenticating requests
@@ -109,20 +101,23 @@ func (s *Scheduler) SetTokenSource(ts oauth2.TokenSource) {
 	s.tokenSource = ts
 }
 
-// Sync replaces the scheduler's current operator clients with a new list.
-// This allows runtime updates from the database without a restart.
-func (s *Scheduler) Sync(configs []OperatorConfig) error {
+// Sync replaces the scheduler's current operator clients with a new list
+// built from the DB-backed admin summaries (each carrying its UUID). This
+// allows runtime updates from the database without a restart. Each client
+// remembers its id so callers can look it up via ClientByID even after a
+// rename.
+func (s *Scheduler) Sync(summaries []OperatorAdminSummary) error {
 	// Snapshot the token source under a read-lock so that a concurrent
 	// SetTokenSource call cannot race with our read of s.tokenSource.
 	s.mu.RLock()
 	ts := s.tokenSource
 	s.mu.RUnlock()
 
-	clients := make([]*Client, 0, len(configs))
-	for _, cfg := range configs {
-		c, err := NewClient(cfg, ts)
+	clients := make([]*Client, 0, len(summaries))
+	for _, summary := range summaries {
+		c, err := NewClient(summary, ts)
 		if err != nil {
-			return fmt.Errorf("creating client for operator %q: %w", cfg.Name, err)
+			return fmt.Errorf("creating client for operator %q: %w", summary.Name, err)
 		}
 		clients = append(clients, c)
 	}
@@ -135,20 +130,21 @@ func (s *Scheduler) Sync(configs []OperatorConfig) error {
 }
 
 // LaunchAnalysis sends the bundle to the first operator that has capacity.
-// Returns the name of the operator that accepted the analysis, or an error
-// if no operator could accept it.
+// Returns the id and name of the operator that accepted the analysis, or
+// an error if no operator could accept it. Returning the id directly lets
+// callers persist the analysis→operator linkage by UUID without a
+// follow-up name→id lookup that could race with a concurrent rename.
 //
-// The scheduling strategy is simple: operators are tried in config order
-// (priority order). The first operator with available capacity gets the
-// analysis. This minimizes usage of later (potentially more expensive)
-// clusters.
-func (s *Scheduler) LaunchAnalysis(ctx context.Context, bundle *AnalysisBundle) (string, error) {
+// The scheduling strategy is simple: operators are tried in priority order.
+// The first operator with available capacity gets the analysis. This
+// minimizes usage of later (potentially more expensive) clusters.
+func (s *Scheduler) LaunchAnalysis(ctx context.Context, bundle *AnalysisBundle) (uuid.UUID, string, error) {
 	s.mu.RLock()
 	clients := slices.Clone(s.operators)
 	s.mu.RUnlock()
 
 	if len(clients) == 0 {
-		return "", ErrNoOperators
+		return uuid.Nil, "", ErrNoOperators
 	}
 
 	// Track capacity-check errors, transient launch failures, and vendor
@@ -204,23 +200,23 @@ func (s *Scheduler) LaunchAnalysis(ctx context.Context, bundle *AnalysisBundle) 
 				log.Warnf("operator %s launch failed transiently, trying next: %v", op.Name(), err)
 				continue
 			}
-			return "", fmt.Errorf("launch on operator %s failed: %w", op.Name(), err)
+			return uuid.Nil, "", fmt.Errorf("launch on operator %s failed: %w", op.Name(), err)
 		}
 
-		log.Infof("analysis %s launched on operator %s", bundle.AnalysisID, op.Name())
-		return op.Name(), nil
+		log.Infof("analysis %s launched on operator %s (id=%s)", bundle.AnalysisID, op.Name(), op.ID())
+		return op.ID(), op.Name(), nil
 	}
 
 	// Every operator's capacity check failed (all returned errors).
 	if capacityErrors == len(clients) {
-		return "", fmt.Errorf("all %d operators failed capacity check: %w", len(clients), ErrAllOperatorsExhausted)
+		return uuid.Nil, "", fmt.Errorf("all %d operators failed capacity check: %w", len(clients), ErrAllOperatorsExhausted)
 	}
 
 	// No operator advertised a compatible GPU vendor. Distinct from the
 	// at-capacity / unhealthy buckets so callers can surface a routing-
 	// policy error rather than a misleading "at capacity" message.
 	if wantVendor != "" && vendorMismatches > 0 && capacityErrors+vendorMismatches == len(clients) {
-		return "", fmt.Errorf("no operator with vendor %s for analysis %s: %w",
+		return uuid.Nil, "", fmt.Errorf("no operator with vendor %s for analysis %s: %w",
 			wantVendor, bundle.AnalysisID, ErrNoCompatibleOperator)
 	}
 
@@ -228,10 +224,10 @@ func (s *Scheduler) LaunchAnalysis(ctx context.Context, bundle *AnalysisBundle) 
 	// transient reasons. Surface the last underlying error so the caller
 	// can distinguish it from a real "all at capacity" situation.
 	if transientErrors > 0 && capacityErrors+transientErrors+vendorMismatches == len(clients) {
-		return "", fmt.Errorf("all %d operators unhealthy; last error: %w", len(clients), lastTransient)
+		return uuid.Nil, "", fmt.Errorf("all %d operators unhealthy; last error: %w", len(clients), lastTransient)
 	}
 
-	return "", ErrAllOperatorsExhausted
+	return uuid.Nil, "", ErrAllOperatorsExhausted
 }
 
 // Clients returns a copy of all operator clients so callers can iterate for
@@ -244,11 +240,28 @@ func (s *Scheduler) Clients() []*Client {
 }
 
 // ClientByName returns the operator client with the given name, or nil.
+// Prefer ClientByID for internal lookups: name is mutable, so a concurrent
+// rename can leave a name-keyed lookup looking for a stale value.
 func (s *Scheduler) ClientByName(name string) *Client {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	for _, op := range s.operators {
 		if op.Name() == name {
+			return op
+		}
+	}
+	return nil
+}
+
+// ClientByID returns the operator client with the given UUID, or nil.
+// Preferred over ClientByName because the id is stable across renames —
+// a client looked up by id won't go stale just because the operator's
+// name was changed.
+func (s *Scheduler) ClientByID(id uuid.UUID) *Client {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	for _, op := range s.operators {
+		if op.ID() == id {
 			return op
 		}
 	}

--- a/operatorclient/scheduler.go
+++ b/operatorclient/scheduler.go
@@ -240,8 +240,10 @@ func (s *Scheduler) Clients() []*Client {
 }
 
 // ClientByName returns the operator client with the given name, or nil.
-// Prefer ClientByID for internal lookups: name is mutable, so a concurrent
-// rename can leave a name-keyed lookup looking for a stale value.
+//
+// Deprecated: Use ClientByID. Operator names are mutable, so a concurrent
+// rename can leave a name-keyed lookup looking for a stale value; ClientByID
+// uses the immutable UUID and is rename-safe.
 func (s *Scheduler) ClientByName(name string) *Client {
 	s.mu.RLock()
 	defer s.mu.RUnlock()

--- a/operatorclient/scheduler_test.go
+++ b/operatorclient/scheduler_test.go
@@ -10,10 +10,33 @@ import (
 	"sync/atomic"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/oauth2"
 )
+
+// schedulerWithConfigs builds a Scheduler whose operators come from the
+// given OperatorConfig list, synthesizing a deterministic UUID per slot so
+// older tests authored against the config-only signature continue to read
+// naturally. Tests that need to assert a specific id should construct
+// OperatorAdminSummary values directly and call Sync.
+func schedulerWithConfigs(t *testing.T, configs []OperatorConfig) *Scheduler {
+	t.Helper()
+	summaries := make([]OperatorAdminSummary, len(configs))
+	for i, cfg := range configs {
+		summaries[i] = OperatorAdminSummary{
+			ID:            uuid.New(),
+			Name:          cfg.Name,
+			URL:           cfg.URL,
+			TLSSkipVerify: cfg.TLSSkipVerify,
+			Priority:      cfg.Priority,
+		}
+	}
+	s := NewScheduler(nil)
+	require.NoError(t, s.Sync(summaries))
+	return s
+}
 
 // mockOperatorServer creates a test HTTP server that simulates an operator.
 // capacitySlots controls how many available slots are reported.
@@ -149,11 +172,10 @@ func TestSchedulerLaunchAnalysis(t *testing.T) {
 				}
 			}()
 
-			scheduler, err := NewScheduler(configs, nil)
-			require.NoError(t, err)
+			scheduler := schedulerWithConfigs(t, configs)
 
 			bundle := &AnalysisBundle{AnalysisID: "test-123"}
-			operatorName, err := scheduler.LaunchAnalysis(context.Background(), bundle)
+			_, operatorName, err := scheduler.LaunchAnalysis(context.Background(), bundle)
 
 			if tt.wantErr != nil {
 				assert.ErrorIs(t, err, tt.wantErr)
@@ -176,13 +198,12 @@ func TestSchedulerLaunchAllCapacityChecksFail(t *testing.T) {
 	srv1 := mockOperatorServerWithStatuses(0, false, http.StatusInternalServerError, 0, "")
 	defer srv1.Close()
 
-	scheduler, err := NewScheduler([]OperatorConfig{
+	scheduler := schedulerWithConfigs(t, []OperatorConfig{
 		{Name: "op-0", URL: srv0.URL},
 		{Name: "op-1", URL: srv1.URL},
-	}, nil)
-	require.NoError(t, err)
+	})
 
-	_, err = scheduler.LaunchAnalysis(context.Background(), &AnalysisBundle{AnalysisID: "test"})
+	_, _, err := scheduler.LaunchAnalysis(context.Background(), &AnalysisBundle{AnalysisID: "test"})
 	require.Error(t, err)
 	assert.ErrorIs(t, err, ErrAllOperatorsExhausted)
 	assert.Contains(t, err.Error(), "failed capacity check", "message should distinguish capacity-failure from at-capacity")
@@ -198,13 +219,12 @@ func TestSchedulerLaunchTransientErrorFalthrough(t *testing.T) {
 	srv1 := mockOperatorServer(5, false)
 	defer srv1.Close()
 
-	scheduler, err := NewScheduler([]OperatorConfig{
+	scheduler := schedulerWithConfigs(t, []OperatorConfig{
 		{Name: "op-0", URL: srv0.URL},
 		{Name: "op-1", URL: srv1.URL},
-	}, nil)
-	require.NoError(t, err)
+	})
 
-	name, err := scheduler.LaunchAnalysis(context.Background(), &AnalysisBundle{AnalysisID: "test"})
+	_, name, err := scheduler.LaunchAnalysis(context.Background(), &AnalysisBundle{AnalysisID: "test"})
 	require.NoError(t, err)
 	assert.Equal(t, "op-1", name, "scheduler must fall through on transient 5xx launch errors")
 }
@@ -219,13 +239,12 @@ func TestSchedulerLaunchNonTransientAborts(t *testing.T) {
 	srv1 := mockOperatorServer(5, false) // would succeed if we reached it
 	defer srv1.Close()
 
-	scheduler, err := NewScheduler([]OperatorConfig{
+	scheduler := schedulerWithConfigs(t, []OperatorConfig{
 		{Name: "op-0", URL: srv0.URL},
 		{Name: "op-1", URL: srv1.URL},
-	}, nil)
-	require.NoError(t, err)
+	})
 
-	_, err = scheduler.LaunchAnalysis(context.Background(), &AnalysisBundle{AnalysisID: "test"})
+	_, _, err := scheduler.LaunchAnalysis(context.Background(), &AnalysisBundle{AnalysisID: "test"})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "op-0", "error must name the operator that failed")
 	assert.Contains(t, err.Error(), "400", "error must surface the HTTP status")
@@ -241,13 +260,12 @@ func TestSchedulerLaunchAllTransient(t *testing.T) {
 	srv1 := mockOperatorServerWithStatuses(5, false, 0, http.StatusBadGateway, "")
 	defer srv1.Close()
 
-	scheduler, err := NewScheduler([]OperatorConfig{
+	scheduler := schedulerWithConfigs(t, []OperatorConfig{
 		{Name: "op-0", URL: srv0.URL},
 		{Name: "op-1", URL: srv1.URL},
-	}, nil)
-	require.NoError(t, err)
+	})
 
-	_, err = scheduler.LaunchAnalysis(context.Background(), &AnalysisBundle{AnalysisID: "test"})
+	_, _, err := scheduler.LaunchAnalysis(context.Background(), &AnalysisBundle{AnalysisID: "test"})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unhealthy", "message should distinguish from at-capacity")
 
@@ -267,14 +285,13 @@ func TestSchedulerLaunchVendorMismatchAllAMD(t *testing.T) {
 	srv1 := mockOperatorServerWithVendor(5, "amd")
 	defer srv1.Close()
 
-	scheduler, err := NewScheduler([]OperatorConfig{
+	scheduler := schedulerWithConfigs(t, []OperatorConfig{
 		{Name: "amd-0", URL: srv0.URL},
 		{Name: "amd-1", URL: srv1.URL},
-	}, nil)
-	require.NoError(t, err)
+	})
 
 	bundle := gpuBundle("nvidia.com/gpu", "main", "requests")
-	_, err = scheduler.LaunchAnalysis(context.Background(), bundle)
+	_, _, err := scheduler.LaunchAnalysis(context.Background(), bundle)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, ErrNoCompatibleOperator)
 	assert.Contains(t, err.Error(), "nvidia", "error must name the requested vendor")
@@ -290,14 +307,13 @@ func TestSchedulerLaunchVendorMismatchSkipsToCompatible(t *testing.T) {
 	srv1 := mockOperatorServerWithVendor(5, "nvidia")
 	defer srv1.Close()
 
-	scheduler, err := NewScheduler([]OperatorConfig{
+	scheduler := schedulerWithConfigs(t, []OperatorConfig{
 		{Name: "amd-op", URL: srv0.URL},
 		{Name: "nvidia-op", URL: srv1.URL},
-	}, nil)
-	require.NoError(t, err)
+	})
 
 	bundle := gpuBundle("nvidia.com/gpu", "main", "requests")
-	name, err := scheduler.LaunchAnalysis(context.Background(), bundle)
+	_, name, err := scheduler.LaunchAnalysis(context.Background(), bundle)
 	require.NoError(t, err)
 	assert.Equal(t, "nvidia-op", name, "must skip AMD operator and land on Nvidia one")
 }
@@ -313,14 +329,13 @@ func TestSchedulerLaunchNoGPURequestSkipsVendorCheck(t *testing.T) {
 	srv1 := mockOperatorServerWithVendor(5, "amd")
 	defer srv1.Close()
 
-	scheduler, err := NewScheduler([]OperatorConfig{
+	scheduler := schedulerWithConfigs(t, []OperatorConfig{
 		{Name: "amd-0", URL: srv0.URL},
 		{Name: "amd-1", URL: srv1.URL},
-	}, nil)
-	require.NoError(t, err)
+	})
 
 	bundle := gpuBundle("", "main", "requests")
-	name, err := scheduler.LaunchAnalysis(context.Background(), bundle)
+	_, name, err := scheduler.LaunchAnalysis(context.Background(), bundle)
 	require.NoError(t, err)
 	assert.Equal(t, "amd-0", name, "no-GPU bundle must accept first capacity-passing operator")
 }
@@ -335,28 +350,26 @@ func TestSchedulerLaunchOperatorWithoutVendorIsCompatible(t *testing.T) {
 	srv0 := mockOperatorServerWithVendor(5, "")
 	defer srv0.Close()
 
-	scheduler, err := NewScheduler([]OperatorConfig{
+	scheduler := schedulerWithConfigs(t, []OperatorConfig{
 		{Name: "no-vendor", URL: srv0.URL},
-	}, nil)
-	require.NoError(t, err)
+	})
 
 	bundle := gpuBundle("nvidia.com/gpu", "main", "requests")
-	name, err := scheduler.LaunchAnalysis(context.Background(), bundle)
+	_, name, err := scheduler.LaunchAnalysis(context.Background(), bundle)
 	require.NoError(t, err)
 	assert.Equal(t, "no-vendor", name)
 }
 
 func TestSchedulerNoOperators(t *testing.T) {
-	scheduler, err := NewScheduler(nil, nil)
-	assert.NoError(t, err)
+	scheduler := NewScheduler(nil)
 
-	_, err = scheduler.LaunchAnalysis(context.Background(), &AnalysisBundle{AnalysisID: "test"})
+	_, _, err := scheduler.LaunchAnalysis(context.Background(), &AnalysisBundle{AnalysisID: "test"})
 	assert.ErrorIs(t, err, ErrNoOperators)
 
-	scheduler, err = NewScheduler([]OperatorConfig{}, nil)
-	assert.NoError(t, err)
+	scheduler = NewScheduler(nil)
+	require.NoError(t, scheduler.Sync(nil))
 
-	_, err = scheduler.LaunchAnalysis(context.Background(), &AnalysisBundle{AnalysisID: "test"})
+	_, _, err = scheduler.LaunchAnalysis(context.Background(), &AnalysisBundle{AnalysisID: "test"})
 	assert.ErrorIs(t, err, ErrNoOperators)
 }
 
@@ -364,10 +377,9 @@ func TestSchedulerClientByName(t *testing.T) {
 	srv := mockOperatorServer(5, false)
 	defer srv.Close()
 
-	scheduler, err := NewScheduler([]OperatorConfig{
+	scheduler := schedulerWithConfigs(t, []OperatorConfig{
 		{Name: "test-op", URL: srv.URL},
-	}, nil)
-	require.NoError(t, err)
+	})
 
 	client := scheduler.ClientByName("test-op")
 	assert.NotNil(t, client)
@@ -375,6 +387,36 @@ func TestSchedulerClientByName(t *testing.T) {
 
 	client = scheduler.ClientByName("nonexistent")
 	assert.Nil(t, client)
+}
+
+// TestSchedulerClientByID covers the id-keyed variant. It also verifies
+// that ClientByID continues to return the right client across a Sync
+// that renames the operator — the rename-safety guarantee the id-based
+// API was introduced to provide.
+func TestSchedulerClientByID(t *testing.T) {
+	srv := mockOperatorServer(5, false)
+	defer srv.Close()
+
+	id := uuid.New()
+	scheduler := NewScheduler(nil)
+	require.NoError(t, scheduler.Sync([]OperatorAdminSummary{
+		{ID: id, Name: "test-op", URL: srv.URL},
+	}))
+
+	client := scheduler.ClientByID(id)
+	require.NotNil(t, client)
+	assert.Equal(t, "test-op", client.Name())
+	assert.Equal(t, id, client.ID())
+
+	assert.Nil(t, scheduler.ClientByID(uuid.New()), "unknown id must return nil")
+
+	// Rename the operator (same id) and verify the lookup still works.
+	require.NoError(t, scheduler.Sync([]OperatorAdminSummary{
+		{ID: id, Name: "renamed", URL: srv.URL},
+	}))
+	client = scheduler.ClientByID(id)
+	require.NotNil(t, client, "id-keyed lookup must survive a rename")
+	assert.Equal(t, "renamed", client.Name())
 }
 
 // TestSchedulerLaunchUnlimitedCapacity verifies that an operator reporting
@@ -403,13 +445,12 @@ func TestSchedulerLaunchUnlimitedCapacity(t *testing.T) {
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
 
-	scheduler, err := NewScheduler([]OperatorConfig{
+	scheduler := schedulerWithConfigs(t, []OperatorConfig{
 		{Name: "unlimited-op", URL: srv.URL},
-	}, nil)
-	require.NoError(t, err)
+	})
 
 	bundle := &AnalysisBundle{AnalysisID: "unlimited-test-456"}
-	operatorName, err := scheduler.LaunchAnalysis(context.Background(), bundle)
+	_, operatorName, err := scheduler.LaunchAnalysis(context.Background(), bundle)
 
 	require.NoError(t, err)
 	assert.Equal(t, "unlimited-op", operatorName)
@@ -424,11 +465,11 @@ func TestSchedulerSyncAndSetTokenSource(t *testing.T) {
 	srv0 := mockOperatorServer(5, false)
 	defer srv0.Close()
 
-	origConfigs := []OperatorConfig{
-		{Name: "original-op", URL: srv0.URL},
+	origSummaries := []OperatorAdminSummary{
+		{ID: uuid.New(), Name: "original-op", URL: srv0.URL},
 	}
-	scheduler, err := NewScheduler(origConfigs, nil)
-	require.NoError(t, err)
+	scheduler := NewScheduler(nil)
+	require.NoError(t, scheduler.Sync(origSummaries))
 
 	// The original operator must be findable.
 	require.NotNil(t, scheduler.ClientByName("original-op"), "original-op should exist before Sync")
@@ -439,11 +480,11 @@ func TestSchedulerSyncAndSetTokenSource(t *testing.T) {
 	srv2 := mockOperatorServer(3, false)
 	defer srv2.Close()
 
-	newConfigs := []OperatorConfig{
-		{Name: "new-op-0", URL: srv1.URL},
-		{Name: "new-op-1", URL: srv2.URL},
+	newSummaries := []OperatorAdminSummary{
+		{ID: uuid.New(), Name: "new-op-0", URL: srv1.URL},
+		{ID: uuid.New(), Name: "new-op-1", URL: srv2.URL},
 	}
-	require.NoError(t, scheduler.Sync(newConfigs))
+	require.NoError(t, scheduler.Sync(newSummaries))
 
 	// The old operator must be gone; new ones must be present.
 	assert.Nil(t, scheduler.ClientByName("original-op"), "original-op should be absent after Sync")
@@ -462,11 +503,11 @@ func TestSchedulerSyncAndSetTokenSource(t *testing.T) {
 		for i := range iterations {
 			// Alternate between the two operator lists so Sync exercises a
 			// real list-shape change (1 ↔ 2 operators) under churn.
-			cfgs := newConfigs
+			summaries := newSummaries
 			if i%2 == 1 {
-				cfgs = origConfigs
+				summaries = origSummaries
 			}
-			if err := scheduler.Sync(cfgs); err != nil {
+			if err := scheduler.Sync(summaries); err != nil {
 				t.Errorf("Sync failed during race: %v", err)
 				return
 			}

--- a/operatorclient/scheduler_test.go
+++ b/operatorclient/scheduler_test.go
@@ -26,11 +26,8 @@ func schedulerWithConfigs(t *testing.T, configs []OperatorConfig) *Scheduler {
 	summaries := make([]OperatorAdminSummary, len(configs))
 	for i, cfg := range configs {
 		summaries[i] = OperatorAdminSummary{
-			ID:            uuid.New(),
-			Name:          cfg.Name,
-			URL:           cfg.URL,
-			TLSSkipVerify: cfg.TLSSkipVerify,
-			Priority:      cfg.Priority,
+			ID:             uuid.New(),
+			OperatorConfig: cfg,
 		}
 	}
 	s := NewScheduler(nil)
@@ -400,7 +397,7 @@ func TestSchedulerClientByID(t *testing.T) {
 	id := uuid.New()
 	scheduler := NewScheduler(nil)
 	require.NoError(t, scheduler.Sync([]OperatorAdminSummary{
-		{ID: id, Name: "test-op", URL: srv.URL},
+		{ID: id, OperatorConfig: OperatorConfig{Name: "test-op", URL: srv.URL}},
 	}))
 
 	client := scheduler.ClientByID(id)
@@ -412,7 +409,7 @@ func TestSchedulerClientByID(t *testing.T) {
 
 	// Rename the operator (same id) and verify the lookup still works.
 	require.NoError(t, scheduler.Sync([]OperatorAdminSummary{
-		{ID: id, Name: "renamed", URL: srv.URL},
+		{ID: id, OperatorConfig: OperatorConfig{Name: "renamed", URL: srv.URL}},
 	}))
 	client = scheduler.ClientByID(id)
 	require.NotNil(t, client, "id-keyed lookup must survive a rename")
@@ -466,7 +463,7 @@ func TestSchedulerSyncAndSetTokenSource(t *testing.T) {
 	defer srv0.Close()
 
 	origSummaries := []OperatorAdminSummary{
-		{ID: uuid.New(), Name: "original-op", URL: srv0.URL},
+		{ID: uuid.New(), OperatorConfig: OperatorConfig{Name: "original-op", URL: srv0.URL}},
 	}
 	scheduler := NewScheduler(nil)
 	require.NoError(t, scheduler.Sync(origSummaries))
@@ -481,8 +478,8 @@ func TestSchedulerSyncAndSetTokenSource(t *testing.T) {
 	defer srv2.Close()
 
 	newSummaries := []OperatorAdminSummary{
-		{ID: uuid.New(), Name: "new-op-0", URL: srv1.URL},
-		{ID: uuid.New(), Name: "new-op-1", URL: srv2.URL},
+		{ID: uuid.New(), OperatorConfig: OperatorConfig{Name: "new-op-0", URL: srv1.URL}},
+		{ID: uuid.New(), OperatorConfig: OperatorConfig{Name: "new-op-1", URL: srv2.URL}},
 	}
 	require.NoError(t, scheduler.Sync(newSummaries))
 

--- a/operatorclient/types.go
+++ b/operatorclient/types.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/cyverse-de/app-exposer/constants"
+	"github.com/google/uuid"
 	appsv1 "k8s.io/api/apps/v1"
 	apiv1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
@@ -279,4 +280,15 @@ type OperatorConfig struct {
 	URL           string `json:"url"             koanf:"url"             db:"url"`
 	TLSSkipVerify bool   `json:"tls_skip_verify" koanf:"tls_skip_verify" db:"tls_skip_verify"`
 	Priority      int    `json:"priority"        koanf:"priority"        db:"priority"`
+}
+
+// OperatorAdminSummary is the admin-facing listing shape for operators. It
+// extends OperatorConfig with the row's UUID so admin clients can address an
+// operator by id (which is stable across renames) rather than by name.
+type OperatorAdminSummary struct {
+	ID            uuid.UUID `json:"id"              db:"id"`
+	Name          string    `json:"name"            db:"name"`
+	URL           string    `json:"url"             db:"url"`
+	TLSSkipVerify bool      `json:"tls_skip_verify" db:"tls_skip_verify"`
+	Priority      int       `json:"priority"        db:"priority"`
 }

--- a/operatorclient/types.go
+++ b/operatorclient/types.go
@@ -268,27 +268,40 @@ type URLReadyResponse struct {
 
 // OperatorConfig holds the public configuration of a single vice-operator
 // instance. It is the canonical shape for operator metadata that crosses
-// process boundaries: koanf tags let it be loaded from a config file;
-// json tags let it be marshalled over the HTTP API; db tags let sqlx
-// scan directly from the operators table's SELECT columns.
+// process boundaries: json tags let it be marshalled over the HTTP API
+// and db tags let sqlx scan directly from the operators table's SELECT
+// columns.
 //
 // The internal full-row struct db.Operator continues to exist for DB
 // access that needs the write-only fields (timestamps, reconciliation
 // state, etc.) that don't belong on the wire.
 type OperatorConfig struct {
-	Name          string `json:"name"            koanf:"name"            db:"name"`
-	URL           string `json:"url"             koanf:"url"             db:"url"`
-	TLSSkipVerify bool   `json:"tls_skip_verify" koanf:"tls_skip_verify" db:"tls_skip_verify"`
-	Priority      int    `json:"priority"        koanf:"priority"        db:"priority"`
+	Name          string `json:"name"            db:"name"`
+	URL           string `json:"url"             db:"url"`
+	TLSSkipVerify bool   `json:"tls_skip_verify" db:"tls_skip_verify"`
+	Priority      int    `json:"priority"        db:"priority"`
 }
 
-// OperatorAdminSummary is the admin-facing listing shape for operators. It
-// extends OperatorConfig with the row's UUID so admin clients can address an
-// operator by id (which is stable across renames) rather than by name.
+// OperatorAdminSummary is the admin-facing listing shape for operators.
+// It extends OperatorConfig (via embedding) with the row's UUID so admin
+// clients can address an operator by id — which is stable across renames
+// — rather than by name. JSON marshalling and sqlx column scans both
+// flatten the embedded struct, so the wire format is the five fields
+// {id, name, url, tls_skip_verify, priority}.
 type OperatorAdminSummary struct {
-	ID            uuid.UUID `json:"id"              db:"id"`
-	Name          string    `json:"name"            db:"name"`
-	URL           string    `json:"url"             db:"url"`
-	TLSSkipVerify bool      `json:"tls_skip_verify" db:"tls_skip_verify"`
-	Priority      int       `json:"priority"        db:"priority"`
+	ID uuid.UUID `json:"id" db:"id"`
+	OperatorConfig
+}
+
+// UpdateOperatorRequest is the body for PATCH
+// /vice/admin/operators/id/{id}. All fields are optional; only fields
+// whose pointers are non-nil are applied. Pointer types let the wire
+// shape distinguish "client omitted this field" from "client wants to
+// set it to the zero value" — a value-typed shape would silently force
+// priority=0 / tls_skip_verify=false on every PATCH that omitted them.
+type UpdateOperatorRequest struct {
+	Name          *string `json:"name,omitempty"`
+	URL           *string `json:"url,omitempty"`
+	TLSSkipVerify *bool   `json:"tls_skip_verify,omitempty"`
+	Priority      *int    `json:"priority,omitempty"`
 }

--- a/quota/enforcer_test.go
+++ b/quota/enforcer_test.go
@@ -85,11 +85,8 @@ func newTestScheduler(t *testing.T, operators ...operatorclient.OperatorConfig) 
 	summaries := make([]operatorclient.OperatorAdminSummary, len(operators))
 	for i, op := range operators {
 		summaries[i] = operatorclient.OperatorAdminSummary{
-			ID:            uuid.New(),
-			Name:          op.Name,
-			URL:           op.URL,
-			TLSSkipVerify: op.TLSSkipVerify,
-			Priority:      op.Priority,
+			ID:             uuid.New(),
+			OperatorConfig: op,
 		}
 	}
 	s := operatorclient.NewScheduler(nil)

--- a/quota/enforcer_test.go
+++ b/quota/enforcer_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cyverse-de/app-exposer/constants"
 	"github.com/cyverse-de/app-exposer/operatorclient"
 	"github.com/cyverse-de/app-exposer/reporting"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -76,10 +77,23 @@ func newTestEnforcer(t *testing.T, scheduler *operatorclient.Scheduler, lookup *
 	}
 }
 
+// newTestScheduler builds a Scheduler whose operators come from the given
+// OperatorConfig list. Synthesizes a fresh UUID per operator so existing
+// call sites can stay name-keyed (the enforcer doesn't care about ids).
 func newTestScheduler(t *testing.T, operators ...operatorclient.OperatorConfig) *operatorclient.Scheduler {
 	t.Helper()
-	s, err := operatorclient.NewScheduler(operators, nil)
-	require.NoError(t, err)
+	summaries := make([]operatorclient.OperatorAdminSummary, len(operators))
+	for i, op := range operators {
+		summaries[i] = operatorclient.OperatorAdminSummary{
+			ID:            uuid.New(),
+			Name:          op.Name,
+			URL:           op.URL,
+			TLSSkipVerify: op.TLSSkipVerify,
+			Priority:      op.Priority,
+		}
+	}
+	s := operatorclient.NewScheduler(nil)
+	require.NoError(t, s.Sync(summaries))
 	return s
 }
 

--- a/reconciler/reconciler.go
+++ b/reconciler/reconciler.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cyverse-de/app-exposer/operatorclient"
 	"github.com/cyverse-de/app-exposer/reporting"
 	"github.com/cyverse-de/messaging/v12"
+	"github.com/google/uuid"
 	"github.com/jmoiron/sqlx"
 	"github.com/lib/pq"
 	"github.com/sirupsen/logrus"
@@ -29,7 +30,7 @@ var log = common.Log.WithFields(logrus.Fields{"package": "reconciler"})
 // from remote operators into the DE database.
 type Reconciler struct {
 	db          db.ReconcilerDB
-	apps        apps.OperatorNameLookup
+	apps        apps.OperatorLookup
 	scheduler   *operatorclient.Scheduler
 	tokenSource oauth2.TokenSource
 	hostname    string
@@ -42,9 +43,9 @@ type Reconciler struct {
 // operator-change notifications; a URI of "" disables NOTIFY-driven syncs and
 // falls back to periodic polling. The token source is passed through to the
 // scheduler for authenticating requests to operator instances. appsLookup may
-// be nil — in that case the per-pod operator_name back-fill in ReconcileNext
+// be nil — in that case the per-pod operator_id back-fill in ReconcileNext
 // is skipped.
-func New(database db.ReconcilerDB, appsLookup apps.OperatorNameLookup, scheduler *operatorclient.Scheduler, ts oauth2.TokenSource) *Reconciler {
+func New(database db.ReconcilerDB, appsLookup apps.OperatorLookup, scheduler *operatorclient.Scheduler, ts oauth2.TokenSource) *Reconciler {
 	return &Reconciler{
 		db:          database,
 		apps:        appsLookup,
@@ -290,6 +291,8 @@ func (r *Reconciler) Run(ctx context.Context) {
 }
 
 // SyncOperators fetches operators from the DB and updates the scheduler.
+// The scheduler is keyed by id (rebuilt atomically), so callers that look
+// up clients by id remain correct across renames.
 func (r *Reconciler) SyncOperators(ctx context.Context) error {
 	ops, err := r.db.ListOperators(ctx)
 	if err != nil {
@@ -300,18 +303,18 @@ func (r *Reconciler) SyncOperators(ctx context.Context) error {
 		log.Info("no operators found in database")
 	}
 
-	configs := make([]operatorclient.OperatorConfig, 0, len(ops))
+	summaries := make([]operatorclient.OperatorAdminSummary, 0, len(ops))
 	names := make([]string, 0, len(ops))
 	for _, op := range ops {
-		configs = append(configs, op.ToOperatorConfig())
+		summaries = append(summaries, op.ToOperatorAdminSummary())
 		names = append(names, op.Name)
 	}
 
-	if err := r.scheduler.Sync(configs); err != nil {
+	if err := r.scheduler.Sync(summaries); err != nil {
 		return err
 	}
 
-	log.Infof("synced %d operator(s) to scheduler: %v", len(configs), names)
+	log.Infof("synced %d operator(s) to scheduler: %v", len(summaries), names)
 	return nil
 }
 
@@ -320,16 +323,20 @@ func (r *Reconciler) SyncOperators(ctx context.Context) error {
 // coordinated atomically by the database.
 func (r *Reconciler) ReconcileNext(ctx context.Context) error {
 	return r.db.ClaimAndReconcile(ctx, r.hostname, DefaultClaimTTL, func(tx *sqlx.Tx, op *db.Operator) error {
-		log.Infof("reconciling operator %q", op.Name)
+		log.Infof("reconciling operator %q (id=%s)", op.Name, op.ID)
 
-		client := r.scheduler.ClientByName(op.Name)
+		// Look up the scheduler client by the operator's stable id rather
+		// than its current name: this is rename-safe even in the brief
+		// window between a Sync that observed the old name and the post-
+		// rename Sync triggered by the operators NOTIFY trigger.
+		client := r.scheduler.ClientByID(op.ID)
 		if client == nil {
 			clients := r.scheduler.Clients()
 			known := make([]string, 0, len(clients))
 			for _, c := range clients {
-				known = append(known, c.Name())
+				known = append(known, fmt.Sprintf("%s (%s)", c.Name(), c.ID()))
 			}
-			return fmt.Errorf("operator %q not found in scheduler (scheduler has %d operator(s): %v)", op.Name, len(known), known)
+			return fmt.Errorf("operator %q (id=%s) not found in scheduler (scheduler has %d operator(s): %v)", op.Name, op.ID, len(known), known)
 		}
 
 		// Fetch bulk status from operator.
@@ -354,17 +361,17 @@ func (r *Reconciler) ReconcileNext(ctx context.Context) error {
 			} else {
 				log.Infof("reconciled analysis %s", pod.AnalysisID)
 			}
-			// Back-fill the operator name for this analysis if it's missing
+			// Back-fill the operator id for this analysis if it's missing
 			// or stale. The launch path also records this via
-			// setOperatorNameWithRetry, but that retry can exhaust, and
-			// without a recorded name every subsequent request for this
+			// setOperatorIDWithRetry, but that retry can exhaust, and
+			// without a recorded id every subsequent request for this
 			// analysis falls through to the operator fan-out search.
 			//
-			// Back-fill errors are logged inside backfillOperatorName and
+			// Back-fill errors are logged inside backfillOperatorID and
 			// deliberately NOT added to analysisErrs — a failed back-fill
 			// is self-healing on the next cycle and doesn't warrant
 			// rolling back status updates we already collected.
-			r.backfillOperatorName(ctx, pod.AnalysisID, op.Name)
+			r.backfillOperatorID(ctx, pod.AnalysisID, op.ID)
 		}
 
 		if len(analysisErrs) > 0 {
@@ -374,31 +381,32 @@ func (r *Reconciler) ReconcileNext(ctx context.Context) error {
 	})
 }
 
-// backfillOperatorName writes the operator name for an analysis when the
-// DB either has no row yet or has a different name recorded. Errors are
-// logged but never propagate — a failed back-fill just means the next
-// reconciliation cycle will try again, and the fan-out fallback in
-// operatorClientForAnalysis continues to work in the meantime.
-func (r *Reconciler) backfillOperatorName(ctx context.Context, analysisID constants.AnalysisID, operatorName string) {
+// backfillOperatorID writes the operator id for an analysis when the
+// jobs row either has uuid.Nil (NULL) or has a different id recorded
+// (e.g. legacy data). Errors are logged but never propagate — a failed
+// back-fill just means the next reconciliation cycle will try again, and
+// the fan-out fallback in operatorClientForAnalysis continues to work in
+// the meantime.
+func (r *Reconciler) backfillOperatorID(ctx context.Context, analysisID constants.AnalysisID, operatorID uuid.UUID) {
 	if r.apps == nil || analysisID == "" {
 		return
 	}
-	current, err := r.apps.GetOperatorName(ctx, analysisID)
+	current, err := r.apps.GetOperatorID(ctx, analysisID)
 	if err != nil {
-		log.Warnf("backfill: GetOperatorName failed for analysis %s: %v", analysisID, err)
+		log.Warnf("backfill: GetOperatorID failed for analysis %s: %v", analysisID, err)
 		return
 	}
-	if current == operatorName {
+	if current == operatorID {
 		return
 	}
-	if err := r.apps.SetOperatorName(ctx, analysisID, operatorName); err != nil {
-		log.Warnf("backfill: SetOperatorName failed for analysis %s → %q: %v", analysisID, operatorName, err)
+	if err := r.apps.SetOperatorID(ctx, analysisID, operatorID); err != nil {
+		log.Warnf("backfill: SetOperatorID failed for analysis %s → %s: %v", analysisID, operatorID, err)
 		return
 	}
-	if current == "" {
-		log.Infof("backfill: recorded operator %q for analysis %s", operatorName, analysisID)
+	if current == uuid.Nil {
+		log.Infof("backfill: recorded operator %s for analysis %s", operatorID, analysisID)
 	} else {
-		log.Infof("backfill: updated operator for analysis %s from %q to %q", analysisID, current, operatorName)
+		log.Infof("backfill: updated operator for analysis %s from %s to %s", analysisID, current, operatorID)
 	}
 }
 

--- a/reconciler/reconciler_test.go
+++ b/reconciler/reconciler_test.go
@@ -428,7 +428,7 @@ func TestReconcileNext(t *testing.T) {
 		// must match claimOp.ID because ReconcileNext looks up the
 		// scheduler client by id, not name.
 		require.NoError(t, r.scheduler.Sync([]operatorclient.OperatorAdminSummary{
-			{ID: opID, Name: "op-a", URL: srv.URL},
+			{ID: opID, OperatorConfig: operatorclient.OperatorConfig{Name: "op-a", URL: srv.URL}},
 		}))
 
 		err := r.ReconcileNext(context.Background())
@@ -470,7 +470,7 @@ func TestReconcileNext(t *testing.T) {
 		}
 		r := newTestReconciler(t, fake)
 		require.NoError(t, r.scheduler.Sync([]operatorclient.OperatorAdminSummary{
-			{ID: opID, Name: "op-a", URL: srv.URL},
+			{ID: opID, OperatorConfig: operatorclient.OperatorConfig{Name: "op-a", URL: srv.URL}},
 		}))
 
 		err := r.ReconcileNext(context.Background())

--- a/reconciler/reconciler_test.go
+++ b/reconciler/reconciler_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cyverse-de/app-exposer/operatorclient"
 	"github.com/cyverse-de/app-exposer/reporting"
 	"github.com/cyverse-de/messaging/v12"
+	"github.com/google/uuid"
 	"github.com/jmoiron/sqlx"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -39,8 +40,7 @@ func TestGetLocalIP(t *testing.T) {
 // the ip and hostname fields are populated (they are set unconditionally in
 // the constructor).
 func TestNewReconciler(t *testing.T) {
-	scheduler, err := operatorclient.NewScheduler(nil, nil)
-	require.NoError(t, err)
+	scheduler := operatorclient.NewScheduler(nil)
 
 	r := New(&fakeReconcilerDB{}, nil, scheduler, nil)
 
@@ -155,8 +155,7 @@ func (f *fakeReconcilerDB) InsertJobStatusUpdate(_ context.Context, _ *sqlx.Tx, 
 // guards against a nil apps before invoking any back-fill.
 func newTestReconciler(t *testing.T, fake *fakeReconcilerDB) *Reconciler {
 	t.Helper()
-	sched, err := operatorclient.NewScheduler(nil, nil)
-	require.NoError(t, err)
+	sched := operatorclient.NewScheduler(nil)
 	return New(fake, nil, sched, nil)
 }
 
@@ -416,17 +415,20 @@ func TestReconcileNext(t *testing.T) {
 		}
 		srv := newListingServer(t, info)
 
+		opID := uuid.New()
 		fake := &fakeReconcilerDB{
 			statuses: map[constants.ExternalID]messaging.JobState{
 				"ext-1": messaging.SubmittedState, // transition Submitted -> Running
 				"ext-2": messaging.RunningState,   // transition Running -> Failed
 			},
-			claimOp: &db.Operator{Name: "op-a", URL: srv.URL},
+			claimOp: &db.Operator{ID: opID, Name: "op-a", URL: srv.URL},
 		}
 		r := newTestReconciler(t, fake)
-		// Wire the scheduler to know about the claimed operator.
-		require.NoError(t, r.scheduler.Sync([]operatorclient.OperatorConfig{
-			{Name: "op-a", URL: srv.URL},
+		// Wire the scheduler to know about the claimed operator. The id
+		// must match claimOp.ID because ReconcileNext looks up the
+		// scheduler client by id, not name.
+		require.NoError(t, r.scheduler.Sync([]operatorclient.OperatorAdminSummary{
+			{ID: opID, Name: "op-a", URL: srv.URL},
 		}))
 
 		err := r.ReconcileNext(context.Background())
@@ -444,7 +446,7 @@ func TestReconcileNext(t *testing.T) {
 
 	t.Run("returns descriptive error when operator is not in scheduler", func(t *testing.T) {
 		fake := &fakeReconcilerDB{
-			claimOp: &db.Operator{Name: "op-missing", URL: "http://unused.invalid"},
+			claimOp: &db.Operator{ID: uuid.New(), Name: "op-missing", URL: "http://unused.invalid"},
 		}
 		r := newTestReconciler(t, fake)
 		// Scheduler intentionally has no clients.
@@ -462,12 +464,13 @@ func TestReconcileNext(t *testing.T) {
 		}))
 		t.Cleanup(srv.Close)
 
+		opID := uuid.New()
 		fake := &fakeReconcilerDB{
-			claimOp: &db.Operator{Name: "op-a", URL: srv.URL},
+			claimOp: &db.Operator{ID: opID, Name: "op-a", URL: srv.URL},
 		}
 		r := newTestReconciler(t, fake)
-		require.NoError(t, r.scheduler.Sync([]operatorclient.OperatorConfig{
-			{Name: "op-a", URL: srv.URL},
+		require.NoError(t, r.scheduler.Sync([]operatorclient.OperatorAdminSummary{
+			{ID: opID, Name: "op-a", URL: srv.URL},
 		}))
 
 		err := r.ReconcileNext(context.Background())


### PR DESCRIPTION
The operator operations were grabbing references from the database by name rather than ID. That causes some hoop-jumping and potential race-conditions in app-exposer and makes it more difficult to write code against the APIs. This PR should standardize on referring to operators by ID.

Also, this PR removes configuring operators in the config, it's all DB driven now and has been for a bit. The YAML config for operators was vestigial and needs to be removed.