### PR TITLE
Move local-storage-class config from app-exposer to vice-operator

### DIFF
--- a/cmd/app-exposer/app.go
+++ b/cmd/app-exposer/app.go
@@ -54,7 +54,6 @@ type ExposerAppInit struct {
 	dbase                   *db.Database
 	MaxConcurrentLaunches   int
 	ImagePullSecretName     string
-	LocalStorageClass       string
 	ClusterConfigSecretName string
 	BypassUsers             []string
 }
@@ -127,7 +126,6 @@ func NewExposerApp(init *ExposerAppInit, apps *apps.Apps, conn *nats.EncodedConn
 		GatewayProvider:               c.String("vice.gateway_provider"),
 		ClusterConfigSecretName:       init.ClusterConfigSecretName,
 		NATSEncodedConn:               conn,
-		LocalStorageClass:             init.LocalStorageClass,
 		BypassUsers:                   init.BypassUsers,
 		TimeLimitExtensionSeconds:     timeLimitExtensionSeconds,
 	}

--- a/cmd/app-exposer/main.go
+++ b/cmd/app-exposer/main.go
@@ -86,7 +86,6 @@ func main() {
 		namespace                            = flag.String("namespace", "default", "The namespace scope this process operates on for non-VICE calls")
 		viceNamespace                        = flag.String("vice-namespace", "vice-apps", "The namespace that VICE apps are launched within")
 		listenPort                           = flag.Int("port", 60000, "(optional) The port to listen on")
-		localStorageClass                    = flag.String("local-storage-class", "openebs-hostpath", "The storage class to use for the persistent host path volume")
 		viceProxy                            = flag.String("vice-proxy", "harbor.cyverse.org/de/vice-proxy", "The image name of the proxy to use for VICE apps. The image tag is set in the config.")
 		transferImage                        = flag.String("transfer-image", "harbor.cyverse.org/de/gocmd:latest", "(optional) Image used to transfer files to/from the data store")
 		transferWorkingDir                   = flag.String("transfer-working-dir", "/de-app-work", "The working directory within the file transfer image.")
@@ -380,7 +379,6 @@ func main() {
 		batchadapter:            jexAdapter,
 		dbase:                   dbase,
 		ImagePullSecretName:     imagePullSecretName,
-		LocalStorageClass:       *localStorageClass,
 		ClusterConfigSecretName: *clusterConfigSecret,
 		BypassUsers:             bypassUsers,
 		MaxConcurrentLaunches:   *maxConcurrentLaunches,

--- a/cmd/vice-operator/main.go
+++ b/cmd/vice-operator/main.go
@@ -69,6 +69,7 @@ func main() {
 		ingressPodExceptions  stringSliceFlag
 		disableInternetAccess bool
 		userSuffix            string
+		localStorageClass     string
 	)
 
 	flag.StringVar(&kubeconfig, "kubeconfig", "", "Path to kubeconfig (empty for in-cluster)")
@@ -119,6 +120,7 @@ func main() {
 	flag.Var(&ingressPodExceptions, "ingress-pod-exception", "Cross-namespace ingress source as kubernetes.io/metadata.name=<ns>,pod-label=val (repeatable). The kubernetes.io/metadata.name pair selects the namespace; remaining pairs select pods.")
 	flag.BoolVar(&disableInternetAccess, "disable-internet-access", false, "Block analysis pods from reaching the public internet; only DNS, explicit host/CIDR exceptions, and pod exceptions are allowed")
 	flag.StringVar(&userSuffix, "user-suffix", constants.DefaultUserSuffix, "Domain suffix appended to usernames if not already present")
+	flag.StringVar(&localStorageClass, "local-storage-class", "", "StorageClass for the per-analysis working-dir PVC (e.g. openebs-hostpath, gp3); empty means use the cluster's default storage class")
 	flag.Parse()
 
 	// Allow secrets to come from environment variables when not set on the
@@ -361,6 +363,7 @@ func main() {
 		ClusterConfigSecret: clusterConfigSecret,
 		EgressConfig:        egressConfig,
 		UserSuffix:          userSuffix,
+		LocalStorageClass:   localStorageClass,
 	})
 	if err != nil {
 		log.Fatalf("failed to construct operator: %v", err)

--- a/incluster/deployments_test.go
+++ b/incluster/deployments_test.go
@@ -33,7 +33,6 @@ func baseInit() *Init {
 		PermissionsURL:                "http://permissions.prod",
 		IRODSZone:                     "example",
 		GatewayProvider:               "traefik",
-		LocalStorageClass:             "example",
 	}
 }
 

--- a/incluster/incluster.go
+++ b/incluster/incluster.go
@@ -53,7 +53,6 @@ type Init struct {
 	PermissionsURL                string
 	IRODSZone                     string
 	GatewayProvider               string
-	LocalStorageClass             string
 	ClusterConfigSecretName       string
 	NATSEncodedConn               *nats.EncodedConn
 	BypassUsers                   []string

--- a/incluster/volumes.go
+++ b/incluster/volumes.go
@@ -262,7 +262,9 @@ func (i *Incluster) getVolumeClaims(ctx context.Context, job *model.Job) ([]*api
 			AccessModes: []apiv1.PersistentVolumeAccessMode{
 				apiv1.ReadWriteOnce,
 			},
-			StorageClassName: &i.LocalStorageClass,
+			// StorageClassName is intentionally left unset. vice-operator
+			// fills it in per-cluster via its --local-storage-class flag;
+			// an empty value here means "use the cluster default".
 			Resources: apiv1.VolumeResourceRequirements{
 				Requests: apiv1.ResourceList{
 					apiv1.ResourceStorage: i.getPersistentVolumeCapacity(job),

--- a/k8s/app-exposer.yml
+++ b/k8s/app-exposer.yml
@@ -55,8 +55,6 @@ spec:
             - "$(APP_EXPOSER_NAMESPACE)"
             - --user-suffix
             - "$(USER_SUFFIX)"
-            - --local-storage-class
-            - "$(VICE_LOCAL_STORAGE_CLASS)"
             - --log-level
             - debug
             - --cluster-config-secret
@@ -93,11 +91,6 @@ spec:
                 secretKeyRef:
                   name: configs
                   key: NATS_URLS
-            - name: VICE_LOCAL_STORAGE_CLASS
-              valueFrom:
-                secretKeyRef:
-                  name: configs
-                  key: VICE_LOCAL_STORAGE_CLASS
             - name: CLUSTER_CONFIG_SECRET
               valueFrom:
                 secretKeyRef:

--- a/operator/handlers.go
+++ b/operator/handlers.go
@@ -63,6 +63,7 @@ type Operator struct {
 	egressConfig        NetworkPolicyConfig // Egress policy config for per-analysis policies.
 	httpClient          HTTPClient          // Client for contacting the vice-proxy sidecar.
 	userSuffix          string              // Domain suffix for usernames (e.g. "@iplantcollaborative.org").
+	localStorageClass   string              // StorageClass for the per-analysis working-dir PVC; empty means cluster default.
 }
 
 // OperatorOptions aggregates everything NewOperator needs. Held as a
@@ -85,6 +86,7 @@ type OperatorOptions struct {
 	ClusterConfigSecret string              // Name of the Secret holding cluster config for vice-proxy envFrom.
 	EgressConfig        NetworkPolicyConfig // Egress policy config for per-analysis policies.
 	UserSuffix          string              // Domain suffix for usernames (e.g. "@iplantcollaborative.org").
+	LocalStorageClass   string              // StorageClass for the per-analysis working-dir PVC; empty means cluster default.
 }
 
 // Validate confirms the wiring-critical fields are present. The caller
@@ -138,6 +140,7 @@ func NewOperator(opts OperatorOptions) (*Operator, error) {
 		egressConfig:        opts.EgressConfig,
 		httpClient:          noRedirectHTTPClient,
 		userSuffix:          opts.UserSuffix,
+		localStorageClass:   opts.LocalStorageClass,
 	}, nil
 }
 

--- a/operator/resources.go
+++ b/operator/resources.go
@@ -94,6 +94,11 @@ func (o *Operator) applyBundle(ctx context.Context, bundle *operatorclient.Analy
 	// them with the operator's namespace before any Create/Update call.
 	o.normalizeNamespaces(bundle)
 
+	// Pick a cluster-appropriate StorageClass for the analysis working-dir
+	// PVC. app-exposer leaves it unset since the right class is cluster-
+	// specific (e.g. openebs-hostpath on-prem, gp3 on EKS).
+	TransformWorkingDirStorageClass(bundle, o.localStorageClass)
+
 	for _, cm := range bundle.ConfigMaps {
 		if cm == nil {
 			continue

--- a/operator/transforms.go
+++ b/operator/transforms.go
@@ -78,6 +78,31 @@ func TransformGPUVendor(deployment *appsv1.Deployment, vendor GPUVendor) {
 	})
 }
 
+// TransformWorkingDirStorageClass overrides the StorageClassName on the
+// per-analysis working-directory PVC (name prefix "working-dir-") with the
+// operator's configured value. app-exposer leaves StorageClassName unset so
+// each operator can pick a class appropriate to its own cluster (e.g. "gp3"
+// on EKS, "openebs-hostpath" on-prem). When storageClass is empty the PVC
+// is left alone, which lets Kubernetes fall back to the cluster's default
+// storage class. Other PVCs in the bundle — notably the iRODS CSI claim
+// (prefix "csi-data-volume-claim-") which must keep its "irods-sc" class
+// to bind to its pre-built PV — are not touched.
+func TransformWorkingDirStorageClass(bundle *operatorclient.AnalysisBundle, storageClass string) {
+	if bundle == nil || storageClass == "" {
+		return
+	}
+	prefix := constants.WorkingDirVolumeName + "-"
+	for _, pvc := range bundle.PersistentVolumeClaims {
+		if pvc == nil {
+			continue
+		}
+		if strings.HasPrefix(pvc.Name, prefix) {
+			sc := storageClass
+			pvc.Spec.StorageClassName = &sc
+		}
+	}
+}
+
 // forEachContainerResources calls fn on the ResourceRequirements of every
 // container and init container in the deployment.
 func forEachContainerResources(deployment *appsv1.Deployment, fn func(*apiv1.ResourceRequirements)) {

--- a/operator/transforms_storage_test.go
+++ b/operator/transforms_storage_test.go
@@ -1,0 +1,97 @@
+package operator
+
+import (
+	"testing"
+
+	"github.com/cyverse-de/app-exposer/constants"
+	"github.com/cyverse-de/app-exposer/operatorclient"
+	"github.com/stretchr/testify/assert"
+	apiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestTransformWorkingDirStorageClass(t *testing.T) {
+	const (
+		workingDirName   = constants.WorkingDirVolumeName + "-abc123"
+		csiClaimName     = constants.CSIDriverDataVolumeClaimNamePrefix + "-abc123"
+		unrelatedName    = "unrelated-pvc-abc123"
+		preExistingIRODS = "irods-sc"
+	)
+
+	newBundle := func() *operatorclient.AnalysisBundle {
+		irods := preExistingIRODS
+		return &operatorclient.AnalysisBundle{
+			PersistentVolumeClaims: []*apiv1.PersistentVolumeClaim{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: workingDirName},
+					Spec:       apiv1.PersistentVolumeClaimSpec{},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: csiClaimName},
+					Spec: apiv1.PersistentVolumeClaimSpec{
+						StorageClassName: &irods,
+						VolumeName:       "csi-data-volume-abc123",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: unrelatedName},
+					Spec:       apiv1.PersistentVolumeClaimSpec{},
+				},
+				nil,
+			},
+		}
+	}
+
+	tests := []struct {
+		name         string
+		storageClass string
+		wantWorking  *string
+	}{
+		{
+			name:         "empty storage class leaves working-dir PVC alone",
+			storageClass: "",
+			wantWorking:  nil,
+		},
+		{
+			name:         "configured storage class is applied to working-dir PVC",
+			storageClass: "gp3",
+			wantWorking:  strPtr("gp3"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bundle := newBundle()
+			TransformWorkingDirStorageClass(bundle, tt.storageClass)
+
+			// working-dir PVC: rewritten when configured, untouched when empty.
+			if tt.wantWorking == nil {
+				assert.Nil(t, bundle.PersistentVolumeClaims[0].Spec.StorageClassName,
+					"working-dir PVC should be left alone when storageClass is empty")
+			} else {
+				if assert.NotNil(t, bundle.PersistentVolumeClaims[0].Spec.StorageClassName) {
+					assert.Equal(t, *tt.wantWorking, *bundle.PersistentVolumeClaims[0].Spec.StorageClassName)
+				}
+			}
+
+			// iRODS CSI PVC: never touched.
+			if assert.NotNil(t, bundle.PersistentVolumeClaims[1].Spec.StorageClassName) {
+				assert.Equal(t, preExistingIRODS, *bundle.PersistentVolumeClaims[1].Spec.StorageClassName,
+					"iRODS CSI PVC must keep its irods-sc storage class")
+			}
+			assert.Equal(t, "csi-data-volume-abc123", bundle.PersistentVolumeClaims[1].Spec.VolumeName,
+				"iRODS CSI PVC volume binding must be preserved")
+
+			// Other PVCs not matching the working-dir prefix: never touched.
+			assert.Nil(t, bundle.PersistentVolumeClaims[2].Spec.StorageClassName,
+				"unrelated PVC must not be modified")
+		})
+	}
+}
+
+func TestTransformWorkingDirStorageClass_NilBundle(t *testing.T) {
+	// Must not panic on a nil bundle.
+	TransformWorkingDirStorageClass(nil, "gp3")
+}
+
+func strPtr(s string) *string { return &s }


### PR DESCRIPTION
## Summary

- The working-dir PVC's `StorageClassName` was set service-wide by app-exposer's `--local-storage-class` flag (default `openebs-hostpath`), which only exists on the on-prem cluster — analyses launched on EKS failed because no such class is provisioned there.
- app-exposer now leaves `StorageClassName` unset on the working-dir PVC; each vice-operator fills it in via a new `--local-storage-class` flag, so the choice lives with the operator that knows its own cluster. Empty value = Kubernetes cluster default.
- The rewrite is scoped to PVCs whose name starts with `working-dir-`, so the iRODS CSI claim (`csi-data-volume-claim-*`) keeps its `irods-sc` class and its binding to the pre-built PV. Hardcoded `CSIDriverStorageClassName` is unchanged — that's a contract with the CSI driver install, not a cluster-specific value.

Paired with the ansible deployment change that passes `--local-storage-class` to each vice-operator (already verified in QA).

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` (full suite green; new transform tests cover empty config no-op, configured value rewrite, iRODS CSI PVC untouched, unrelated PVCs untouched, nil-bundle safety)
- [x] QA cluster: vice-operator with `--local-storage-class=openebs-hostpath` — analyses launch and the working-dir PVC binds to the expected class; iRODS CSI mount continues to work
- [ ] Production rollout: confirm on-prem analyses unaffected, and EKS analyses bind their working-dir PVC to the configured cluster-appropriate class

🤖 Generated with [Claude Code](https://claude.com/claude-code)