### PR TITLE
Push-based VICE status updates via leader-elected operator informer

### DIFF
--- a/cmd/vice-operator/main.go
+++ b/cmd/vice-operator/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cyverse-de/app-exposer/operator"
 	"github.com/cyverse-de/go-mod/viceauth"
 	"github.com/sirupsen/logrus"
+	"k8s.io/client-go/kubernetes"
 )
 
 var log = common.Log
@@ -70,6 +71,10 @@ func main() {
 		disableInternetAccess bool
 		userSuffix            string
 		localStorageClass     string
+		statusListenerURL     string
+		statusLeaseNamespace  string
+		statusLeaseName       string
+		clusterName           string
 	)
 
 	flag.StringVar(&kubeconfig, "kubeconfig", "", "Path to kubeconfig (empty for in-cluster)")
@@ -121,6 +126,10 @@ func main() {
 	flag.BoolVar(&disableInternetAccess, "disable-internet-access", false, "Block analysis pods from reaching the public internet; only DNS, explicit host/CIDR exceptions, and pod exceptions are allowed")
 	flag.StringVar(&userSuffix, "user-suffix", constants.DefaultUserSuffix, "Domain suffix appended to usernames if not already present")
 	flag.StringVar(&localStorageClass, "local-storage-class", "", "StorageClass for the per-analysis working-dir PVC (e.g. openebs-hostpath, gp3); empty means use the cluster's default storage class")
+	flag.StringVar(&statusListenerURL, "status-listener-url", "", "Base URL of job-status-listener (e.g. https://de.example.org/job); empty disables the push-based status informer and falls back to the reconciler's polling")
+	flag.StringVar(&statusLeaseNamespace, "status-lease-namespace", "", "Namespace for the status-publisher coordination Lease (defaults to --namespace)")
+	flag.StringVar(&statusLeaseName, "status-lease-name", "vice-operator-status-publisher", "Name of the coordination Lease used to elect the status-publisher leader")
+	flag.StringVar(&clusterName, "cluster-name", "", "Cluster identifier sent as the Host field on status updates (defaults to the operator's hostname)")
 	flag.Parse()
 
 	// Allow secrets to come from environment variables when not set on the
@@ -418,9 +427,63 @@ func main() {
 		}
 	}()
 
+	// Start the leader-elected status informer in a goroutine when the
+	// listener URL is configured. When the URL is empty (e.g. local dev or a
+	// deployment that wants to keep relying on the reconciler's polling), the
+	// informer is skipped entirely.
+	if statusListenerURL != "" {
+		startStatusInformer(clientset, namespace, statusListenerURL, statusLeaseNamespace, statusLeaseName, clusterName)
+	} else {
+		log.Info("--status-listener-url is empty; status informer disabled (reconciler polling will remain the sole status source)")
+	}
+
 	// API server blocks on the main goroutine.
 	if err := app.Start(apiAddr); err != nil {
 		log.Error(err)
 		os.Exit(1)
 	}
+}
+
+// startStatusInformer constructs the publisher + informer and launches the
+// leader-election loop in a background goroutine. Validation failures are
+// fatal — they indicate a misconfigured deployment that wouldn't recover by
+// retrying.
+func startStatusInformer(clientset kubernetes.Interface, namespace, listenerURL, leaseNamespace, leaseName, clusterName string) {
+	identity, err := os.Hostname()
+	if err != nil || identity == "" {
+		log.Fatalf("status informer requires a hostname for the lease identity: %v", err)
+	}
+	host := clusterName
+	if host == "" {
+		host = identity
+	}
+
+	publisher, err := operator.NewStatusPublisher(listenerURL, host)
+	if err != nil {
+		log.Fatalf("status informer: %v", err)
+	}
+
+	if leaseNamespace == "" {
+		leaseNamespace = namespace
+	}
+
+	informer, err := operator.NewStatusInformer(operator.StatusInformerConfig{
+		Clientset:      clientset,
+		Publisher:      publisher,
+		Namespace:      namespace,
+		LeaseNamespace: leaseNamespace,
+		LeaseName:      leaseName,
+		Identity:       identity,
+	})
+	if err != nil {
+		log.Fatalf("status informer: %v", err)
+	}
+
+	log.Infof("status informer starting (listener=%s, lease=%s/%s, identity=%s, host=%s)",
+		listenerURL, leaseNamespace, leaseName, identity, host)
+	go func() {
+		if err := informer.Run(context.Background()); err != nil && err != context.Canceled {
+			log.Errorf("status informer exited: %v", err)
+		}
+	}()
 }

--- a/cmd/vice-operator/main.go
+++ b/cmd/vice-operator/main.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"net/url"
@@ -482,7 +483,7 @@ func startStatusInformer(clientset kubernetes.Interface, namespace, listenerURL,
 	log.Infof("status informer starting (listener=%s, lease=%s/%s, identity=%s, host=%s)",
 		listenerURL, leaseNamespace, leaseName, identity, host)
 	go func() {
-		if err := informer.Run(context.Background()); err != nil && err != context.Canceled {
+		if err := informer.Run(context.Background()); err != nil && !errors.Is(err, context.Canceled) {
 			log.Errorf("status informer exited: %v", err)
 		}
 	}()

--- a/common/podphase.go
+++ b/common/podphase.go
@@ -1,0 +1,22 @@
+package common
+
+import "github.com/cyverse-de/messaging/v12"
+
+// MapPodPhaseToStatus translates a Kubernetes pod phase into the corresponding
+// JobState used by the job-status pipeline. Unknown phases fall back to
+// SubmittedState so analyses that haven't reached a recognized phase aren't
+// silently treated as Running or terminal.
+func MapPodPhaseToStatus(phase string) messaging.JobState {
+	switch phase {
+	case "Pending":
+		return messaging.SubmittedState
+	case "Running":
+		return messaging.RunningState
+	case "Succeeded":
+		return messaging.SucceededState
+	case "Failed":
+		return messaging.FailedState
+	default:
+		return messaging.SubmittedState
+	}
+}

--- a/common/podphase_test.go
+++ b/common/podphase_test.go
@@ -1,0 +1,28 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/cyverse-de/messaging/v12"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMapPodPhaseToStatus(t *testing.T) {
+	tests := []struct {
+		phase    string
+		expected messaging.JobState
+	}{
+		{"Pending", messaging.SubmittedState},
+		{"Running", messaging.RunningState},
+		{"Succeeded", messaging.SucceededState},
+		{"Failed", messaging.FailedState},
+		{"Unknown", messaging.SubmittedState},
+		{"", messaging.SubmittedState},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.phase, func(t *testing.T) {
+			assert.Equal(t, tt.expected, MapPodPhaseToStatus(tt.phase))
+		})
+	}
+}

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -739,6 +739,45 @@ const docTemplate = `{
                 }
             }
         },
+        "/vice/admin/{host}/canonical-url": {
+            "get": {
+                "description": "Searches every configured operator for the analysis with the\ngiven subdomain. On match, returns the URL built from that\noperator's base_url. Returns 404 when no operator owns the\nsubdomain or the owning operator has no base_url. Returns\n502 when every operator was unreachable.",
+                "produces": [
+                    "application/json"
+                ],
+                "summary": "Resolve a VICE subdomain to its canonical cross-cluster URL",
+                "operationId": "admin-canonical-url",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "The analysis subdomain",
+                        "name": "host",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/httphandlers.CanonicalURLResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/common.ErrorResponse"
+                        }
+                    },
+                    "502": {
+                        "description": "Bad Gateway",
+                        "schema": {
+                            "$ref": "#/definitions/httphandlers.aggregatedFailureResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/vice/admin/{host}/description": {
             "get": {
                 "description": "Returns a listing entry for a single analysis\nassociated with the host/subdomain passed in as 'host' from the URL.",
@@ -1888,6 +1927,14 @@ const docTemplate = `{
                 }
             }
         },
