### PR TITLE
Per-operator VICE base URL (operators.base_url)

### DIFF
--- a/cmd/vice-operator-tool/main.go
+++ b/cmd/vice-operator-tool/main.go
@@ -60,6 +60,15 @@ func main() {
 	}
 }
 
+// derefOr returns the pointee of p, or fallback when p is nil. Used to render
+// the nullable base_url field for human-readable output.
+func derefOr(p *string, fallback string) string {
+	if p == nil {
+		return fallback
+	}
+	return *p
+}
+
 // requireBaseURL validates and parses the --app-exposer-url flag.
 func requireBaseURL(raw string) *url.URL {
 	if raw == "" {
@@ -80,13 +89,14 @@ func runAdd(baseURLStr string, args []string) {
 	fs := flag.NewFlagSet("add", flag.ExitOnError)
 	name := fs.String("name", "", "Operator name (required)")
 	opURL := fs.String("url", "", "Operator URL (required)")
+	baseURL := fs.String("base-url", "", "VICE landing-domain base URL for analyses on this operator (required)")
 	tlsSkip := fs.Bool("tls-skip-verify", false, "Skip TLS certificate verification")
 	priority := fs.Int("priority", 0, "Scheduling priority (lower = tried first, default 0)")
 	// ExitOnError means Parse calls os.Exit on failure; it never returns a non-nil error.
 	_ = fs.Parse(args) //nolint:errcheck // see comment above
 
-	if *name == "" || *opURL == "" {
-		fmt.Fprintln(os.Stderr, "error: --name and --url are required")
+	if *name == "" || *opURL == "" || *baseURL == "" {
+		fmt.Fprintln(os.Stderr, "error: --name, --url, and --base-url are required")
 		fs.Usage()
 		os.Exit(1)
 	}
@@ -97,14 +107,15 @@ func runAdd(baseURLStr string, args []string) {
 		URL:           *opURL,
 		TLSSkipVerify: *tlsSkip,
 		Priority:      *priority,
+		BaseURL:       baseURL,
 	})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(1)
 	}
 
-	fmt.Printf("Operator %q added successfully (id=%s, url=%s, priority=%d, tls_skip_verify=%v)\n",
-		summary.Name, summary.ID, summary.URL, summary.Priority, summary.TLSSkipVerify)
+	fmt.Printf("Operator %q added successfully (id=%s, url=%s, base_url=%s, priority=%d, tls_skip_verify=%v)\n",
+		summary.Name, summary.ID, summary.URL, derefOr(summary.BaseURL, "-"), summary.Priority, summary.TLSSkipVerify)
 }
 
 // resolveOperatorID looks up an operator by name and returns its UUID.
@@ -144,9 +155,9 @@ func runList(baseURLStr string, args []string) {
 	}
 
 	w := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
-	fmt.Fprintln(w, "ID\tNAME\tURL\tPRIORITY\tTLS_SKIP_VERIFY") //nolint:errcheck
+	fmt.Fprintln(w, "ID\tNAME\tURL\tBASE_URL\tPRIORITY\tTLS_SKIP_VERIFY") //nolint:errcheck
 	for _, op := range ops {
-		fmt.Fprintf(w, "%s\t%s\t%s\t%d\t%v\n", op.ID, op.Name, op.URL, op.Priority, op.TLSSkipVerify) //nolint:errcheck
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%d\t%v\n", op.ID, op.Name, op.URL, derefOr(op.BaseURL, "-"), op.Priority, op.TLSSkipVerify) //nolint:errcheck
 	}
 	if err := w.Flush(); err != nil {
 		fmt.Fprintf(os.Stderr, "error: flushing tabwriter: %v\n", err)
@@ -160,6 +171,7 @@ func runUpdate(baseURLStr string, args []string) {
 	name := fs.String("name", "", "Current operator name (required, used to look up the row)")
 	newName := fs.String("new-name", "", "New operator name (rename)")
 	opURL := fs.String("url", "", "New operator URL")
+	baseURL := fs.String("base-url", "", "New VICE landing-domain base URL")
 	tlsSkip := fs.Bool("tls-skip-verify", false, "Set TLS skip-verify flag")
 	priority := fs.Int("priority", 0, "Set scheduling priority")
 	// ExitOnError means Parse calls os.Exit on failure; it never returns a non-nil error.
@@ -182,6 +194,8 @@ func runUpdate(baseURLStr string, args []string) {
 			req.Name = newName
 		case "url":
 			req.URL = opURL
+		case "base-url":
+			req.BaseURL = baseURL
 		case "tls-skip-verify":
 			req.TLSSkipVerify = tlsSkip
 		case "priority":
@@ -189,8 +203,8 @@ func runUpdate(baseURLStr string, args []string) {
 		}
 	})
 
-	if req.Name == nil && req.URL == nil && req.TLSSkipVerify == nil && req.Priority == nil {
-		fmt.Fprintln(os.Stderr, "error: at least one of --new-name, --url, --tls-skip-verify, --priority must be set")
+	if req.Name == nil && req.URL == nil && req.BaseURL == nil && req.TLSSkipVerify == nil && req.Priority == nil {
+		fmt.Fprintln(os.Stderr, "error: at least one of --new-name, --url, --base-url, --tls-skip-verify, --priority must be set")
 		os.Exit(1)
 	}
 
@@ -217,11 +231,11 @@ func runUpdate(baseURLStr string, args []string) {
 	// "old → new" only when they differ to keep the steady-state path
 	// terse.
 	if *name != summary.Name {
-		fmt.Printf("Operator %q → %q updated successfully (id=%s, url=%s, priority=%d, tls_skip_verify=%v)\n",
-			*name, summary.Name, summary.ID, summary.URL, summary.Priority, summary.TLSSkipVerify)
+		fmt.Printf("Operator %q → %q updated successfully (id=%s, url=%s, base_url=%s, priority=%d, tls_skip_verify=%v)\n",
+			*name, summary.Name, summary.ID, summary.URL, derefOr(summary.BaseURL, "-"), summary.Priority, summary.TLSSkipVerify)
 	} else {
-		fmt.Printf("Operator %q updated successfully (id=%s, url=%s, priority=%d, tls_skip_verify=%v)\n",
-			summary.Name, summary.ID, summary.URL, summary.Priority, summary.TLSSkipVerify)
+		fmt.Printf("Operator %q updated successfully (id=%s, url=%s, base_url=%s, priority=%d, tls_skip_verify=%v)\n",
+			summary.Name, summary.ID, summary.URL, derefOr(summary.BaseURL, "-"), summary.Priority, summary.TLSSkipVerify)
 	}
 }
 

--- a/db/operators.go
+++ b/db/operators.go
@@ -13,14 +13,11 @@ import (
 
 // Operator models the operators table.
 type Operator struct {
-	ID            uuid.UUID `db:"id"`
-	Name          string    `db:"name"`
-	URL           string    `db:"url"`
-	TLSSkipVerify bool      `db:"tls_skip_verify"`
-	Priority      int       `db:"priority"`
-	// BaseURL is the VICE landing-domain base URL for analyses launched on
-	// this operator (e.g. https://sandbox.cyverse.rocks). Nullable: legacy
-	// rows predate the column.
+	ID               uuid.UUID  `db:"id"`
+	Name             string     `db:"name"`
+	URL              string     `db:"url"`
+	TLSSkipVerify    bool       `db:"tls_skip_verify"`
+	Priority         int        `db:"priority"`
 	BaseURL          *string    `db:"base_url"`
 	LastReconciledAt *time.Time `db:"last_reconciled_at"`
 	ReconciledBy     *string    `db:"reconciled_by"`
@@ -58,7 +55,7 @@ func (o *Operator) ToOperatorConfig() operatorclient.OperatorConfig {
 }
 
 // ToOperatorAdminSummary projects the DB's full Operator row down to the
-// admin-facing summary shape (id plus the five public config fields).
+// admin-facing summary shape.
 // Reuses ToOperatorConfig for the embedded config so the projection stays
 // in lock-step if OperatorConfig gains a new field. Used by handlers that
 // return a single row's identity to admin clients — notably create and
@@ -85,10 +82,10 @@ func (d *Database) ListOperators(ctx context.Context) ([]Operator, error) {
 }
 
 // ListOperatorAdminSummaries returns the admin-listing fields of every
-// operator (id plus the five public config fields), ordered by priority
-// (lower values first) with creation time as tiebreaker. Including id lets
-// admin clients address an operator by its stable UUID rather than by name,
-// which is important for PATCH where the operator may be renamed.
+// operator, ordered by priority (lower values first) with creation time as
+// tiebreaker. Including id lets admin clients address an operator by its
+// stable UUID rather than by name, which is important for PATCH where the
+// operator may be renamed.
 func (d *Database) ListOperatorAdminSummaries(ctx context.Context) ([]operatorclient.OperatorAdminSummary, error) {
 	ops := make([]operatorclient.OperatorAdminSummary, 0)
 	const query = `

--- a/db/operators.go
+++ b/db/operators.go
@@ -58,7 +58,7 @@ func (o *Operator) ToOperatorConfig() operatorclient.OperatorConfig {
 }
 
 // ToOperatorAdminSummary projects the DB's full Operator row down to the
-// admin-facing summary shape (id plus the four public config fields).
+// admin-facing summary shape (id plus the five public config fields).
 // Reuses ToOperatorConfig for the embedded config so the projection stays
 // in lock-step if OperatorConfig gains a new field. Used by handlers that
 // return a single row's identity to admin clients — notably create and
@@ -85,7 +85,7 @@ func (d *Database) ListOperators(ctx context.Context) ([]Operator, error) {
 }
 
 // ListOperatorAdminSummaries returns the admin-listing fields of every
-// operator (id plus the four public config fields), ordered by priority
+// operator (id plus the five public config fields), ordered by priority
 // (lower values first) with creation time as tiebreaker. Including id lets
 // admin clients address an operator by its stable UUID rather than by name,
 // which is important for PATCH where the operator may be renamed.
@@ -134,6 +134,11 @@ func (d *Database) DeleteOperatorByID(ctx context.Context, id uuid.UUID) error {
 // NOTIFY trigger; base_url is not (it is consumed by the apps service, not
 // app-exposer's scheduler). Reconciliation columns are intentionally
 // reconciler-only and not exposed here.
+//
+// Because UpdateOperatorByID applies fields with COALESCE, a nil pointer
+// means "leave unchanged" — there is no way to clear base_url back to NULL
+// once set. That is intentional: base_url is required from creation onward,
+// so the only NULL rows are legacy operators that predate the column.
 type OperatorUpdate struct {
 	Name          *string
 	URL           *string

--- a/db/operators.go
+++ b/db/operators.go
@@ -13,11 +13,15 @@ import (
 
 // Operator models the operators table.
 type Operator struct {
-	ID               uuid.UUID  `db:"id"`
-	Name             string     `db:"name"`
-	URL              string     `db:"url"`
-	TLSSkipVerify    bool       `db:"tls_skip_verify"`
-	Priority         int        `db:"priority"`
+	ID            uuid.UUID `db:"id"`
+	Name          string    `db:"name"`
+	URL           string    `db:"url"`
+	TLSSkipVerify bool      `db:"tls_skip_verify"`
+	Priority      int       `db:"priority"`
+	// BaseURL is the VICE landing-domain base URL for analyses launched on
+	// this operator (e.g. https://sandbox.cyverse.rocks). Nullable: legacy
+	// rows predate the column.
+	BaseURL          *string    `db:"base_url"`
 	LastReconciledAt *time.Time `db:"last_reconciled_at"`
 	ReconciledBy     *string    `db:"reconciled_by"`
 	CreatedAt        time.Time  `db:"created_at"`
@@ -49,6 +53,7 @@ func (o *Operator) ToOperatorConfig() operatorclient.OperatorConfig {
 		URL:           o.URL,
 		TLSSkipVerify: o.TLSSkipVerify,
 		Priority:      o.Priority,
+		BaseURL:       o.BaseURL,
 	}
 }
 
@@ -70,7 +75,7 @@ func (o *Operator) ToOperatorAdminSummary() operatorclient.OperatorAdminSummary 
 func (d *Database) ListOperators(ctx context.Context) ([]Operator, error) {
 	var ops []Operator
 	const query = `
-		SELECT id, name, url, tls_skip_verify, priority,
+		SELECT id, name, url, tls_skip_verify, priority, base_url,
 		       last_reconciled_at, reconciled_by, created_at, updated_at
 		FROM operators
 		ORDER BY priority ASC, created_at ASC
@@ -87,7 +92,7 @@ func (d *Database) ListOperators(ctx context.Context) ([]Operator, error) {
 func (d *Database) ListOperatorAdminSummaries(ctx context.Context) ([]operatorclient.OperatorAdminSummary, error) {
 	ops := make([]operatorclient.OperatorAdminSummary, 0)
 	const query = `
-		SELECT id, name, url, tls_skip_verify, priority
+		SELECT id, name, url, tls_skip_verify, priority, base_url
 		FROM operators
 		ORDER BY priority ASC, created_at ASC
 	`
@@ -99,13 +104,13 @@ func (d *Database) ListOperatorAdminSummaries(ctx context.Context) ([]operatorcl
 // created row with DB-generated fields (id, created_at, updated_at) populated.
 func (d *Database) InsertOperator(ctx context.Context, op *Operator) (*Operator, error) {
 	const query = `
-		INSERT INTO operators (name, url, tls_skip_verify, priority)
-		VALUES ($1, $2, $3, $4)
-		RETURNING id, name, url, tls_skip_verify, priority,
+		INSERT INTO operators (name, url, tls_skip_verify, priority, base_url)
+		VALUES ($1, $2, $3, $4, $5)
+		RETURNING id, name, url, tls_skip_verify, priority, base_url,
 		          last_reconciled_at, reconciled_by, created_at, updated_at
 	`
 	var created Operator
-	err := d.db.QueryRowxContext(ctx, query, op.Name, op.URL, op.TLSSkipVerify, op.Priority).StructScan(&created)
+	err := d.db.QueryRowxContext(ctx, query, op.Name, op.URL, op.TLSSkipVerify, op.Priority, op.BaseURL).StructScan(&created)
 	if err != nil {
 		return nil, err
 	}
@@ -124,15 +129,17 @@ func (d *Database) DeleteOperatorByID(ctx context.Context, id uuid.UUID) error {
 }
 
 // OperatorUpdate carries the optional fields for a partial-update of an
-// operator row. A nil pointer leaves the column unchanged. Only fields that
-// the AFTER UPDATE NOTIFY trigger covers (name, url, tls_skip_verify,
-// priority) are exposed here; reconciliation columns are intentionally
-// reconciler-only.
+// operator row. A nil pointer leaves the column unchanged. The name, url,
+// tls_skip_verify, and priority columns are covered by the AFTER UPDATE
+// NOTIFY trigger; base_url is not (it is consumed by the apps service, not
+// app-exposer's scheduler). Reconciliation columns are intentionally
+// reconciler-only and not exposed here.
 type OperatorUpdate struct {
 	Name          *string
 	URL           *string
 	TLSSkipVerify *bool
 	Priority      *int
+	BaseURL       *string
 }
 
 // UpdateOperatorByID applies a partial update to the operator row identified
@@ -154,13 +161,14 @@ func (d *Database) UpdateOperatorByID(ctx context.Context, id uuid.UUID, upd Ope
 		SET name            = COALESCE($2, name),
 		    url             = COALESCE($3, url),
 		    tls_skip_verify = COALESCE($4, tls_skip_verify),
-		    priority        = COALESCE($5, priority)
+		    priority        = COALESCE($5, priority),
+		    base_url        = COALESCE($6, base_url)
 		WHERE id = $1
-		RETURNING id, name, url, tls_skip_verify, priority,
+		RETURNING id, name, url, tls_skip_verify, priority, base_url,
 		          last_reconciled_at, reconciled_by, created_at, updated_at
 	`
 	var updated Operator
-	err := d.db.QueryRowxContext(ctx, query, id, upd.Name, upd.URL, upd.TLSSkipVerify, upd.Priority).StructScan(&updated)
+	err := d.db.QueryRowxContext(ctx, query, id, upd.Name, upd.URL, upd.TLSSkipVerify, upd.Priority, upd.BaseURL).StructScan(&updated)
 	if err != nil {
 		return nil, err
 	}
@@ -180,7 +188,7 @@ func (d *Database) ClaimAndReconcile(ctx context.Context, hostname string, recon
 	defer tx.Rollback() //nolint:errcheck // rollback after commit is a no-op
 
 	const claimQuery = `
-		SELECT id, name, url, tls_skip_verify, priority,
+		SELECT id, name, url, tls_skip_verify, priority, base_url,
 		       last_reconciled_at, reconciled_by, created_at, updated_at
 		FROM operators
 		WHERE last_reconciled_at IS NULL OR last_reconciled_at < $1

--- a/db/operators_test.go
+++ b/db/operators_test.go
@@ -85,12 +85,12 @@ func TestUpdateOperatorByID(t *testing.T) {
 	id := uuid.MustParse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
 	now := time.Now()
 
-	const expectedSQL = `UPDATE operators SET name = COALESCE($2, name), url = COALESCE($3, url), tls_skip_verify = COALESCE($4, tls_skip_verify), priority = COALESCE($5, priority) WHERE id = $1 RETURNING id, name, url, tls_skip_verify, priority, last_reconciled_at, reconciled_by, created_at, updated_at`
+	const expectedSQL = `UPDATE operators SET name = COALESCE($2, name), url = COALESCE($3, url), tls_skip_verify = COALESCE($4, tls_skip_verify), priority = COALESCE($5, priority), base_url = COALESCE($6, base_url) WHERE id = $1 RETURNING id, name, url, tls_skip_verify, priority, base_url, last_reconciled_at, reconciled_by, created_at, updated_at`
 
 	// returnedColumns matches the RETURNING list so StructScan can populate
 	// the *Operator struct on the success path.
 	returnedColumns := []string{
-		"id", "name", "url", "tls_skip_verify", "priority",
+		"id", "name", "url", "tls_skip_verify", "priority", "base_url",
 		"last_reconciled_at", "reconciled_by", "created_at", "updated_at",
 	}
 
@@ -102,8 +102,8 @@ func TestUpdateOperatorByID(t *testing.T) {
 		name string
 		upd  OperatorUpdate
 		// wantArgs is the argument slice in the order the production query
-		// binds them: [id, name, url, tls_skip_verify, priority]. Any
-		// driver.Value here is matched literally; nil represents SQL NULL.
+		// binds them: [id, name, url, tls_skip_verify, priority, base_url].
+		// Any driver.Value here is matched literally; nil represents SQL NULL.
 		wantArgs []driver.Value
 		// dbErr is what sqlmock returns; nil means "succeed and return a row".
 		dbErr error
@@ -111,33 +111,39 @@ func TestUpdateOperatorByID(t *testing.T) {
 		{
 			name:     "single field — priority only",
 			upd:      OperatorUpdate{Priority: intPtr(7)},
-			wantArgs: []driver.Value{id.String(), nil, nil, nil, int64(7)},
+			wantArgs: []driver.Value{id.String(), nil, nil, nil, int64(7), nil},
 		},
 		{
 			name:     "rename only",
 			upd:      OperatorUpdate{Name: strPtr("renamed")},
-			wantArgs: []driver.Value{id.String(), "renamed", nil, nil, nil},
+			wantArgs: []driver.Value{id.String(), "renamed", nil, nil, nil, nil},
 		},
 		{
-			name: "all four fields",
+			name:     "base_url only",
+			upd:      OperatorUpdate{BaseURL: strPtr("https://a.cyverse.run")},
+			wantArgs: []driver.Value{id.String(), nil, nil, nil, nil, "https://a.cyverse.run"},
+		},
+		{
+			name: "all fields",
 			upd: OperatorUpdate{
 				Name:          strPtr("a"),
 				URL:           strPtr("https://a.example.com"),
 				TLSSkipVerify: boolPtr(true),
 				Priority:      intPtr(2),
+				BaseURL:       strPtr("https://a.cyverse.run"),
 			},
-			wantArgs: []driver.Value{id.String(), "a", "https://a.example.com", true, int64(2)},
+			wantArgs: []driver.Value{id.String(), "a", "https://a.example.com", true, int64(2), "https://a.cyverse.run"},
 		},
 		{
 			name:     "no row matches — surfaces sql.ErrNoRows from RETURNING",
 			upd:      OperatorUpdate{Priority: intPtr(1)},
-			wantArgs: []driver.Value{id.String(), nil, nil, nil, int64(1)},
+			wantArgs: []driver.Value{id.String(), nil, nil, nil, int64(1), nil},
 			dbErr:    sql.ErrNoRows,
 		},
 		{
 			name:     "unique violation — surfaces *pq.Error 23505",
 			upd:      OperatorUpdate{Name: strPtr("dup")},
-			wantArgs: []driver.Value{id.String(), "dup", nil, nil, nil},
+			wantArgs: []driver.Value{id.String(), "dup", nil, nil, nil, nil},
 			dbErr:    &pq.Error{Code: "23505", Message: "duplicate key value violates unique constraint"},
 		},
 	}
@@ -153,7 +159,7 @@ func TestUpdateOperatorByID(t *testing.T) {
 				expect.WillReturnError(tt.dbErr)
 			} else {
 				rows := sqlmock.NewRows(returnedColumns).
-					AddRow(id, "n", "https://u", false, 0, sql.NullTime{}, sql.NullString{}, now, now)
+					AddRow(id, "n", "https://u", false, 0, sql.NullString{}, sql.NullTime{}, sql.NullString{}, now, now)
 				expect.WillReturnRows(rows)
 			}
 

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -2977,6 +2977,10 @@ const docTemplate = `{
         "operatorclient.OperatorAdminSummary": {
             "type": "object",
             "properties": {
+                "base_url": {
+                    "description": "BaseURL is the VICE landing-domain base URL for analyses launched on\nthis operator. A pointer because the column is nullable: legacy rows\npredate it. Required when creating an operator.",
+                    "type": "string"
+                },
                 "id": {
                     "type": "string"
                 },
@@ -2997,6 +3001,10 @@ const docTemplate = `{
         "operatorclient.OperatorConfig": {
             "type": "object",
             "properties": {
+                "base_url": {
+                    "description": "BaseURL is the VICE landing-domain base URL for analyses launched on\nthis operator. A pointer because the column is nullable: legacy rows\npredate it. Required when creating an operator.",
+                    "type": "string"
+                },
                 "name": {
                     "type": "string"
                 },
@@ -3025,6 +3033,9 @@ const docTemplate = `{
         "operatorclient.UpdateOperatorRequest": {
             "type": "object",
             "properties": {
+                "base_url": {
+                    "type": "string"
+                },
                 "name": {
                     "type": "string"
                 },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -2971,6 +2971,10 @@
         "operatorclient.OperatorAdminSummary": {
             "type": "object",
             "properties": {
+                "base_url": {
+                    "description": "BaseURL is the VICE landing-domain base URL for analyses launched on\nthis operator. A pointer because the column is nullable: legacy rows\npredate it. Required when creating an operator.",
+                    "type": "string"
+                },
                 "id": {
                     "type": "string"
                 },
@@ -2991,6 +2995,10 @@
         "operatorclient.OperatorConfig": {
             "type": "object",
             "properties": {
+                "base_url": {
+                    "description": "BaseURL is the VICE landing-domain base URL for analyses launched on\nthis operator. A pointer because the column is nullable: legacy rows\npredate it. Required when creating an operator.",
+                    "type": "string"
+                },
                 "name": {
                     "type": "string"
                 },
@@ -3019,6 +3027,9 @@
         "operatorclient.UpdateOperatorRequest": {
             "type": "object",
             "properties": {
+                "base_url": {
+                    "type": "string"
+                },
                 "name": {
                     "type": "string"
                 },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -920,6 +920,12 @@ definitions:
     type: object
   operatorclient.OperatorAdminSummary:
     properties:
+      base_url:
+        description: |-
+          BaseURL is the VICE landing-domain base URL for analyses launched on
+          this operator. A pointer because the column is nullable: legacy rows
+          predate it. Required when creating an operator.
+        type: string
       id:
         type: string
       name:
@@ -933,6 +939,12 @@ definitions:
     type: object
   operatorclient.OperatorConfig:
     properties:
+      base_url:
+        description: |-
+          BaseURL is the VICE landing-domain base URL for analyses launched on
+          this operator. A pointer because the column is nullable: legacy rows
+          predate it. Required when creating an operator.
+        type: string
       name:
         type: string
       priority:
@@ -951,6 +963,8 @@ definitions:
     type: object
   operatorclient.UpdateOperatorRequest:
     properties:
+      base_url:
+        type: string
       name:
         type: string
       priority:

--- a/httphandlers/handlers.go
+++ b/httphandlers/handlers.go
@@ -622,8 +622,8 @@ func (h *HTTPHandlers) CreateOperatorHandler(c echo.Context) error {
 		return operatorWriteError("insert", req.Name, err)
 	}
 
-	// Project to the admin-summary shape: id plus the five public config
-	// fields. Drops timestamps and reconciliation state.
+	// Project to the admin-summary shape, dropping timestamps and
+	// reconciliation state.
 	return c.JSON(http.StatusCreated, created.ToOperatorAdminSummary())
 }
 

--- a/httphandlers/handlers.go
+++ b/httphandlers/handlers.go
@@ -522,24 +522,35 @@ func (h *HTTPHandlers) AdminOperatorCapacitiesHandler(c echo.Context) error {
 	return c.JSON(http.StatusOK, results)
 }
 
-// validateOperatorFields validates the optional name and url for an
-// operator request. nil pointers indicate the field is absent (a valid
+// validateOperatorFields validates the optional name, url, and base_url for
+// an operator request. nil pointers indicate the field is absent (a valid
 // state for a partial update); non-nil pointers are validated against the
 // same rules the operators table's CHECK and UNIQUE constraints enforce —
-// non-whitespace text, and for url an HTTP(S) URL with a host. Uniqueness
-// is checked at the DB layer rather than here.
-func validateOperatorFields(name, urlStr *string) error {
+// non-whitespace text, and for the URL fields an HTTP(S) URL with a host.
+// Uniqueness is checked at the DB layer rather than here. Requiredness (e.g.
+// base_url at create time) is enforced by the calling handler, not here.
+func validateOperatorFields(name, urlStr, baseURL *string) error {
 	if name != nil && strings.TrimSpace(*name) == "" {
 		return echo.NewHTTPError(http.StatusBadRequest, "name must not be empty or whitespace")
 	}
-	if urlStr != nil {
-		if strings.TrimSpace(*urlStr) == "" {
-			return echo.NewHTTPError(http.StatusBadRequest, "url must not be empty or whitespace")
-		}
-		parsed, err := url.Parse(*urlStr)
-		if err != nil || (parsed.Scheme != "http" && parsed.Scheme != "https") || parsed.Host == "" {
-			return echo.NewHTTPError(http.StatusBadRequest, "url must be a valid HTTP(S) URL")
-		}
+	if err := validateHTTPURL("url", urlStr); err != nil {
+		return err
+	}
+	return validateHTTPURL("base_url", baseURL)
+}
+
+// validateHTTPURL checks that a non-nil pointer holds a non-whitespace
+// HTTP(S) URL with a host. A nil pointer (absent field) is valid.
+func validateHTTPURL(field string, urlStr *string) error {
+	if urlStr == nil {
+		return nil
+	}
+	if strings.TrimSpace(*urlStr) == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, field+" must not be empty or whitespace")
+	}
+	parsed, err := url.Parse(*urlStr)
+	if err != nil || (parsed.Scheme != "http" && parsed.Scheme != "https") || parsed.Host == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, field+" must be a valid HTTP(S) URL")
 	}
 	return nil
 }
@@ -586,9 +597,13 @@ func (h *HTTPHandlers) CreateOperatorHandler(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
 
-	// Both fields are required at create time, so pass them as non-nil to
-	// reuse the same validator the update path uses for present-fields.
-	if err := validateOperatorFields(&req.Name, &req.URL); err != nil {
+	// name, url, and base_url are all required at create time. base_url is a
+	// pointer (nullable column), so its presence is checked explicitly here;
+	// name and url are value types and always "present".
+	if req.BaseURL == nil || strings.TrimSpace(*req.BaseURL) == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "base_url is required")
+	}
+	if err := validateOperatorFields(&req.Name, &req.URL, req.BaseURL); err != nil {
 		return err
 	}
 
@@ -597,6 +612,7 @@ func (h *HTTPHandlers) CreateOperatorHandler(c echo.Context) error {
 		URL:           req.URL,
 		TLSSkipVerify: req.TLSSkipVerify,
 		Priority:      req.Priority,
+		BaseURL:       req.BaseURL,
 	}
 
 	created, err := h.db.InsertOperator(ctx, op)
@@ -641,11 +657,11 @@ func (h *HTTPHandlers) UpdateOperatorHandler(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
 
-	if req.Name == nil && req.URL == nil && req.TLSSkipVerify == nil && req.Priority == nil {
+	if req.Name == nil && req.URL == nil && req.TLSSkipVerify == nil && req.Priority == nil && req.BaseURL == nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "request body must update at least one field")
 	}
 
-	if err := validateOperatorFields(req.Name, req.URL); err != nil {
+	if err := validateOperatorFields(req.Name, req.URL, req.BaseURL); err != nil {
 		return err
 	}
 
@@ -654,6 +670,7 @@ func (h *HTTPHandlers) UpdateOperatorHandler(c echo.Context) error {
 		URL:           req.URL,
 		TLSSkipVerify: req.TLSSkipVerify,
 		Priority:      req.Priority,
+		BaseURL:       req.BaseURL,
 	})
 	if errors.Is(err, sql.ErrNoRows) {
 		return echo.NewHTTPError(http.StatusNotFound, "operator not found")

--- a/httphandlers/handlers.go
+++ b/httphandlers/handlers.go
@@ -599,8 +599,10 @@ func (h *HTTPHandlers) CreateOperatorHandler(c echo.Context) error {
 
 	// name, url, and base_url are all required at create time. base_url is a
 	// pointer (nullable column), so its presence is checked explicitly here;
-	// name and url are value types and always "present".
-	if req.BaseURL == nil || strings.TrimSpace(*req.BaseURL) == "" {
+	// name and url are value types and always "present". Format/whitespace
+	// validation is left to validateOperatorFields so the error messages
+	// stay consistent across all three fields.
+	if req.BaseURL == nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "base_url is required")
 	}
 	if err := validateOperatorFields(&req.Name, &req.URL, req.BaseURL); err != nil {
@@ -620,7 +622,7 @@ func (h *HTTPHandlers) CreateOperatorHandler(c echo.Context) error {
 		return operatorWriteError("insert", req.Name, err)
 	}
 
-	// Project to the admin-summary shape: id plus the four public config
+	// Project to the admin-summary shape: id plus the five public config
 	// fields. Drops timestamps and reconciliation state.
 	return c.JSON(http.StatusCreated, created.ToOperatorAdminSummary())
 }

--- a/httphandlers/operators_test.go
+++ b/httphandlers/operators_test.go
@@ -16,10 +16,11 @@ func TestValidateOperatorFields(t *testing.T) {
 	strPtr := func(s string) *string { return &s }
 
 	tests := []struct {
-		name    string
-		nameArg *string
-		urlArg  *string
-		wantErr bool
+		name       string
+		nameArg    *string
+		urlArg     *string
+		baseURLArg *string
+		wantErr    bool
 		// wantStatus is checked only when wantErr is true.
 		wantStatus int
 	}{
@@ -95,11 +96,28 @@ func TestValidateOperatorFields(t *testing.T) {
 			urlArg:  strPtr("http://op.example.com"),
 			wantErr: false,
 		},
+		{
+			name:       "valid base_url accepted",
+			baseURLArg: strPtr("https://sandbox.cyverse.rocks"),
+			wantErr:    false,
+		},
+		{
+			name:       "whitespace base_url rejected",
+			baseURLArg: strPtr("   "),
+			wantErr:    true,
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "non-HTTP base_url rejected",
+			baseURLArg: strPtr("ftp://sandbox.cyverse.rocks"),
+			wantErr:    true,
+			wantStatus: http.StatusBadRequest,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := validateOperatorFields(tt.nameArg, tt.urlArg)
+			err := validateOperatorFields(tt.nameArg, tt.urlArg, tt.baseURLArg)
 			if tt.wantErr {
 				if assert.Error(t, err) {
 					httpErr, ok := err.(*echo.HTTPError)

--- a/operator/resources.go
+++ b/operator/resources.go
@@ -53,10 +53,46 @@ func upsert[T metav1.Object](ctx context.Context, client k8sResource[T], kind, n
 	return nil
 }
 
+// normalizeNamespaces forces metadata.namespace on every namespaced bundle
+// resource to the operator's namespace. app-exposer builds bundles without
+// knowledge of the target cluster's namespace; most resources arrive with it
+// unset, but the HTTPRoute carries the source cluster's VICE namespace. The
+// K8s API rejects a Create/Update whose object namespace differs from the
+// request namespace, so any stray value must be overwritten here.
+// PersistentVolumes are cluster-scoped and intentionally left alone.
+func (o *Operator) normalizeNamespaces(bundle *operatorclient.AnalysisBundle) {
+	for _, cm := range bundle.ConfigMaps {
+		if cm != nil {
+			cm.Namespace = o.namespace
+		}
+	}
+	for _, pvc := range bundle.PersistentVolumeClaims {
+		if pvc != nil {
+			pvc.Namespace = o.namespace
+		}
+	}
+	if bundle.Deployment != nil {
+		bundle.Deployment.Namespace = o.namespace
+	}
+	if bundle.Service != nil {
+		bundle.Service.Namespace = o.namespace
+	}
+	if bundle.HTTPRoute != nil {
+		bundle.HTTPRoute.Namespace = o.namespace
+	}
+	if bundle.PodDisruptionBudget != nil {
+		bundle.PodDisruptionBudget.Namespace = o.namespace
+	}
+}
+
 // applyBundle creates or updates all K8s resources in the bundle.
 func (o *Operator) applyBundle(ctx context.Context, bundle *operatorclient.AnalysisBundle) error {
 	log.Infof("applying bundle for analysis %s (%d configmaps, %d pvs, %d pvcs)",
 		bundle.AnalysisID, len(bundle.ConfigMaps), len(bundle.PersistentVolumes), len(bundle.PersistentVolumeClaims))
+
+	// Resources arrive with namespaces that may not match this cluster; align
+	// them with the operator's namespace before any Create/Update call.
+	o.normalizeNamespaces(bundle)
 
 	for _, cm := range bundle.ConfigMaps {
 		if cm == nil {

--- a/operatorclient/types.go
+++ b/operatorclient/types.go
@@ -276,14 +276,11 @@ type URLReadyResponse struct {
 // access that needs the write-only fields (timestamps, reconciliation
 // state, etc.) that don't belong on the wire.
 type OperatorConfig struct {
-	Name          string `json:"name"            db:"name"`
-	URL           string `json:"url"             db:"url"`
-	TLSSkipVerify bool   `json:"tls_skip_verify" db:"tls_skip_verify"`
-	Priority      int    `json:"priority"        db:"priority"`
-	// BaseURL is the VICE landing-domain base URL for analyses launched on
-	// this operator. A pointer because the column is nullable: legacy rows
-	// predate it. Required when creating an operator.
-	BaseURL *string `json:"base_url,omitempty" db:"base_url"`
+	Name          string  `json:"name"               db:"name"`
+	URL           string  `json:"url"                db:"url"`
+	TLSSkipVerify bool    `json:"tls_skip_verify"    db:"tls_skip_verify"`
+	Priority      int     `json:"priority"           db:"priority"`
+	BaseURL       *string `json:"base_url,omitempty" db:"base_url"` // required at create; nil only for legacy rows
 }
 
 // OperatorAdminSummary is the admin-facing listing shape for operators.

--- a/operatorclient/types.go
+++ b/operatorclient/types.go
@@ -290,8 +290,8 @@ type OperatorConfig struct {
 // It extends OperatorConfig (via embedding) with the row's UUID so admin
 // clients can address an operator by id — which is stable across renames
 // — rather than by name. JSON marshalling and sqlx column scans both
-// flatten the embedded struct, so the wire format is the five fields
-// {id, name, url, tls_skip_verify, priority}.
+// flatten the embedded struct, so the wire format is the six fields
+// {id, name, url, base_url, tls_skip_verify, priority}.
 type OperatorAdminSummary struct {
 	ID uuid.UUID `json:"id" db:"id"`
 	OperatorConfig

--- a/operatorclient/types.go
+++ b/operatorclient/types.go
@@ -280,6 +280,10 @@ type OperatorConfig struct {
 	URL           string `json:"url"             db:"url"`
 	TLSSkipVerify bool   `json:"tls_skip_verify" db:"tls_skip_verify"`
 	Priority      int    `json:"priority"        db:"priority"`
+	// BaseURL is the VICE landing-domain base URL for analyses launched on
+	// this operator. A pointer because the column is nullable: legacy rows
+	// predate it. Required when creating an operator.
+	BaseURL *string `json:"base_url,omitempty" db:"base_url"`
 }
 
 // OperatorAdminSummary is the admin-facing listing shape for operators.
@@ -304,4 +308,5 @@ type UpdateOperatorRequest struct {
 	URL           *string `json:"url,omitempty"`
 	TLSSkipVerify *bool   `json:"tls_skip_verify,omitempty"`
 	Priority      *int    `json:"priority,omitempty"`
+	BaseURL       *string `json:"base_url,omitempty"`
 }


### PR DESCRIPTION
## Summary

- Adds a `base_url` field — the VICE landing-domain base URL for analyses launched on an operator (e.g. `https://sandbox.cyverse.rocks`) — to the `Operator` db model, the `operatorclient` config/update types, the admin create/update HTTP handlers, and the `vice-operator-tool` `add`/`list`/`update` subcommands. Required at create, optional on update; the column is nullable so pre-existing rows are unaffected.
- Also normalizes bundle resource namespaces in the operator (separate commit): `applyBundle` now forces `metadata.namespace` on every namespaced bundle resource to the operator's own namespace, fixing a 500 (`the namespace of the provided object does not match...`) when the HTTPRoute arrived carrying the source cluster's namespace.

## Context

VICE analyses can now be scheduled onto different Kubernetes clusters, each fronted by its own `vice-operator`. The `base_url` metadata lets the `apps` service build interactive-app URLs that point at the cluster actually running the analysis instead of a single static domain.

Depends on cyverse-de/de-database#37 (adds the `operators.base_url` column). Companion `apps` PR builds the URLs from this data. All three repos share the `operator-base-url` branch.

## Test plan

- [x] `go build ./...`, `go test ./...`
- [x] swagger docs regenerated (`just docs`, `just operator-docs`)
- [ ] `vice-operator-tool add` without `--base-url` returns 400; with it persists
- [ ] `vice-operator-tool list` shows the `BASE_URL` column; `update --base-url` changes it
- [ ] launch on a non-default operator no longer 500s on HTTPRoute create

🤖 Generated with [Claude Code](https://claude.com/claude-code)