### PR TITLE
Seed initial job status when reconciler finds a new analysis

### DIFF
--- a/reconciler/reconciler.go
+++ b/reconciler/reconciler.go
@@ -365,29 +365,36 @@ func (r *Reconciler) ReconcileNext(ctx context.Context) error {
 }
 
 func (r *Reconciler) reconcileAnalysis(ctx context.Context, tx *sqlx.Tx, pod reporting.PodInfo) error {
-	// Skip pods that are missing required labels — these may be from a
-	// different system or were created before labels were populated.
+	// Skip pods missing the labels that identify them as a DE analysis —
+	// these may belong to a different system or predate label population.
+	// The label check is the "is this one of ours" gate; everything past
+	// here is treated as a DE analysis we own status for.
 	if pod.AnalysisID == "" || pod.ExternalID == "" {
 		log.Debugf("pod %s missing analysis-id or external-id label, skipping", pod.Name)
 		return nil
 	}
 
-	// Compare against the most recent job_status_updates row rather than the
-	// jobs table. There can be lag between recording a status update and
-	// propagating it to jobs, which would cause duplicate reconciliation
-	// updates if we compared against the jobs table.
+	clusterStatus := mapPodPhaseToStatus(pod.Phase)
+
+	// Compare against the most recent job_status_updates row rather than
+	// the jobs table — there can be lag between recording a status update
+	// and propagating it to jobs.
 	dbStatus, err := r.db.GetLatestStatusByExternalID(ctx, tx, pod.ExternalID)
-	if err != nil {
-		// No status updates yet — the pod may have been created before any
-		// status was recorded, or it may belong to a different system.
-		if errors.Is(err, sql.ErrNoRows) {
-			log.Debugf("no status updates for analysis %s (external %s), skipping", pod.AnalysisID, pod.ExternalID)
-			return nil
-		}
+	switch {
+	case errors.Is(err, sql.ErrNoRows):
+		// No prior status row. Probable cause: the analysis was launched
+		// against a remote-cluster operator (e.g. AWS) where
+		// vice-status-listener isn't running, so nothing else ever
+		// published an initial Submitted/Running update. Seed the table
+		// with the cluster's current state so downstream consumers like
+		// job-status-to-apps-adapter pick it up; subsequent ticks then
+		// fall through to the normal change-detection path.
+		log.Infof("analysis %s (external %s) has no prior status; recording initial %s from cluster",
+			pod.AnalysisID, pod.ExternalID, clusterStatus)
+		return r.recordStatusUpdate(ctx, tx, pod.ExternalID, clusterStatus, pod.Message)
+	case err != nil:
 		return err
 	}
-
-	clusterStatus := mapPodPhaseToStatus(pod.Phase)
 
 	if clusterStatus != dbStatus {
 		log.Infof("analysis %s status change: %s -> %s (cluster truth)", pod.AnalysisID, dbStatus, clusterStatus)

--- a/reconciler/reconciler_test.go
+++ b/reconciler/reconciler_test.go
@@ -234,13 +234,29 @@ func TestReconcileAnalysis(t *testing.T) {
 			wantInserts: 0,
 		},
 		{
-			name: "skips when no prior status row (ErrNoRows)",
+			// Bootstraps the job_status_updates row from the cluster state
+			// when nothing else has published one — the only way analyses
+			// on remote-cluster operators (e.g. AWS, where
+			// vice-status-listener isn't running) ever leave Submitted.
+			name: "seeds initial status when no prior row exists",
 			pod: reporting.PodInfo{
 				MetaInfo: reporting.MetaInfo{AnalysisID: "an-1", ExternalID: "ext-1"},
 				Phase:    "Running",
 			},
 			hasPrior:    false,
-			wantInserts: 0,
+			wantInserts: 1,
+			wantStatus:  messaging.RunningState,
+		},
+		{
+			name: "seeds initial Failed status when no prior row exists",
+			pod: reporting.PodInfo{
+				MetaInfo: reporting.MetaInfo{AnalysisID: "an-1", ExternalID: "ext-1"},
+				Phase:    "Failed",
+				Message:  "pod OOMKilled",
+			},
+			hasPrior:    false,
+			wantInserts: 1,
+			wantStatus:  messaging.FailedState,
 		},
 		{
 			name: "records update on status change",


### PR DESCRIPTION
## Summary
- Reconciler skipped any pod whose `external_id` had no prior row in `job_status_updates`, on the theory that "we shouldn't touch analyses we don't already know about." That gate is what kept remote-cluster (e.g. AWS) analyses from ever leaving Submitted: `vice-status-listener` only watches the local cluster's `vice-apps` namespace, so nothing else ever publishes an initial Running update for AWS-deployed pods. The reconciler greets each AWS analysis every 60s and silently skips it.
- The label check at the top of `reconcileAnalysis` (`analysis-id` / `external-id`) is already the "is this one of ours" gate. When that passes and there's no prior row, seed one from the cluster's current pod phase; subsequent ticks fall through to the normal change-detection path.

## Verification of the bug
QA `app-exposer` logs show three AWS analyses being polled and skipped on every cycle, e.g.:
```
debug "reconciling analysis fad94ba6-... (external b61bfc81-...)"
debug "no status updates for analysis fad94ba6-... , skipping"
info  "reconciled analysis fad94ba6-..."
```

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` — full suite green
- [x] Updated `TestReconcileAnalysis` cases cover the seed path (Running and Failed, including message passthrough)
- [ ] Deploy to QA and confirm an AWS-launched analysis gets a `Running` `job_status_updates` row within one reconcile cycle (~60s) of pod start

🤖 Generated with [Claude Code](https://claude.com/claude-code)