+        "httphandlers.CanonicalURLResponse": {
+            "type": "object",
+            "properties": {
+                "url": {
+                    "type": "string"
+                }
+            }
+        },
         "httphandlers.ExternalIDResp": {
             "type": "object",
             "properties": {
@@ -2043,6 +2090,20 @@ const docTemplate = `{
                     "type": "array",
                     "items": {
                         "type": "string"
+                    }
+                }
+            }
+        },
+        "httphandlers.aggregatedFailureResponse": {
+            "type": "object",
+            "properties": {
+                "error": {
+                    "type": "string"
+                },
+                "operator_errors": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/httphandlers.OperatorError"
                     }
                 }
             }

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -733,6 +733,45 @@
                 }
             }
         },
+        "/vice/admin/{host}/canonical-url": {
+            "get": {
+                "description": "Searches every configured operator for the analysis with the\ngiven subdomain. On match, returns the URL built from that\noperator's base_url. Returns 404 when no operator owns the\nsubdomain or the owning operator has no base_url. Returns\n502 when every operator was unreachable.",
+                "produces": [
+                    "application/json"
+                ],
+                "summary": "Resolve a VICE subdomain to its canonical cross-cluster URL",
+                "operationId": "admin-canonical-url",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "The analysis subdomain",
+                        "name": "host",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/httphandlers.CanonicalURLResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/common.ErrorResponse"
+                        }
+                    },
+                    "502": {
+                        "description": "Bad Gateway",
+                        "schema": {
+                            "$ref": "#/definitions/httphandlers.aggregatedFailureResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/vice/admin/{host}/description": {
             "get": {
                 "description": "Returns a listing entry for a single analysis\nassociated with the host/subdomain passed in as 'host' from the URL.",
@@ -1882,6 +1921,14 @@
                 }
             }
         },
+        "httphandlers.CanonicalURLResponse": {
+            "type": "object",
+            "properties": {
+                "url": {
+                    "type": "string"
+                }
+            }
+        },
         "httphandlers.ExternalIDResp": {
             "type": "object",
             "properties": {
@@ -2037,6 +2084,20 @@
                     "type": "array",
                     "items": {
                         "type": "string"
+                    }
+                }
+            }
+        },
+        "httphandlers.aggregatedFailureResponse": {
+            "type": "object",
+            "properties": {
+                "error": {
+                    "type": "string"
+                },
+                "operator_errors": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/httphandlers.OperatorError"
                     }
                 }
             }

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -136,6 +136,11 @@ definitions:
       subdomain:
         type: string
     type: object
+  httphandlers.CanonicalURLResponse:
+    properties:
+      url:
+        type: string
+    type: object
   httphandlers.ExternalIDResp:
     properties:
       external_id:
@@ -237,6 +242,15 @@ definitions:
       vice:
         items:
           type: string
+        type: array
+    type: object
+  httphandlers.aggregatedFailureResponse:
+    properties:
+      error:
+        type: string
+      operator_errors:
+        items:
+          $ref: '#/definitions/httphandlers.OperatorError'
         type: array
     type: object
   httphandlers.uuidBody:
@@ -11811,6 +11825,37 @@ paths:
           schema:
             $ref: '#/definitions/common.ErrorResponse'
       summary: Triggers output uploads from an analysis
+  /vice/admin/{host}/canonical-url:
+    get:
+      description: |-
+        Searches every configured operator for the analysis with the
+        given subdomain. On match, returns the URL built from that
+        operator's base_url. Returns 404 when no operator owns the
+        subdomain or the owning operator has no base_url. Returns
+        502 when every operator was unreachable.
+      operationId: admin-canonical-url
+      parameters:
+      - description: The analysis subdomain
+        in: path
+        name: host
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/httphandlers.CanonicalURLResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/common.ErrorResponse'
+        "502":
+          description: Bad Gateway
+          schema:
+            $ref: '#/definitions/httphandlers.aggregatedFailureResponse'
+      summary: Resolve a VICE subdomain to its canonical cross-cluster URL
   /vice/admin/{host}/description:
     get:
       description: |-

--- a/operator/statusinformer.go
+++ b/operator/statusinformer.go
@@ -2,6 +2,7 @@ package operator
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -57,22 +58,22 @@ type StatusInformer struct {
 // to Run.
 func NewStatusInformer(cfg StatusInformerConfig) (*StatusInformer, error) {
 	if cfg.Clientset == nil {
-		return nil, fmt.Errorf("StatusInformerConfig.Clientset is required")
+		return nil, errors.New("clientset is required")
 	}
 	if cfg.Publisher == nil {
-		return nil, fmt.Errorf("StatusInformerConfig.Publisher is required")
+		return nil, errors.New("publisher is required")
 	}
 	if cfg.Namespace == "" {
-		return nil, fmt.Errorf("StatusInformerConfig.Namespace is required")
+		return nil, errors.New("namespace is required")
 	}
 	if cfg.LeaseNamespace == "" {
-		return nil, fmt.Errorf("StatusInformerConfig.LeaseNamespace is required")
+		return nil, errors.New("lease namespace is required")
 	}
 	if cfg.LeaseName == "" {
-		return nil, fmt.Errorf("StatusInformerConfig.LeaseName is required")
+		return nil, errors.New("lease name is required")
 	}
 	if cfg.Identity == "" {
-		return nil, fmt.Errorf("StatusInformerConfig.Identity is required")
+		return nil, errors.New("identity is required")
 	}
 	return &StatusInformer{
 		cfg:       cfg,
@@ -244,9 +245,12 @@ func (s *StatusInformer) handleAddOrUpdate(ctx context.Context, dep *appsv1.Depl
 }
 
 // handleDelete publishes a Succeeded update when a Deployment is removed.
-// Mirrors vice-status-listener's assumption that deletion implies the
-// analysis finished cleanly; truly failed analyses surface their failure
-// before deletion (or get caught by the reconciler safety net).
+// Mirrors vice-status-listener's assumption that deletion implies a clean
+// finish. Known gap: a crashed pod (replicas 1 → 0) generates no event here
+// because handleAddOrUpdate skips on AvailableReplicas < 1, so the eventual
+// delete reports Succeeded over what was actually a failure. The reconciler
+// safety net catches this only if it observes the Failed pod phase before
+// the pod is gone; closing the gap fully needs a pod-level informer.
 func (s *StatusInformer) handleDelete(ctx context.Context, dep *appsv1.Deployment) {
 	externalID, ok := dep.Labels[constants.ExternalIDLabel]
 	if !ok || externalID == "" {

--- a/operator/statusinformer.go
+++ b/operator/statusinformer.go
@@ -1,0 +1,289 @@
+package operator
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/cyverse-de/app-exposer/constants"
+	"github.com/cyverse-de/messaging/v12"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/leaderelection"
+	"k8s.io/client-go/tools/leaderelection/resourcelock"
+)
+
+// Lease tuning matches the controller-runtime defaults — short enough that
+// failover takes ~15s, long enough to ride out brief API-server hiccups
+// without thrashing.
+const (
+	statusLeaseDuration = 15 * time.Second
+	statusRenewDeadline = 10 * time.Second
+	statusRetryPeriod   = 2 * time.Second
+)
+
+// leaderLoopBackoff is the pause between leader-election attempts when the
+// previous attempt returned (lost leadership or failed to acquire). Keeps the
+// loop from hot-spinning if the API server briefly rejects lease writes.
+const leaderLoopBackoff = 5 * time.Second
+
+// StatusInformerConfig wires up StatusInformer. All fields are required.
+type StatusInformerConfig struct {
+	Clientset      kubernetes.Interface
+	Publisher      *StatusPublisher
+	Namespace      string // namespace to watch for VICE deployments
+	LeaseNamespace string // namespace to hold the coordination lease
+	LeaseName      string // lease object name (shared across operator replicas)
+	Identity       string // unique per-replica identity, e.g. pod name
+}
+
+// StatusInformer runs a Kubernetes Deployment informer that publishes VICE
+// analysis status updates to job-status-listener. Leader-elected via a
+// coordination.k8s.io Lease so multi-replica operator deployments don't
+// publish duplicate updates.
+type StatusInformer struct {
+	cfg StatusInformerConfig
+
+	mu        sync.Mutex
+	lastState map[constants.ExternalID]messaging.JobState
+}
+
+// NewStatusInformer validates the config and returns a StatusInformer ready
+// to Run.
+func NewStatusInformer(cfg StatusInformerConfig) (*StatusInformer, error) {
+	if cfg.Clientset == nil {
+		return nil, fmt.Errorf("StatusInformerConfig.Clientset is required")
+	}
+	if cfg.Publisher == nil {
+		return nil, fmt.Errorf("StatusInformerConfig.Publisher is required")
+	}
+	if cfg.Namespace == "" {
+		return nil, fmt.Errorf("StatusInformerConfig.Namespace is required")
+	}
+	if cfg.LeaseNamespace == "" {
+		return nil, fmt.Errorf("StatusInformerConfig.LeaseNamespace is required")
+	}
+	if cfg.LeaseName == "" {
+		return nil, fmt.Errorf("StatusInformerConfig.LeaseName is required")
+	}
+	if cfg.Identity == "" {
+		return nil, fmt.Errorf("StatusInformerConfig.Identity is required")
+	}
+	return &StatusInformer{
+		cfg:       cfg,
+		lastState: make(map[constants.ExternalID]messaging.JobState),
+	}, nil
+}
+
+// Run blocks until ctx is done. Repeatedly attempts to acquire leadership; the
+// informer only runs while this replica holds the lease.
+func (s *StatusInformer) Run(ctx context.Context) error {
+	lock := &resourcelock.LeaseLock{
+		LeaseMeta: metav1.ObjectMeta{
+			Name:      s.cfg.LeaseName,
+			Namespace: s.cfg.LeaseNamespace,
+		},
+		Client: s.cfg.Clientset.CoordinationV1(),
+		LockConfig: resourcelock.ResourceLockConfig{
+			Identity: s.cfg.Identity,
+		},
+	}
+
+	for {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+
+		leaderelection.RunOrDie(ctx, leaderelection.LeaderElectionConfig{
+			Lock:            lock,
+			LeaseDuration:   statusLeaseDuration,
+			RenewDeadline:   statusRenewDeadline,
+			RetryPeriod:     statusRetryPeriod,
+			ReleaseOnCancel: true,
+			Name:            s.cfg.LeaseName,
+			Callbacks: leaderelection.LeaderCallbacks{
+				OnStartedLeading: func(leaderCtx context.Context) {
+					log.Infof("acquired status-publisher leadership (identity=%s); starting informer", s.cfg.Identity)
+					s.resetState()
+					s.runInformer(leaderCtx)
+				},
+				OnStoppedLeading: func() {
+					log.Warnf("lost status-publisher leadership (identity=%s); informer stopped", s.cfg.Identity)
+				},
+				OnNewLeader: func(identity string) {
+					if identity != s.cfg.Identity {
+						log.Infof("observed new status-publisher leader: %s", identity)
+					}
+				},
+			},
+		})
+
+		// RunOrDie returned — either leadership was lost or ctx is done.
+		// Pause briefly so we don't hot-loop if the API server is rejecting
+		// lease writes.
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(leaderLoopBackoff):
+		}
+	}
+}
+
+// resetState clears the in-memory phase cache. Called when this replica
+// becomes leader so that a freshly-elected leader doesn't suppress updates
+// based on a stale view from a prior leadership term.
+func (s *StatusInformer) resetState() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.lastState = make(map[constants.ExternalID]messaging.JobState)
+}
+
+// runInformer starts a Deployment informer and blocks until leaderCtx is
+// done. Should only be invoked from the leader-election OnStartedLeading
+// callback so that exactly one replica is publishing at a time.
+func (s *StatusInformer) runInformer(leaderCtx context.Context) {
+	set := labels.Set(map[string]string{
+		constants.AppTypeLabel: string(constants.Interactive),
+	})
+
+	factory := informers.NewSharedInformerFactoryWithOptions(
+		s.cfg.Clientset,
+		0,
+		informers.WithNamespace(s.cfg.Namespace),
+		informers.WithTweakListOptions(func(opts *metav1.ListOptions) {
+			opts.LabelSelector = set.AsSelector().String()
+		}),
+	)
+
+	informer := factory.Apps().V1().Deployments().Informer()
+	_, err := informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj any) {
+			dep, ok := obj.(*appsv1.Deployment)
+			if !ok {
+				log.Warnf("status informer add: unexpected object type %T", obj)
+				return
+			}
+			s.handleAddOrUpdate(leaderCtx, dep)
+		},
+		UpdateFunc: func(_, newObj any) {
+			dep, ok := newObj.(*appsv1.Deployment)
+			if !ok {
+				log.Warnf("status informer update: unexpected object type %T", newObj)
+				return
+			}
+			s.handleAddOrUpdate(leaderCtx, dep)
+		},
+		DeleteFunc: func(obj any) {
+			dep, ok := obj.(*appsv1.Deployment)
+			if !ok {
+				// On final-state-unknown the cache delivers a
+				// DeletedFinalStateUnknown wrapper rather than the typed
+				// object; pull the Deployment out if it's there.
+				tombstone, isTomb := obj.(cache.DeletedFinalStateUnknown)
+				if !isTomb {
+					log.Warnf("status informer delete: unexpected object type %T", obj)
+					return
+				}
+				dep, ok = tombstone.Obj.(*appsv1.Deployment)
+				if !ok {
+					log.Warnf("status informer delete tombstone: unexpected object type %T", tombstone.Obj)
+					return
+				}
+			}
+			s.handleDelete(leaderCtx, dep)
+		},
+	})
+	if err != nil {
+		log.Errorf("status informer: AddEventHandler failed: %v", err)
+		return
+	}
+
+	factory.Start(leaderCtx.Done())
+	if !cache.WaitForCacheSync(leaderCtx.Done(), informer.HasSynced) {
+		log.Warn("status informer cache sync did not complete (leadership likely lost)")
+		return
+	}
+	log.Info("status informer cache synced; publishing updates")
+
+	<-leaderCtx.Done()
+}
+
+// handleAddOrUpdate publishes a Running update when a Deployment is observed
+// with an available replica and we haven't already published Running for it.
+// Add events for already-running analyses are coalesced via the lastState
+// cache so re-syncs after leader handoff don't generate duplicate updates
+// for any particular replica's lifetime — duplicates across leader handoffs
+// are bounded but possible (see plans/push-based-status-updates.md).
+func (s *StatusInformer) handleAddOrUpdate(ctx context.Context, dep *appsv1.Deployment) {
+	if dep.DeletionTimestamp != nil {
+		// A delete is in flight; let DeleteFunc handle the terminal state.
+		return
+	}
+
+	externalID, ok := dep.Labels[constants.ExternalIDLabel]
+	if !ok || externalID == "" {
+		log.Warnf("status informer: deployment %s/%s missing %s label", dep.Namespace, dep.Name, constants.ExternalIDLabel)
+		return
+	}
+
+	if dep.Status.AvailableReplicas < 1 {
+		// Pod isn't ready yet; wait for the next event. The initial
+		// Running update will fire on the first event where the
+		// deployment reports an available replica.
+		return
+	}
+
+	analysisName := dep.Labels[constants.AppNameLabel]
+	message := fmt.Sprintf("deployment %s is running for analysis %s", dep.Name, analysisName)
+	s.publishIfChanged(ctx, constants.ExternalID(externalID), messaging.RunningState, message)
+}
+
+// handleDelete publishes a Succeeded update when a Deployment is removed.
+// Mirrors vice-status-listener's assumption that deletion implies the
+// analysis finished cleanly; truly failed analyses surface their failure
+// before deletion (or get caught by the reconciler safety net).
+func (s *StatusInformer) handleDelete(ctx context.Context, dep *appsv1.Deployment) {
+	externalID, ok := dep.Labels[constants.ExternalIDLabel]
+	if !ok || externalID == "" {
+		log.Warnf("status informer: deleted deployment %s/%s missing %s label", dep.Namespace, dep.Name, constants.ExternalIDLabel)
+		return
+	}
+
+	analysisName := dep.Labels[constants.AppNameLabel]
+	message := fmt.Sprintf("deployment %s has been deleted for analysis %s", dep.Name, analysisName)
+	s.publishIfChanged(ctx, constants.ExternalID(externalID), messaging.SucceededState, message)
+
+	// Drop the cache entry so a future re-launch of the same external ID
+	// (unlikely, but possible) doesn't suppress the next Running update.
+	s.mu.Lock()
+	delete(s.lastState, constants.ExternalID(externalID))
+	s.mu.Unlock()
+}
+
+// publishIfChanged posts a status update if the cached last-published state
+// for this external ID differs from the new state. Updates the cache on
+// successful publish; a failed publish leaves the cache unchanged so the
+// next event retries.
+func (s *StatusInformer) publishIfChanged(ctx context.Context, externalID constants.ExternalID, state messaging.JobState, message string) {
+	s.mu.Lock()
+	prev, known := s.lastState[externalID]
+	s.mu.Unlock()
+
+	if known && prev == state {
+		return
+	}
+
+	if err := s.cfg.Publisher.Publish(ctx, externalID, state, message); err != nil {
+		log.Errorf("status informer: publishing %s for %s failed (will retry on next event): %v", state, externalID, err)
+		return
+	}
+
+	s.mu.Lock()
+	s.lastState[externalID] = state
+	s.mu.Unlock()
+}

--- a/operator/statusinformer_test.go
+++ b/operator/statusinformer_test.go
@@ -23,13 +23,13 @@ import (
 // updates the informer actually emitted.
 type recordingListener struct {
 	mu       sync.Mutex
-	requests []AnalysisStatus
+	requests []StatusUpdatePayload
 }
 
 func (r *recordingListener) handler() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		body, _ := io.ReadAll(req.Body)
-		var status AnalysisStatus
+		var status StatusUpdatePayload
 		_ = json.Unmarshal(body, &status)
 		r.mu.Lock()
 		r.requests = append(r.requests, status)
@@ -38,10 +38,10 @@ func (r *recordingListener) handler() http.Handler {
 	})
 }
 
-func (r *recordingListener) snapshot() []AnalysisStatus {
+func (r *recordingListener) snapshot() []StatusUpdatePayload {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	out := make([]AnalysisStatus, len(r.requests))
+	out := make([]StatusUpdatePayload, len(r.requests))
 	copy(out, r.requests)
 	return out
 }

--- a/operator/statusinformer_test.go
+++ b/operator/statusinformer_test.go
@@ -1,0 +1,285 @@
+package operator
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/cyverse-de/app-exposer/constants"
+	"github.com/cyverse-de/messaging/v12"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+// recordingListener captures every status POST so tests can assert which
+// updates the informer actually emitted.
+type recordingListener struct {
+	mu       sync.Mutex
+	requests []AnalysisStatus
+}
+
+func (r *recordingListener) handler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		body, _ := io.ReadAll(req.Body)
+		var status AnalysisStatus
+		_ = json.Unmarshal(body, &status)
+		r.mu.Lock()
+		r.requests = append(r.requests, status)
+		r.mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	})
+}
+
+func (r *recordingListener) snapshot() []AnalysisStatus {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]AnalysisStatus, len(r.requests))
+	copy(out, r.requests)
+	return out
+}
+
+// newTestInformer constructs an informer + publisher backed by a recording
+// listener. Returns the informer and the listener so tests can drive the
+// informer's handler methods directly and inspect the resulting traffic.
+func newTestInformer(t *testing.T) (*StatusInformer, *recordingListener) {
+	t.Helper()
+	rec := &recordingListener{}
+	srv := httptest.NewServer(rec.handler())
+	t.Cleanup(srv.Close)
+
+	publisher, err := NewStatusPublisher(srv.URL, "test-cluster")
+	require.NoError(t, err)
+
+	informer, err := NewStatusInformer(StatusInformerConfig{
+		Clientset:      fake.NewSimpleClientset(),
+		Publisher:      publisher,
+		Namespace:      "vice-apps",
+		LeaseNamespace: "vice-apps",
+		LeaseName:      "vice-operator-status-publisher",
+		Identity:       "test-pod",
+	})
+	require.NoError(t, err)
+	return informer, rec
+}
+
+func deployment(externalID, name string, availableReplicas int32) *appsv1.Deployment {
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "vice-apps",
+			Labels: map[string]string{
+				constants.ExternalIDLabel: externalID,
+				constants.AppTypeLabel:    string(constants.Interactive),
+				constants.AppNameLabel:    "my-app",
+			},
+		},
+		Status: appsv1.DeploymentStatus{
+			AvailableReplicas: availableReplicas,
+		},
+	}
+}
+
+func TestNewStatusInformerValidation(t *testing.T) {
+	cs := fake.NewSimpleClientset()
+	pub, err := NewStatusPublisher("http://example.org", "h")
+	require.NoError(t, err)
+
+	tests := []struct {
+		name string
+		cfg  StatusInformerConfig
+	}{
+		{"missing clientset", StatusInformerConfig{Publisher: pub, Namespace: "ns", LeaseNamespace: "ns", LeaseName: "l", Identity: "i"}},
+		{"missing publisher", StatusInformerConfig{Clientset: cs, Namespace: "ns", LeaseNamespace: "ns", LeaseName: "l", Identity: "i"}},
+		{"missing namespace", StatusInformerConfig{Clientset: cs, Publisher: pub, LeaseNamespace: "ns", LeaseName: "l", Identity: "i"}},
+		{"missing lease namespace", StatusInformerConfig{Clientset: cs, Publisher: pub, Namespace: "ns", LeaseName: "l", Identity: "i"}},
+		{"missing lease name", StatusInformerConfig{Clientset: cs, Publisher: pub, Namespace: "ns", LeaseNamespace: "ns", Identity: "i"}},
+		{"missing identity", StatusInformerConfig{Clientset: cs, Publisher: pub, Namespace: "ns", LeaseNamespace: "ns", LeaseName: "l"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := NewStatusInformer(tt.cfg)
+			assert.Error(t, err)
+		})
+	}
+}
+
+func TestHandleAddOrUpdate(t *testing.T) {
+	tests := []struct {
+		name        string
+		deps        []*appsv1.Deployment
+		wantStates  []messaging.JobState
+		wantHosts   []string
+		description string
+	}{
+		{
+			name:        "ready deployment fires Running once",
+			deps:        []*appsv1.Deployment{deployment("ext-1", "vice-1", 1)},
+			wantStates:  []messaging.JobState{messaging.RunningState},
+			description: "first observation with available replica publishes Running",
+		},
+		{
+			name:        "not-ready deployment does not publish",
+			deps:        []*appsv1.Deployment{deployment("ext-1", "vice-1", 0)},
+			wantStates:  nil,
+			description: "Pending pod with no available replica is suppressed until ready",
+		},
+		{
+			name: "ready then ready again deduplicates",
+			deps: []*appsv1.Deployment{
+				deployment("ext-1", "vice-1", 1),
+				deployment("ext-1", "vice-1", 1),
+			},
+			wantStates:  []messaging.JobState{messaging.RunningState},
+			description: "repeated Running observations should publish only once",
+		},
+		{
+			name: "not-ready then ready publishes Running once",
+			deps: []*appsv1.Deployment{
+				deployment("ext-1", "vice-1", 0),
+				deployment("ext-1", "vice-1", 1),
+			},
+			wantStates: []messaging.JobState{messaging.RunningState},
+		},
+		{
+			name: "two different deployments both publish",
+			deps: []*appsv1.Deployment{
+				deployment("ext-1", "vice-1", 1),
+				deployment("ext-2", "vice-2", 1),
+			},
+			wantStates: []messaging.JobState{messaging.RunningState, messaging.RunningState},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			informer, rec := newTestInformer(t)
+			ctx := context.Background()
+			for _, dep := range tt.deps {
+				informer.handleAddOrUpdate(ctx, dep)
+			}
+			snap := rec.snapshot()
+			var gotStates []messaging.JobState
+			for _, r := range snap {
+				gotStates = append(gotStates, r.State)
+			}
+			assert.Equal(t, tt.wantStates, gotStates, tt.description)
+		})
+	}
+}
+
+func TestHandleAddOrUpdateSkipsDeletingDeployment(t *testing.T) {
+	informer, rec := newTestInformer(t)
+	now := metav1.NewTime(time.Now())
+	dep := deployment("ext-1", "vice-1", 1)
+	dep.DeletionTimestamp = &now
+
+	informer.handleAddOrUpdate(context.Background(), dep)
+	assert.Empty(t, rec.snapshot(), "deployments mid-deletion should be left for the delete handler")
+}
+
+func TestHandleAddOrUpdateRequiresExternalIDLabel(t *testing.T) {
+	informer, rec := newTestInformer(t)
+	dep := deployment("ext-1", "vice-1", 1)
+	delete(dep.Labels, constants.ExternalIDLabel)
+
+	informer.handleAddOrUpdate(context.Background(), dep)
+	assert.Empty(t, rec.snapshot(), "deployments without external-id label should be skipped")
+}
+
+func TestHandleDeletePublishesSucceeded(t *testing.T) {
+	informer, rec := newTestInformer(t)
+	dep := deployment("ext-1", "vice-1", 1)
+
+	informer.handleAddOrUpdate(context.Background(), dep)
+	informer.handleDelete(context.Background(), dep)
+
+	got := rec.snapshot()
+	require.Len(t, got, 2)
+	assert.Equal(t, messaging.RunningState, got[0].State)
+	assert.Equal(t, messaging.SucceededState, got[1].State)
+}
+
+func TestHandleDeleteClearsCacheForRelaunch(t *testing.T) {
+	informer, rec := newTestInformer(t)
+	dep := deployment("ext-1", "vice-1", 1)
+
+	informer.handleAddOrUpdate(context.Background(), dep)
+	informer.handleDelete(context.Background(), dep)
+	// Relaunch with the same external ID — should publish Running again
+	// (not be suppressed by the cached Succeeded state).
+	informer.handleAddOrUpdate(context.Background(), dep)
+
+	got := rec.snapshot()
+	require.Len(t, got, 3)
+	assert.Equal(t, messaging.RunningState, got[0].State)
+	assert.Equal(t, messaging.SucceededState, got[1].State)
+	assert.Equal(t, messaging.RunningState, got[2].State)
+}
+
+func TestPublishIfChangedDoesNotCacheOnError(t *testing.T) {
+	// First listener fails; second succeeds. Both observations of the
+	// same Running state should result in two POST attempts because the
+	// first didn't update the cache.
+	var (
+		mu        sync.Mutex
+		callCount int
+		failFirst = true
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		mu.Lock()
+		callCount++
+		shouldFail := failFirst && callCount == 1
+		mu.Unlock()
+		if shouldFail {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	publisher, err := NewStatusPublisher(srv.URL, "h")
+	require.NoError(t, err)
+	informer, err := NewStatusInformer(StatusInformerConfig{
+		Clientset:      fake.NewSimpleClientset(),
+		Publisher:      publisher,
+		Namespace:      "vice-apps",
+		LeaseNamespace: "vice-apps",
+		LeaseName:      "l",
+		Identity:       "i",
+	})
+	require.NoError(t, err)
+
+	dep := deployment("ext-1", "vice-1", 1)
+	informer.handleAddOrUpdate(context.Background(), dep)
+	informer.handleAddOrUpdate(context.Background(), dep)
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, 2, callCount, "retried after first POST failed")
+}
+
+func TestResetStateAllowsRepublish(t *testing.T) {
+	informer, rec := newTestInformer(t)
+	dep := deployment("ext-1", "vice-1", 1)
+
+	informer.handleAddOrUpdate(context.Background(), dep)
+	// Simulate leadership handoff: resetState wipes the cache so a re-elected
+	// leader publishes the current state again (the bounded-duplicate path
+	// called out in plans/push-based-status-updates.md).
+	informer.resetState()
+	informer.handleAddOrUpdate(context.Background(), dep)
+
+	got := rec.snapshot()
+	require.Len(t, got, 2)
+	assert.Equal(t, messaging.RunningState, got[0].State)
+	assert.Equal(t, messaging.RunningState, got[1].State)
+}

--- a/operator/statuspublisher.go
+++ b/operator/statuspublisher.go
@@ -1,0 +1,102 @@
+package operator
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"path"
+	"time"
+
+	"github.com/cyverse-de/app-exposer/common"
+	"github.com/cyverse-de/app-exposer/constants"
+	"github.com/cyverse-de/messaging/v12"
+)
+
+// statusPublisherTimeout bounds a single POST to job-status-listener. The
+// listener is expected to publish to AMQP and return quickly; anything longer
+// suggests an unresponsive downstream and shouldn't stall the informer's event
+// goroutine.
+const statusPublisherTimeout = 10 * time.Second
+
+// statusHTTPClient is used by StatusPublisher. Exposed as a package var so
+// tests can substitute a client whose Transport redirects to an httptest.Server.
+var statusHTTPClient = &http.Client{Timeout: statusPublisherTimeout}
+
+// AnalysisStatus is the body shape expected by job-status-listener's
+// POST /{external-id}/status endpoint. Matches vice-status-listener's
+// AnalysisStatus so the listener doesn't need a new contract.
+type AnalysisStatus struct {
+	Host    string             `json:"Host"`
+	State   messaging.JobState `json:"State"`
+	Message string             `json:"Message"`
+}
+
+// StatusPublisher posts VICE analysis status updates to job-status-listener.
+// One instance is shared across the operator process; safe for concurrent use.
+type StatusPublisher struct {
+	baseURL  *url.URL
+	hostname string
+	client   *http.Client
+}
+
+// NewStatusPublisher parses listenerURL and returns a publisher that posts
+// updates to <listenerURL>/<external-id>/status. The hostname is sent as the
+// AnalysisStatus.Host field so the downstream pipeline can identify which
+// publisher emitted each update; pass the cluster name (or pod hostname) to
+// disambiguate multi-cluster operators.
+func NewStatusPublisher(listenerURL, hostname string) (*StatusPublisher, error) {
+	u, err := url.Parse(listenerURL)
+	if err != nil {
+		return nil, fmt.Errorf("parsing status listener URL %q: %w", listenerURL, err)
+	}
+	if u.Scheme == "" || u.Host == "" {
+		return nil, fmt.Errorf("status listener URL %q must include scheme and host", listenerURL)
+	}
+	return &StatusPublisher{
+		baseURL:  u,
+		hostname: hostname,
+		client:   statusHTTPClient,
+	}, nil
+}
+
+// Publish posts a single status update for the given external ID. Returns an
+// error if the request couldn't be sent or the listener returned a non-2xx/3xx
+// response; the caller decides whether to retry or drop the update.
+func (p *StatusPublisher) Publish(ctx context.Context, externalID constants.ExternalID, state messaging.JobState, message string) error {
+	body, err := json.Marshal(AnalysisStatus{
+		Host:    p.hostname,
+		State:   state,
+		Message: message,
+	})
+	if err != nil {
+		return fmt.Errorf("marshalling status payload: %w", err)
+	}
+
+	target := *p.baseURL
+	target.Path = path.Join(target.Path, string(externalID), "status")
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, target.String(), bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("building status request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("posting %s status for %s to %s: %w", state, externalID, target.String(), err)
+	}
+	defer common.CloseBody(resp)
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 400 {
+		respBody, readErr := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		if readErr != nil {
+			return fmt.Errorf("status listener returned %d for %s (%s); body read failed: %w", resp.StatusCode, externalID, state, readErr)
+		}
+		return fmt.Errorf("status listener returned %d for %s (%s): %s", resp.StatusCode, externalID, state, string(respBody))
+	}
+	return nil
+}

--- a/operator/statuspublisher.go
+++ b/operator/statuspublisher.go
@@ -26,10 +26,11 @@ const statusPublisherTimeout = 10 * time.Second
 // tests can substitute a client whose Transport redirects to an httptest.Server.
 var statusHTTPClient = &http.Client{Timeout: statusPublisherTimeout}
 
-// AnalysisStatus is the body shape expected by job-status-listener's
+// StatusUpdatePayload is the body shape expected by job-status-listener's
 // POST /{external-id}/status endpoint. Matches vice-status-listener's
-// AnalysisStatus so the listener doesn't need a new contract.
-type AnalysisStatus struct {
+// payload so the listener doesn't need a new contract. Named to avoid
+// shadowing constants.AnalysisStatus, an unrelated apps-service enum.
+type StatusUpdatePayload struct {
 	Host    string             `json:"Host"`
 	State   messaging.JobState `json:"State"`
 	Message string             `json:"Message"`
@@ -37,15 +38,17 @@ type AnalysisStatus struct {
 
 // StatusPublisher posts VICE analysis status updates to job-status-listener.
 // One instance is shared across the operator process; safe for concurrent use.
+// The HTTP client lives at package scope (statusHTTPClient) so tests can
+// substitute it; capturing it on the struct would freeze the substitution
+// timing and lose that hook.
 type StatusPublisher struct {
 	baseURL  *url.URL
 	hostname string
-	client   *http.Client
 }
 
 // NewStatusPublisher parses listenerURL and returns a publisher that posts
 // updates to <listenerURL>/<external-id>/status. The hostname is sent as the
-// AnalysisStatus.Host field so the downstream pipeline can identify which
+// payload's Host field so the downstream pipeline can identify which
 // publisher emitted each update; pass the cluster name (or pod hostname) to
 // disambiguate multi-cluster operators.
 func NewStatusPublisher(listenerURL, hostname string) (*StatusPublisher, error) {
@@ -59,7 +62,6 @@ func NewStatusPublisher(listenerURL, hostname string) (*StatusPublisher, error) 
 	return &StatusPublisher{
 		baseURL:  u,
 		hostname: hostname,
-		client:   statusHTTPClient,
 	}, nil
 }
 
@@ -67,7 +69,7 @@ func NewStatusPublisher(listenerURL, hostname string) (*StatusPublisher, error) 
 // error if the request couldn't be sent or the listener returned a non-2xx/3xx
 // response; the caller decides whether to retry or drop the update.
 func (p *StatusPublisher) Publish(ctx context.Context, externalID constants.ExternalID, state messaging.JobState, message string) error {
-	body, err := json.Marshal(AnalysisStatus{
+	body, err := json.Marshal(StatusUpdatePayload{
 		Host:    p.hostname,
 		State:   state,
 		Message: message,
@@ -85,7 +87,7 @@ func (p *StatusPublisher) Publish(ctx context.Context, externalID constants.Exte
 	}
 	req.Header.Set("Content-Type", "application/json")
 
-	resp, err := p.client.Do(req)
+	resp, err := statusHTTPClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("posting %s status for %s to %s: %w", state, externalID, target.String(), err)
 	}

--- a/operator/statuspublisher_test.go
+++ b/operator/statuspublisher_test.go
@@ -57,7 +57,7 @@ func TestStatusPublisherPublish(t *testing.T) {
 		serverBody   string
 		wantError    bool
 		wantPath     string
-		wantBody     AnalysisStatus
+		wantBody     StatusUpdatePayload
 	}{
 		{
 			name:         "happy path running",
@@ -65,7 +65,7 @@ func TestStatusPublisherPublish(t *testing.T) {
 			message:      "deployment X is running",
 			serverStatus: http.StatusOK,
 			wantPath:     "/" + string(externalID) + "/status",
-			wantBody:     AnalysisStatus{Host: hostname, State: messaging.RunningState, Message: "deployment X is running"},
+			wantBody:     StatusUpdatePayload{Host: hostname, State: messaging.RunningState, Message: "deployment X is running"},
 		},
 		{
 			name:         "happy path with base path",
@@ -74,7 +74,7 @@ func TestStatusPublisherPublish(t *testing.T) {
 			basePath:     "/job",
 			serverStatus: http.StatusAccepted,
 			wantPath:     "/job/" + string(externalID) + "/status",
-			wantBody:     AnalysisStatus{Host: hostname, State: messaging.SucceededState, Message: "done"},
+			wantBody:     StatusUpdatePayload{Host: hostname, State: messaging.SucceededState, Message: "done"},
 		},
 		{
 			name:         "listener returns 500",
@@ -96,7 +96,7 @@ func TestStatusPublisherPublish(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var gotPath, gotMethod, gotContentType string
-			var gotBody AnalysisStatus
+			var gotBody StatusUpdatePayload
 			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				gotPath = r.URL.Path
 				gotMethod = r.Method

--- a/operator/statuspublisher_test.go
+++ b/operator/statuspublisher_test.go
@@ -1,0 +1,147 @@
+package operator
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/cyverse-de/app-exposer/constants"
+	"github.com/cyverse-de/messaging/v12"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewStatusPublisher(t *testing.T) {
+	tests := []struct {
+		name      string
+		url       string
+		wantError bool
+	}{
+		{"valid https URL", "https://de.example.org/job", false},
+		{"valid http URL", "http://localhost:8080", false},
+		{"valid URL with path", "https://de.example.org/some/path", false},
+		{"empty URL", "", true},
+		{"missing scheme", "de.example.org/job", true},
+		{"malformed URL", "://not-a-url", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p, err := NewStatusPublisher(tt.url, "test-host")
+			if tt.wantError {
+				assert.Error(t, err)
+				assert.Nil(t, p)
+			} else {
+				require.NoError(t, err)
+				assert.NotNil(t, p)
+			}
+		})
+	}
+}
+
+func TestStatusPublisherPublish(t *testing.T) {
+	const (
+		externalID = constants.ExternalID("ext-abc-123")
+		hostname   = "vice-operator-aws"
+	)
+
+	tests := []struct {
+		name         string
+		state        messaging.JobState
+		message      string
+		basePath     string // appended to the test server URL
+		serverStatus int
+		serverBody   string
+		wantError    bool
+		wantPath     string
+		wantBody     AnalysisStatus
+	}{
+		{
+			name:         "happy path running",
+			state:        messaging.RunningState,
+			message:      "deployment X is running",
+			serverStatus: http.StatusOK,
+			wantPath:     "/" + string(externalID) + "/status",
+			wantBody:     AnalysisStatus{Host: hostname, State: messaging.RunningState, Message: "deployment X is running"},
+		},
+		{
+			name:         "happy path with base path",
+			state:        messaging.SucceededState,
+			message:      "done",
+			basePath:     "/job",
+			serverStatus: http.StatusAccepted,
+			wantPath:     "/job/" + string(externalID) + "/status",
+			wantBody:     AnalysisStatus{Host: hostname, State: messaging.SucceededState, Message: "done"},
+		},
+		{
+			name:         "listener returns 500",
+			state:        messaging.FailedState,
+			message:      "boom",
+			serverStatus: http.StatusInternalServerError,
+			serverBody:   "internal error",
+			wantError:    true,
+		},
+		{
+			name:         "listener returns 400",
+			state:        messaging.RunningState,
+			serverStatus: http.StatusBadRequest,
+			serverBody:   "bad payload",
+			wantError:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var gotPath, gotMethod, gotContentType string
+			var gotBody AnalysisStatus
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotPath = r.URL.Path
+				gotMethod = r.Method
+				gotContentType = r.Header.Get("Content-Type")
+				body, _ := io.ReadAll(r.Body)
+				_ = json.Unmarshal(body, &gotBody)
+				w.WriteHeader(tt.serverStatus)
+				if tt.serverBody != "" {
+					_, _ = io.WriteString(w, tt.serverBody)
+				}
+			}))
+			t.Cleanup(srv.Close)
+
+			p, err := NewStatusPublisher(srv.URL+tt.basePath, hostname)
+			require.NoError(t, err)
+
+			err = p.Publish(context.Background(), externalID, tt.state, tt.message)
+			if tt.wantError {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, http.MethodPost, gotMethod)
+			assert.Equal(t, tt.wantPath, gotPath)
+			assert.Equal(t, "application/json", gotContentType)
+			assert.Equal(t, tt.wantBody, gotBody)
+		})
+	}
+}
+
+func TestStatusPublisherPublishContextCancelled(t *testing.T) {
+	// Server that hangs long enough for the cancelled context to short-circuit
+	// the request.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+	}))
+	t.Cleanup(srv.Close)
+
+	p, err := NewStatusPublisher(srv.URL, "test-host")
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // pre-cancelled
+	err = p.Publish(ctx, "ext-1", messaging.RunningState, "x")
+	require.Error(t, err)
+	assert.True(t, strings.Contains(err.Error(), "context canceled") || strings.Contains(err.Error(), "context deadline exceeded"),
+		"expected context error, got %v", err)
+}

--- a/reconciler/reconciler.go
+++ b/reconciler/reconciler.go
@@ -101,14 +101,16 @@ const (
 	// DefaultSyncInterval is the periodic-poll cadence used as a fallback
 	// when NOTIFY-driven syncs are unavailable.
 	DefaultSyncInterval = 5 * time.Minute
-	// DefaultReconcileInterval is the per-operator reconciliation cadence;
-	// tighter than the sync cadence because reconciliation runs per
-	// operator while sync just refreshes the operator list.
-	DefaultReconcileInterval = 30 * time.Second
+	// DefaultReconcileInterval is the per-operator reconciliation cadence.
+	// The push-based status informer in vice-operator is the hot path;
+	// reconciliation runs as a safety net that catches transitions missed
+	// during operator outages or leader-election gaps, so a coarse interval
+	// is fine and reduces operator-API + DB load.
+	DefaultReconcileInterval = 5 * time.Minute
 	// DefaultClaimTTL bounds how soon a previously-reconciled operator is
 	// eligible for re-reconciliation; must be comfortably larger than
 	// DefaultReconcileInterval to avoid back-to-back claims on one operator.
-	DefaultClaimTTL = 60 * time.Second
+	DefaultClaimTTL = 10 * time.Minute
 )
 
 // startListener returns a channel that fires whenever this process should
@@ -374,7 +376,7 @@ func (r *Reconciler) reconcileAnalysis(ctx context.Context, tx *sqlx.Tx, pod rep
 		return nil
 	}
 
-	clusterStatus := mapPodPhaseToStatus(pod.Phase)
+	clusterStatus := common.MapPodPhaseToStatus(pod.Phase)
 
 	// Compare against the most recent job_status_updates row rather than
 	// the jobs table — there can be lag between recording a status update
@@ -402,21 +404,6 @@ func (r *Reconciler) reconcileAnalysis(ctx context.Context, tx *sqlx.Tx, pod rep
 	}
 
 	return nil
-}
-
-func mapPodPhaseToStatus(phase string) messaging.JobState {
-	switch phase {
-	case "Pending":
-		return messaging.SubmittedState
-	case "Running":
-		return messaging.RunningState
-	case "Succeeded":
-		return messaging.SucceededState
-	case "Failed":
-		return messaging.FailedState
-	default:
-		return messaging.SubmittedState
-	}
 }
 
 func (r *Reconciler) recordStatusUpdate(ctx context.Context, tx *sqlx.Tx, externalID constants.ExternalID, status messaging.JobState, message string) error {

--- a/reconciler/reconciler_test.go
+++ b/reconciler/reconciler_test.go
@@ -52,26 +52,6 @@ func TestNewReconciler(t *testing.T) {
 	_ = r.hostname
 }
 
-func TestMapPodPhaseToStatus(t *testing.T) {
-	tests := []struct {
-		phase    string
-		expected messaging.JobState
-	}{
-		{"Pending", messaging.SubmittedState},
-		{"Running", messaging.RunningState},
-		{"Succeeded", messaging.SucceededState},
-		{"Failed", messaging.FailedState},
-		{"Unknown", messaging.SubmittedState},
-		{"", messaging.SubmittedState},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.phase, func(t *testing.T) {
-			assert.Equal(t, tt.expected, mapPodPhaseToStatus(tt.phase))
-		})
-	}
-}
-
 // fakeReconcilerDB implements db.ReconcilerDB for unit tests. It records
 // calls so assertions can be made against the side effects the reconciler
 // produces, and per-method errors can be injected to exercise failure paths.


### PR DESCRIPTION
## Summary
- Adds a leader-elected K8s Deployment informer to `vice-operator` that pushes job status updates to `job-status-listener` directly, replacing the reconciler's polling on the hot path.
- Bumps the reconciler interval from 30s → 5min; it stays as a safety net for missed pushes, leader-failover gaps, and (still essential) the initial-status seed for new analyses.
- Multi-replica safe via `coordination.k8s.io/Lease`-based leader election; only the leader runs the informer.

## Why
Remote-cluster VICE analyses had a 30s latency floor on every transition because `vice-status-listener` only runs in the local cluster and the reconciler polls each operator. Pushing from the operator drops that to ~1-2s for the transitions the informer observes; the reconciler still catches what the informer can't (e.g. pre-launch ImagePullBackOff, dropped pushes, leader handoff gaps).

## Notes
- New `--status-listener-url` flag opts each operator into push mode. Empty (default) preserves today's reconciler-only behavior.
- Cluster identity is sent as the `Host` field on status payloads via `--cluster-name` (falls back to pod hostname).
- Shared `MapPodPhaseToStatus` lives in `common/` so the informer and reconciler agree on phase semantics.
- Auth on `job-status-listener` is intentionally deferred to a follow-up PR — see `plans/push-based-status-updates.md` for the design.

## Required deploy-side changes
- Add `coordination.k8s.io/leases: get,create,update` to the `vice-operator` Role (RBAC for the lease).
- Add a `URLRewrite` filter to the `/job` HTTPRoute in `deployments/ansible/roles/kubernetes_ingress/tasks/gateway_api.yml` so external traffic to `/job/<uuid>/status` reaches the listener as `/<uuid>/status`. (Already applied locally; needs to be committed in the deployments repo.)

## Test plan
- [ ] Unit tests pass: `go test ./...`
- [ ] Lint clean: `golangci-lint run ./operator/ ./common/ ./reconciler/ ./cmd/vice-operator/`
- [ ] Deploy to a remote cluster with `--status-listener-url` set; confirm `job_status_updates` shows `Running` within ~1-2s of pod ready.
- [ ] Scale operator to 3 replicas; confirm only the leader's logs show informer events and `kubectl get lease -n <ns> vice-operator-status-publisher` shows the holder.
- [ ] Delete the leader pod; confirm failover within ~30s with at most one duplicate update per running analysis.
- [ ] Launch an analysis with a deliberately broken image; confirm the reconciler's initial-seed path still fires.