### PR TITLE
Keycloak reconfig

### DIFF
--- a/cmd/vice-operator/app.go
+++ b/cmd/vice-operator/app.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"net/http"
+	"slices"
 	"strings"
 
 	"github.com/coreos/go-oidc/v3/oidc"
@@ -24,10 +25,12 @@ type App struct {
 
 // NewApp creates a new App with all operator routes registered.
 // When verifier is non-nil, all API routes require a valid Keycloak JWT Bearer
-// token (or a valid session cookie set by the Swagger login flow).
+// token (or a valid session cookie set by the Swagger login flow). The token
+// must additionally carry adminRole in realm_access.roles or at least one
+// value in adminEntitlements in its entitlement claim — the API is admin-only.
 // swaggerCfg controls the Swagger UI login gate; when disabled, docs are served
 // without authentication.
-func NewApp(op *operator.Operator, verifier *oidc.IDTokenVerifier, expectedClientID string, swaggerCfg *SwaggerAuthConfig) *App {
+func NewApp(op *operator.Operator, verifier *oidc.IDTokenVerifier, expectedClientID string, swaggerCfg *SwaggerAuthConfig, adminRole string, adminEntitlements []string) *App {
 	e := echo.New()
 	e.Use(middleware.Logger())
 	e.Use(middleware.Recover())
@@ -59,7 +62,7 @@ func NewApp(op *operator.Operator, verifier *oidc.IDTokenVerifier, expectedClien
 	// All API routes go through an optional auth group.
 	api := e.Group("")
 	if verifier != nil {
-		api.Use(bearerAuthMiddleware(verifier, expectedClientID, swaggerCfg))
+		api.Use(bearerAuthMiddleware(verifier, expectedClientID, swaggerCfg, adminRole, adminEntitlements))
 	}
 	api.GET("/capacity", op.HandleCapacity)
 	api.POST("/analyses", op.HandleLaunch)
@@ -146,7 +149,12 @@ func stripBearer(auth string) (string, bool) {
 // the client ID rather than "aud", so the standard audience check is skipped and
 // azp is verified manually against the expected API client ID and (optionally)
 // the Swagger UI client ID.
-func bearerAuthMiddleware(verifier *oidc.IDTokenVerifier, expectedClientID string, swaggerCfg *SwaggerAuthConfig) echo.MiddlewareFunc {
+//
+// After azp validation, the token must additionally carry adminRole in
+// realm_access.roles[] or at least one value in adminEntitlements in its
+// entitlement claim. This restricts the API to service accounts that hold the
+// role and to admin users whose group memberships surface as entitlements.
+func bearerAuthMiddleware(verifier *oidc.IDTokenVerifier, expectedClientID string, swaggerCfg *SwaggerAuthConfig, adminRole string, adminEntitlements []string) echo.MiddlewareFunc {
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {
 			var rawToken string
@@ -169,9 +177,15 @@ func bearerAuthMiddleware(verifier *oidc.IDTokenVerifier, expectedClientID strin
 				return echo.NewHTTPError(http.StatusUnauthorized, "invalid token: "+err.Error())
 			}
 
-			// Extract azp (authorized party) from the token claims.
+			// Pull every claim we need in a single Claims() call. Re-parsing
+			// the token a second time for the role/entitlement check would
+			// double the JSON-decode cost on every request.
 			var claims struct {
-				AZP string `json:"azp"`
+				AZP         string `json:"azp"`
+				RealmAccess struct {
+					Roles []string `json:"roles"`
+				} `json:"realm_access"`
+				Entitlement []string `json:"entitlement"`
 			}
 			if err := token.Claims(&claims); err != nil {
 				return echo.NewHTTPError(http.StatusUnauthorized, "failed to parse token claims: "+err.Error())
@@ -182,7 +196,34 @@ func bearerAuthMiddleware(verifier *oidc.IDTokenVerifier, expectedClientID strin
 				return echo.NewHTTPError(http.StatusForbidden, "unauthorized client")
 			}
 
+			// Admin gate: realm role OR entitlement intersection. The role
+			// path is how service accounts get in; the entitlement path is
+			// how human admins get in via group membership.
+			if !allowedByAdminGate(claims.RealmAccess.Roles, claims.Entitlement, adminRole, adminEntitlements) {
+				return echo.NewHTTPError(http.StatusForbidden, "insufficient privileges")
+			}
+
 			return next(c)
 		}
 	}
+}
+
+// allowedByAdminGate reports whether a token with the given realm roles and
+// entitlement values should be admitted by the API's admin gate. A token
+// passes if it carries adminRole in roles, or if any of its entitlements
+// appears in adminEntitlements.
+func allowedByAdminGate(roles, entitlements []string, adminRole string, adminEntitlements []string) bool {
+	return slices.Contains(roles, adminRole) || anyMatch(entitlements, adminEntitlements)
+}
+
+// anyMatch reports whether any element of a is also present in b. Used for
+// the entitlement-intersection check; both inputs are typically very small
+// (≤10 entries) so a nested loop beats building a set.
+func anyMatch(a, b []string) bool {
+	for _, v := range a {
+		if slices.Contains(b, v) {
+			return true
+		}
+	}
+	return false
 }

--- a/cmd/vice-operator/app_test.go
+++ b/cmd/vice-operator/app_test.go
@@ -169,6 +169,79 @@ func TestBuildSwaggerAuthConfigCookieSecret(t *testing.T) {
 	}
 }
 
+func TestAllowedByAdminGate(t *testing.T) {
+	const role = "vice-operator"
+	allowedEnts := []string{"core-services", "tito-admins"}
+
+	tests := []struct {
+		name         string
+		roles        []string
+		entitlements []string
+		adminRole    string
+		allowedEnts  []string
+		want         bool
+	}{
+		{"role only", []string{"vice-operator"}, nil, role, allowedEnts, true},
+		{"entitlement only", nil, []string{"tito-admins"}, role, allowedEnts, true},
+		{"both role and entitlement", []string{"vice-operator"}, []string{"core-services"}, role, allowedEnts, true},
+		{"neither", []string{"some-other-role"}, []string{"users"}, role, allowedEnts, false},
+		{"empty claims", nil, nil, role, allowedEnts, false},
+		{"role match with extra roles present", []string{"users", "vice-operator", "default-roles-cyverse"}, nil, role, allowedEnts, true},
+		{"entitlement match among many", nil, []string{"users", "core-services", "students"}, role, allowedEnts, true},
+		{"custom admin role", []string{"vice-ops"}, nil, "vice-ops", allowedEnts, true},
+		{"custom admin role rejects default", []string{"vice-operator"}, nil, "vice-ops", allowedEnts, false},
+		{"empty allowed entitlements + role match", []string{"vice-operator"}, nil, role, nil, true},
+		{"empty allowed entitlements + entitlement-only token", nil, []string{"core-services"}, role, nil, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := allowedByAdminGate(tt.roles, tt.entitlements, tt.adminRole, tt.allowedEnts)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestAnyMatch(t *testing.T) {
+	tests := []struct {
+		name string
+		a, b []string
+		want bool
+	}{
+		{"both empty", nil, nil, false},
+		{"first empty", nil, []string{"x"}, false},
+		{"second empty", []string{"x"}, nil, false},
+		{"single match", []string{"x"}, []string{"x"}, true},
+		{"no overlap", []string{"a", "b"}, []string{"c", "d"}, false},
+		{"partial overlap", []string{"a", "b", "c"}, []string{"x", "b", "y"}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, anyMatch(tt.a, tt.b))
+		})
+	}
+}
+
+func TestParseAdminEntitlements(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		{"empty", "", nil},
+		{"single", "core-services", []string{"core-services"}},
+		{"multiple", "core-services,tito-admins,dev", []string{"core-services", "tito-admins", "dev"}},
+		{"whitespace around entries", "  core-services , tito-admins  ", []string{"core-services", "tito-admins"}},
+		{"empty entries dropped", "core-services,,tito-admins,", []string{"core-services", "tito-admins"}},
+		{"only commas", ",,,", nil},
+		{"only whitespace", "   ", nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, parseAdminEntitlements(tt.in))
+		})
+	}
+}
+
 func TestStripBearer(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/cmd/vice-operator/helpers.go
+++ b/cmd/vice-operator/helpers.go
@@ -40,6 +40,20 @@ func parseSelector(s string) (map[string]string, error) {
 	return result, nil
 }
 
+// parseAdminEntitlements splits a comma-separated entitlement list, trims
+// whitespace, and drops empty entries. An empty input yields an empty slice
+// (which means "no entitlement-claim values are accepted as admin").
+func parseAdminEntitlements(raw string) []string {
+	var out []string
+	for part := range strings.SplitSeq(raw, ",") {
+		part = strings.TrimSpace(part)
+		if part != "" {
+			out = append(out, part)
+		}
+	}
+	return out
+}
+
 // stringSliceFlag implements flag.Value for repeatable string flags.
 type stringSliceFlag []string
 

--- a/cmd/vice-operator/main.go
+++ b/cmd/vice-operator/main.go
@@ -30,6 +30,8 @@ func main() {
 		apiAuth               bool
 		apiAuthIssuerURL      string
 		apiAuthClientID       string
+		adminRole             string
+		adminEntitlementsRaw  string
 		viceBaseURL           string
 		clusterConfigSecret   string
 		imagePullSecret       string
@@ -76,6 +78,8 @@ func main() {
 	flag.BoolVar(&apiAuth, "api-auth", true, "Enable OIDC JWT Bearer auth for the API")
 	flag.StringVar(&apiAuthIssuerURL, "api-auth-issuer-url", "", "OIDC issuer URL for API auth (e.g. https://keycloak.example.com/realms/cyverse)")
 	flag.StringVar(&apiAuthClientID, "api-auth-client-id", "", "Expected client ID (azp claim) for API auth")
+	flag.StringVar(&adminRole, "admin-role", "vice-operator", "Realm role that grants API access (or ADMIN_ROLE env var)")
+	flag.StringVar(&adminEntitlementsRaw, "admin-entitlements", "", "Comma-separated list of entitlement-claim values that grant API access (or ADMIN_ENTITLEMENTS env var)")
 	flag.StringVar(&viceBaseURL, "vice-base-url", "https://cyverse.run", "Base URL for VICE, stored in the cluster config secret")
 	flag.StringVar(&clusterConfigSecret, "cluster-config-secret", "cluster-config-secret", "Name of the K8s Secret holding cluster config")
 	flag.StringVar(&imagePullSecret, "image-pull-secret", "vice-image-pull-secret", "Name of the K8s image pull Secret")
@@ -123,6 +127,17 @@ func main() {
 	envFallback(&keycloakClientSecret, "KEYCLOAK_CLIENT_SECRET")
 	envFallback(&swaggerClientSecret, "SWAGGER_CLIENT_SECRET")
 	envFallback(&swaggerCookieSecret, "SWAGGER_COOKIE_SECRET")
+	envFallback(&adminEntitlementsRaw, "ADMIN_ENTITLEMENTS")
+	// admin-role defaults to "vice-operator"; the env fallback only kicks in
+	// when the flag wasn't passed explicitly. The current envFallback helper
+	// can't distinguish "not passed" from "passed empty," so handle this one
+	// inline: respect the env override only when the flag default is unchanged.
+	if adminRole == "vice-operator" {
+		if v := os.Getenv("ADMIN_ROLE"); v != "" {
+			adminRole = v
+		}
+	}
+	adminEntitlements := parseAdminEntitlements(adminEntitlementsRaw)
 
 	// Validate OIDC auth flags.
 	if apiAuth && (apiAuthIssuerURL == "" || apiAuthClientID == "") {
@@ -168,6 +183,10 @@ func main() {
 		"KEYCLOAK_REALM":         keycloakRealm,
 		"KEYCLOAK_CLIENT_ID":     keycloakClientID,
 		"KEYCLOAK_CLIENT_SECRET": keycloakClientSecret,
+		// Propagated to vice-proxy (via EnvFrom) so it can grant admins
+		// access to running analyses regardless of the per-analysis
+		// allowed-users list.
+		"ADMIN_ENTITLEMENTS": adminEntitlementsRaw,
 	}
 	if disableViceProxyAuth {
 		clusterConfig["DISABLE_AUTH"] = "true"
@@ -327,7 +346,7 @@ func main() {
 		log.Fatalf("%v", err)
 	}
 
-	app := NewApp(op, verifier, apiAuthClientID, swaggerCfg)
+	app := NewApp(op, verifier, apiAuthClientID, swaggerCfg, adminRole, adminEntitlements)
 	loadingApp := NewLoadingApp(op)
 
 	apiAddr := fmt.Sprintf(":%d", port)

--- a/cmd/vice-operator/main.go
+++ b/cmd/vice-operator/main.go
@@ -128,11 +128,18 @@ func main() {
 	envFallback(&swaggerClientSecret, "SWAGGER_CLIENT_SECRET")
 	envFallback(&swaggerCookieSecret, "SWAGGER_COOKIE_SECRET")
 	envFallback(&adminEntitlementsRaw, "ADMIN_ENTITLEMENTS")
-	// admin-role defaults to "vice-operator"; the env fallback only kicks in
-	// when the flag wasn't passed explicitly. The current envFallback helper
-	// can't distinguish "not passed" from "passed empty," so handle this one
-	// inline: respect the env override only when the flag default is unchanged.
-	if adminRole == "vice-operator" {
+	// --admin-role has a non-empty default, so the envFallback "is empty?"
+	// trick can't distinguish "user passed default" from "user didn't pass
+	// anything." Walk visited flags to detect explicit-set, then apply the
+	// env override only when the user wasn't explicit. This makes the
+	// explicit flag always win over the env var.
+	adminRoleSet := false
+	flag.Visit(func(f *flag.Flag) {
+		if f.Name == "admin-role" {
+			adminRoleSet = true
+		}
+	})
+	if !adminRoleSet {
 		if v := os.Getenv("ADMIN_ROLE"); v != "" {
 			adminRole = v
 		}

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -1170,21 +1170,18 @@ const docTemplate = `{
                     },
                     {
                         "type": "integer",
-                        "format": "int64",
                         "description": "The number of seconds in the past to begin showing logs",
                         "name": "since",
                         "in": "query"
                     },
                     {
                         "type": "integer",
-                        "format": "int64",
                         "description": "The number of seconds since the epoch to begin showing logs",
                         "name": "since-time",
                         "in": "query"
                     },
                     {
                         "type": "integer",
-                        "format": "int64",
                         "description": "The number of lines from the end of the log to show",
                         "name": "tail-lines",
                         "in": "query"
@@ -2328,7 +2325,6 @@ const docTemplate = `{
         },
         "intstr.Type": {
             "type": "integer",
-            "format": "int64",
             "enum": [
                 0,
                 1
@@ -2337,10 +2333,6 @@ const docTemplate = `{
                 "Int": "The IntOrString holds an int.",
                 "String": "The IntOrString holds a string."
             },
-            "x-enum-descriptions": [
-                "The IntOrString holds an int.",
-                "The IntOrString holds a string."
-            ],
             "x-enum-varnames": [
                 "Int",
                 "String"
@@ -3433,11 +3425,6 @@ const docTemplate = `{
                         "DecimalExponent": "e.g., 12e6",
                         "DecimalSI": "e.g., 12M  (12 * 10^6)"
                     },
-                    "x-enum-descriptions": [
-                        "e.g., 12e6",
-                        "e.g., 12Mi (12 * 2^20)",
-                        "e.g., 12M  (12 * 10^6)"
-                    ],
                     "x-enum-varnames": [
                         "DecimalExponent",
                         "BinarySI",
@@ -4053,8 +4040,7 @@ const docTemplate = `{
                     "additionalProperties": {
                         "type": "array",
                         "items": {
-                            "type": "integer",
-                            "format": "int32"
+                            "type": "integer"
                         }
                     }
                 },
@@ -9879,12 +9865,6 @@ const docTemplate = `{
                 "StorageMediumHugePagesPrefix": "prefix for full medium notation HugePages-\u003csize\u003e",
                 "StorageMediumMemory": "use memory (e.g. tmpfs on linux)"
             },
-            "x-enum-descriptions": [
-                "use whatever the default is for the node, assume anything we don't explicitly handle is this",
-                "use memory (e.g. tmpfs on linux)",
-                "use hugepages",
-                "prefix for full medium notation HugePages-\u003csize\u003e"
-            ],
             "x-enum-varnames": [
                 "StorageMediumDefault",
                 "StorageMediumMemory",

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -1164,21 +1164,18 @@
                     },
                     {
                         "type": "integer",
-                        "format": "int64",
                         "description": "The number of seconds in the past to begin showing logs",
                         "name": "since",
                         "in": "query"
                     },
                     {
                         "type": "integer",
-                        "format": "int64",
                         "description": "The number of seconds since the epoch to begin showing logs",
                         "name": "since-time",
                         "in": "query"
                     },
                     {
                         "type": "integer",
-                        "format": "int64",
                         "description": "The number of lines from the end of the log to show",
                         "name": "tail-lines",
                         "in": "query"
@@ -2322,7 +2319,6 @@
         },
         "intstr.Type": {
             "type": "integer",
-            "format": "int64",
             "enum": [
                 0,
                 1
@@ -2331,10 +2327,6 @@
                 "Int": "The IntOrString holds an int.",
                 "String": "The IntOrString holds a string."
             },
-            "x-enum-descriptions": [
-                "The IntOrString holds an int.",
-                "The IntOrString holds a string."
-            ],
             "x-enum-varnames": [
                 "Int",
                 "String"
@@ -3427,11 +3419,6 @@
                         "DecimalExponent": "e.g., 12e6",
                         "DecimalSI": "e.g., 12M  (12 * 10^6)"
                     },
-                    "x-enum-descriptions": [
-                        "e.g., 12e6",
-                        "e.g., 12Mi (12 * 2^20)",
-                        "e.g., 12M  (12 * 10^6)"
-                    ],
                     "x-enum-varnames": [
                         "DecimalExponent",
                         "BinarySI",
@@ -4047,8 +4034,7 @@
                     "additionalProperties": {
                         "type": "array",
                         "items": {
-                            "type": "integer",
-                            "format": "int32"
+                            "type": "integer"
                         }
                     }
                 },
@@ -9873,12 +9859,6 @@
                 "StorageMediumHugePagesPrefix": "prefix for full medium notation HugePages-\u003csize\u003e",
                 "StorageMediumMemory": "use memory (e.g. tmpfs on linux)"
             },
-            "x-enum-descriptions": [
-                "use whatever the default is for the node, assume anything we don't explicitly handle is this",
-                "use memory (e.g. tmpfs on linux)",
-                "use hugepages",
-                "prefix for full medium notation HugePages-\u003csize\u003e"
-            ],
             "x-enum-varnames": [
                 "StorageMediumDefault",
                 "StorageMediumMemory",

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -424,14 +424,10 @@ definitions:
     enum:
     - 0
     - 1
-    format: int64
     type: integer
     x-enum-comments:
       Int: The IntOrString holds an int.
       String: The IntOrString holds a string.
-    x-enum-descriptions:
-    - The IntOrString holds an int.
-    - The IntOrString holds a string.
     x-enum-varnames:
     - Int
     - String
@@ -1220,10 +1216,6 @@ definitions:
           BinarySI: e.g., 12Mi (12 * 2^20)
           DecimalExponent: e.g., 12e6
           DecimalSI: e.g., 12M  (12 * 10^6)
-        x-enum-descriptions:
-        - e.g., 12e6
-        - e.g., 12Mi (12 * 2^20)
-        - e.g., 12M  (12 * 10^6)
         x-enum-varnames:
         - DecimalExponent
         - BinarySI
@@ -2061,7 +2053,6 @@ definitions:
       binaryData:
         additionalProperties:
           items:
-            format: int32
             type: integer
           type: array
         description: |-
@@ -10414,12 +10405,6 @@ definitions:
       StorageMediumHugePages: use hugepages
       StorageMediumHugePagesPrefix: prefix for full medium notation HugePages-<size>
       StorageMediumMemory: use memory (e.g. tmpfs on linux)
-    x-enum-descriptions:
-    - use whatever the default is for the node, assume anything we don't explicitly
-      handle is this
-    - use memory (e.g. tmpfs on linux)
-    - use hugepages
-    - prefix for full medium notation HugePages-<size>
     x-enum-varnames:
     - StorageMediumDefault
     - StorageMediumMemory
@@ -11447,17 +11432,14 @@ paths:
         name: previous
         type: boolean
       - description: The number of seconds in the past to begin showing logs
-        format: int64
         in: query
         name: since
         type: integer
       - description: The number of seconds since the epoch to begin showing logs
-        format: int64
         in: query
         name: since-time
         type: integer
       - description: The number of lines from the end of the log to show
-        format: int64
         in: query
         name: tail-lines
         type: integer

--- a/operatordocs/operator_docs.go
+++ b/operatordocs/operator_docs.go
@@ -986,7 +986,6 @@ const docTemplateoperator = `{
         },
         "intstr.Type": {
             "type": "integer",
-            "format": "int64",
             "enum": [
                 0,
                 1
@@ -995,10 +994,6 @@ const docTemplateoperator = `{
                 "Int": "The IntOrString holds an int.",
                 "String": "The IntOrString holds a string."
             },
-            "x-enum-descriptions": [
-                "The IntOrString holds an int.",
-                "The IntOrString holds a string."
-            ],
             "x-enum-varnames": [
                 "Int",
                 "String"
@@ -1794,11 +1789,6 @@ const docTemplateoperator = `{
                         "DecimalExponent": "e.g., 12e6",
                         "DecimalSI": "e.g., 12M  (12 * 10^6)"
                     },
-                    "x-enum-descriptions": [
-                        "e.g., 12e6",
-                        "e.g., 12Mi (12 * 2^20)",
-                        "e.g., 12M  (12 * 10^6)"
-                    ],
                     "x-enum-varnames": [
                         "DecimalExponent",
                         "BinarySI",
@@ -2414,8 +2404,7 @@ const docTemplateoperator = `{
                     "additionalProperties": {
                         "type": "array",
                         "items": {
-                            "type": "integer",
-                            "format": "int32"
+                            "type": "integer"
                         }
                     }
                 },
@@ -8240,12 +8229,6 @@ const docTemplateoperator = `{
                 "StorageMediumHugePagesPrefix": "prefix for full medium notation HugePages-\u003csize\u003e",
                 "StorageMediumMemory": "use memory (e.g. tmpfs on linux)"
             },
-            "x-enum-descriptions": [
-                "use whatever the default is for the node, assume anything we don't explicitly handle is this",
-                "use memory (e.g. tmpfs on linux)",
-                "use hugepages",
-                "prefix for full medium notation HugePages-\u003csize\u003e"
-            ],
             "x-enum-varnames": [
                 "StorageMediumDefault",
                 "StorageMediumMemory",

--- a/operatordocs/operator_swagger.json
+++ b/operatordocs/operator_swagger.json
@@ -979,7 +979,6 @@
         },
         "intstr.Type": {
             "type": "integer",
-            "format": "int64",
             "enum": [
                 0,
                 1
@@ -988,10 +987,6 @@
                 "Int": "The IntOrString holds an int.",
                 "String": "The IntOrString holds a string."
             },
-            "x-enum-descriptions": [
-                "The IntOrString holds an int.",
-                "The IntOrString holds a string."
-            ],
             "x-enum-varnames": [
                 "Int",
                 "String"
@@ -1787,11 +1782,6 @@
                         "DecimalExponent": "e.g., 12e6",
                         "DecimalSI": "e.g., 12M  (12 * 10^6)"
                     },
-                    "x-enum-descriptions": [
-                        "e.g., 12e6",
-                        "e.g., 12Mi (12 * 2^20)",
-                        "e.g., 12M  (12 * 10^6)"
-                    ],
                     "x-enum-varnames": [
                         "DecimalExponent",
                         "BinarySI",
@@ -2407,8 +2397,7 @@
                     "additionalProperties": {
                         "type": "array",
                         "items": {
-                            "type": "integer",
-                            "format": "int32"
+                            "type": "integer"
                         }
                     }
                 },
@@ -8233,12 +8222,6 @@
                 "StorageMediumHugePagesPrefix": "prefix for full medium notation HugePages-\u003csize\u003e",
                 "StorageMediumMemory": "use memory (e.g. tmpfs on linux)"
             },
-            "x-enum-descriptions": [
-                "use whatever the default is for the node, assume anything we don't explicitly handle is this",
-                "use memory (e.g. tmpfs on linux)",
-                "use hugepages",
-                "prefix for full medium notation HugePages-\u003csize\u003e"
-            ],
             "x-enum-varnames": [
                 "StorageMediumDefault",
                 "StorageMediumMemory",

--- a/operatordocs/operator_swagger.yaml
+++ b/operatordocs/operator_swagger.yaml
@@ -23,14 +23,10 @@ definitions:
     enum:
     - 0
     - 1
-    format: int64
     type: integer
     x-enum-comments:
       Int: The IntOrString holds an int.
       String: The IntOrString holds a string.
-    x-enum-descriptions:
-    - The IntOrString holds an int.
-    - The IntOrString holds a string.
     x-enum-varnames:
     - Int
     - String
@@ -607,10 +603,6 @@ definitions:
           BinarySI: e.g., 12Mi (12 * 2^20)
           DecimalExponent: e.g., 12e6
           DecimalSI: e.g., 12M  (12 * 10^6)
-        x-enum-descriptions:
-        - e.g., 12e6
-        - e.g., 12Mi (12 * 2^20)
-        - e.g., 12M  (12 * 10^6)
         x-enum-varnames:
         - DecimalExponent
         - BinarySI
@@ -1448,7 +1440,6 @@ definitions:
       binaryData:
         additionalProperties:
           items:
-            format: int32
             type: integer
           type: array
         description: |-
@@ -9801,12 +9792,6 @@ definitions:
       StorageMediumHugePages: use hugepages
       StorageMediumHugePagesPrefix: prefix for full medium notation HugePages-<size>
       StorageMediumMemory: use memory (e.g. tmpfs on linux)
-    x-enum-descriptions:
-    - use whatever the default is for the node, assume anything we don't explicitly
-      handle is this
-    - use memory (e.g. tmpfs on linux)
-    - use hugepages
-    - prefix for full medium notation HugePages-<size>
     x-enum-varnames:
     - StorageMediumDefault
     - StorageMediumMemory


### PR DESCRIPTION
Adds new logic to vice-operator for admitting users/callers to the API. Admins and callers in the vice-operator Keycloak group can use the API. Admins can access the Swagger UI and the analyses. Regular users can only access analyses (that they have permissions for, but that's been the case for a while).