### PR TITLE
Route VICE launches by per-cluster GPU model capability

### DIFF
--- a/cmd/vice-operator/helpers.go
+++ b/cmd/vice-operator/helpers.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 )
@@ -76,6 +77,7 @@ func (m *nameValueMapFlag) String() string {
 	for k, v := range *m {
 		pairs = append(pairs, k+":"+v)
 	}
+	slices.Sort(pairs)
 	return strings.Join(pairs, ",")
 }
 

--- a/cmd/vice-operator/helpers.go
+++ b/cmd/vice-operator/helpers.go
@@ -62,3 +62,31 @@ func (s *stringSliceFlag) Set(val string) error {
 	*s = append(*s, val)
 	return nil
 }
+
+// nameValueMapFlag implements flag.Value for repeatable NAME:VALUE pairs
+// that build up a map. Used for --gpu-model-mapping. Repeated keys
+// overwrite earlier values (documented behavior; the last Set wins).
+type nameValueMapFlag map[string]string
+
+func (m *nameValueMapFlag) String() string {
+	if *m == nil {
+		return ""
+	}
+	pairs := make([]string, 0, len(*m))
+	for k, v := range *m {
+		pairs = append(pairs, k+":"+v)
+	}
+	return strings.Join(pairs, ",")
+}
+
+func (m *nameValueMapFlag) Set(val string) error {
+	name, value, ok := strings.Cut(val, ":")
+	if !ok || name == "" || value == "" {
+		return fmt.Errorf("invalid NAME:VALUE pair %q (expected NAME:VALUE with non-empty halves)", val)
+	}
+	if *m == nil {
+		*m = make(map[string]string)
+	}
+	(*m)[name] = value
+	return nil
+}

--- a/cmd/vice-operator/helpers_test.go
+++ b/cmd/vice-operator/helpers_test.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNameValueMapFlag(t *testing.T) {
+	t.Run("single pair", func(t *testing.T) {
+		var m nameValueMapFlag
+		require.NoError(t, m.Set("NVIDIA-A10G:a10g"))
+		assert.Equal(t, nameValueMapFlag{"NVIDIA-A10G": "a10g"}, m)
+	})
+
+	t.Run("multiple pairs accumulate", func(t *testing.T) {
+		var m nameValueMapFlag
+		require.NoError(t, m.Set("NVIDIA-A10G:a10g"))
+		require.NoError(t, m.Set("NVIDIA-L4:l4"))
+		require.NoError(t, m.Set("NVIDIA-L40S:l40s"))
+		assert.Equal(t, nameValueMapFlag{
+			"NVIDIA-A10G": "a10g",
+			"NVIDIA-L4":   "l4",
+			"NVIDIA-L40S": "l40s",
+		}, m)
+	})
+
+	t.Run("duplicate key — last wins", func(t *testing.T) {
+		var m nameValueMapFlag
+		require.NoError(t, m.Set("k:v1"))
+		require.NoError(t, m.Set("k:v2"))
+		assert.Equal(t, nameValueMapFlag{"k": "v2"}, m)
+	})
+
+	t.Run("malformed input rejected", func(t *testing.T) {
+		cases := []string{
+			"no-colon-here",
+			":empty-name",
+			"empty-value:",
+			"",
+		}
+		for _, in := range cases {
+			var m nameValueMapFlag
+			err := m.Set(in)
+			assert.Error(t, err, "Set(%q) should error", in)
+		}
+	})
+
+	t.Run("String roundtrip is parseable back", func(t *testing.T) {
+		// String is order-unstable because it iterates a map, but each
+		// individual NAME:VALUE pair must round-trip cleanly. Just
+		// confirm the pairs format is what callers will see.
+		m := nameValueMapFlag{"k1": "v1"}
+		assert.Equal(t, "k1:v1", m.String())
+	})
+}

--- a/cmd/vice-operator/main.go
+++ b/cmd/vice-operator/main.go
@@ -69,6 +69,9 @@ func main() {
 		egressHostExceptions  stringSliceFlag
 		egressCIDRExceptions  stringSliceFlag
 		ingressPodExceptions  stringSliceFlag
+		gpuModels             stringSliceFlag
+		gpuModelMapping       nameValueMapFlag
+		gpuModelAffinityKey   string
 		disableInternetAccess bool
 		userSuffix            string
 		localStorageClass     string
@@ -82,6 +85,9 @@ func main() {
 	flag.StringVar(&namespace, "namespace", "vice-apps", "Namespace for VICE resources")
 	flag.IntVar(&port, "port", 60001, "Listen port")
 	flag.StringVar(&gpuVendorFlag, "gpu-vendor", "nvidia", "GPU vendor: nvidia or amd")
+	flag.Var(&gpuModels, "gpu-model", "Canonical (GFD-style) GPU model this cluster can deliver, e.g. NVIDIA-A10G (repeatable). Advertised to the scheduler so model-specific analyses route here. Empty means model-agnostic.")
+	flag.Var(&gpuModelMapping, "gpu-model-mapping", "NAME:VALUE pair mapping a canonical GPU model name to this cluster's node-label value, e.g. NVIDIA-A10G:a10g on EKS (repeatable). Applied during launch to rewrite the deployment's GPU model affinity.")
+	flag.StringVar(&gpuModelAffinityKey, "gpu-model-affinity-key", "", "Node-label key this cluster uses for GPU-model affinity (e.g. eks.amazonaws.com/instance-gpu-name on EKS). Empty leaves the bundle's canonical nvidia.com/gpu.product key untouched.")
 	flag.IntVar(&maxAnalyses, "max-analyses", 50, "Max concurrent analyses (0 disables the limit for autoscaling clusters)")
 	flag.StringVar(&nodeLabelSelector, "node-label-selector", "", "Filter schedulable nodes by label")
 	flag.StringVar(&logLevel, "log-level", "info", "Log level")
@@ -364,6 +370,9 @@ func main() {
 		GatewayNamespace:    gatewayNamespace,
 		GatewayName:         gatewayName,
 		GPUVendor:           gpuVendor,
+		GPUModels:           gpuModels,
+		GPUModelAffinityKey: gpuModelAffinityKey,
+		GPUModelMapping:     gpuModelMapping,
 		CapacityCalc:        capacityCalc,
 		ImageCache:          imageCache,
 		LoadingServiceName:  loadingServiceName,

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -3025,6 +3025,12 @@ const docTemplate = `{
                 "runningAnalyses": {
                     "type": "integer"
                 },
+                "supportedGPUModels": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "usedCPU": {
                     "description": "millicores",
                     "type": "integer"

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -3019,6 +3019,12 @@
                 "runningAnalyses": {
                     "type": "integer"
                 },
+                "supportedGPUModels": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "usedCPU": {
                     "description": "millicores",
                     "type": "integer"

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -925,6 +925,10 @@ definitions:
         type: integer
       runningAnalyses:
         type: integer
+      supportedGPUModels:
+        items:
+          type: string
+        type: array
       usedCPU:
         description: millicores
         type: integer

--- a/operator/capacity_test.go
+++ b/operator/capacity_test.go
@@ -241,3 +241,36 @@ func TestHandleCapacityIncludesGPUVendor(t *testing.T) {
 		})
 	}
 }
+
+// TestHandleCapacityIncludesGPUModels confirms that HandleCapacity copies
+// the operator's configured GPU model list into the response so the
+// scheduler can filter capability at routing time.
+func TestHandleCapacityIncludesGPUModels(t *testing.T) {
+	tests := []struct {
+		name   string
+		models []string
+		want   []string
+	}{
+		{"no models advertised", nil, nil},
+		{"single model", []string{"NVIDIA-A10G"}, []string{"NVIDIA-A10G"}},
+		{"multiple models", []string{"NVIDIA-A10G", "NVIDIA-L4", "NVIDIA-L40S"}, []string{"NVIDIA-A10G", "NVIDIA-L4", "NVIDIA-L40S"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			op, _, _ := newTestOperatorWithModels(t, 10, tt.models)
+
+			e := echo.New()
+			req := httptest.NewRequest(http.MethodGet, "/capacity", nil)
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+
+			require.NoError(t, op.HandleCapacity(c))
+			require.Equal(t, http.StatusOK, rec.Code)
+
+			var resp operatorclient.CapacityResponse
+			require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+			assert.Equal(t, tt.want, resp.SupportedGPUModels)
+		})
+	}
+}

--- a/operator/handlers.go
+++ b/operator/handlers.go
@@ -53,6 +53,9 @@ type Operator struct {
 	gatewayNamespace    string
 	gatewayName         string
 	gpuVendor           GPUVendor
+	gpuModels           []string          // Canonical GFD-style GPU model names this cluster can deliver; empty means model-agnostic.
+	gpuModelAffinityKey string            // Node-label key this cluster uses for GPU-model affinity; empty means use the canonical nvidia.com/gpu.product.
+	gpuModelMapping     map[string]string // Canonical NVIDIA-* model name → cluster-side value (e.g. NVIDIA-A10G → a10g on EKS).
 	capacityCalc        *CapacityCalculator
 	imageCache          *ImageCacheManager
 	loadingServiceName  string
@@ -77,6 +80,9 @@ type OperatorOptions struct {
 	GatewayNamespace    string
 	GatewayName         string
 	GPUVendor           GPUVendor
+	GPUModels           []string          // Canonical GFD-style GPU model names this cluster can deliver; empty means model-agnostic.
+	GPUModelAffinityKey string            // Node-label key this cluster uses for GPU-model affinity; empty means use the canonical nvidia.com/gpu.product.
+	GPUModelMapping     map[string]string // Canonical NVIDIA-* model name → cluster-side value (e.g. NVIDIA-A10G → a10g on EKS).
 	CapacityCalc        *CapacityCalculator
 	ImageCache          *ImageCacheManager
 	LoadingServiceName  string
@@ -130,6 +136,9 @@ func NewOperator(opts OperatorOptions) (*Operator, error) {
 		gatewayNamespace:    opts.GatewayNamespace,
 		gatewayName:         opts.GatewayName,
 		gpuVendor:           opts.GPUVendor,
+		gpuModels:           opts.GPUModels,
+		gpuModelAffinityKey: opts.GPUModelAffinityKey,
+		gpuModelMapping:     opts.GPUModelMapping,
 		capacityCalc:        opts.CapacityCalc,
 		imageCache:          opts.ImageCache,
 		loadingServiceName:  opts.LoadingServiceName,
@@ -197,6 +206,7 @@ func (o *Operator) HandleCapacity(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
 	cap.GPUVendor = string(o.gpuVendor)
+	cap.SupportedGPUModels = o.gpuModels
 	return c.JSON(http.StatusOK, cap)
 }
 
@@ -261,6 +271,12 @@ func (o *Operator) HandleLaunch(c echo.Context) error {
 	// Inject per-analysis vice-proxy args and ensure the cluster config secret
 	// is referenced as envFrom so vice-proxy gets cluster-level env vars.
 	TransformViceProxyArgs(bundle.Deployment, string(bundle.AnalysisID), o.clusterConfigSecret)
+
+	// Translate the bundle's canonical GPU-model node affinity into the
+	// key and values this cluster's nodes label themselves with. Must run
+	// BEFORE TransformGPUVendor: on AMD clusters that pass renames the
+	// nvidia.com/gpu.product key out from under this transform's lookup.
+	TransformGPUModels(bundle.Deployment, o.gpuModelAffinityKey, o.gpuModelMapping)
 
 	// Rewrite GPU resource names to match the cluster's GPU vendor.
 	TransformGPUVendor(bundle.Deployment, o.gpuVendor)

--- a/operator/handlers.go
+++ b/operator/handlers.go
@@ -274,7 +274,7 @@ func (o *Operator) HandleLaunch(c echo.Context) error {
 
 	// Translate the bundle's canonical GPU-model node affinity into the
 	// key and values this cluster's nodes label themselves with. Must run
-	// BEFORE TransformGPUVendor: on AMD clusters that pass renames the
+	// BEFORE TransformGPUVendor, which on AMD clusters renames the
 	// nvidia.com/gpu.product key out from under this transform's lookup.
 	TransformGPUModels(bundle.Deployment, o.gpuModelAffinityKey, o.gpuModelMapping)
 

--- a/operator/handlers_launch_test.go
+++ b/operator/handlers_launch_test.go
@@ -231,6 +231,78 @@ func TestHandleLaunchGPUVendorAMD(t *testing.T) {
 	assert.False(t, hasNvidia, "deployed deployment should not have nvidia.com/gpu in requests")
 }
 
+// TestHandleLaunchGPUModelTranslation verifies that HandleLaunch rewrites the
+// bundle's canonical GPU-model node affinity (nvidia.com/gpu.product) into the
+// cluster-local key and values configured on the operator (the EKS case).
+func TestHandleLaunchGPUModelTranslation(t *testing.T) {
+	op, clientset, _ := newTestOperatorWith(t, 10, GPUVendorNvidia, []string{"NVIDIA-A10G"})
+	op.gpuModelAffinityKey = "eks.amazonaws.com/instance-gpu-name"
+	op.gpuModelMapping = map[string]string{"NVIDIA-A10G": "a10g"}
+
+	bundle := operatorclient.AnalysisBundle{
+		AnalysisID: "gpu-model-test",
+		Deployment: &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   "gpu-model-dep",
+				Labels: map[string]string{constants.AnalysisIDLabel: "gpu-model-test"},
+			},
+			Spec: appsv1.DeploymentSpec{
+				Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "test"}},
+				Template: apiv1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "test"}},
+					Spec: apiv1.PodSpec{
+						Affinity: &apiv1.Affinity{
+							NodeAffinity: &apiv1.NodeAffinity{
+								RequiredDuringSchedulingIgnoredDuringExecution: &apiv1.NodeSelector{
+									NodeSelectorTerms: []apiv1.NodeSelectorTerm{{
+										MatchExpressions: []apiv1.NodeSelectorRequirement{{
+											Key:      constants.GPUModelAffinityKey,
+											Operator: apiv1.NodeSelectorOpIn,
+											Values:   []string{"NVIDIA-A10G"},
+										}},
+									}},
+								},
+							},
+						},
+						Containers: []apiv1.Container{{Name: "analysis", Image: "img"}},
+					},
+				},
+			},
+		},
+		Service: &apiv1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   "gpu-model-svc",
+				Labels: map[string]string{constants.AnalysisIDLabel: "gpu-model-test"},
+			},
+			Spec: apiv1.ServiceSpec{Ports: []apiv1.ServicePort{{Port: 80}}},
+		},
+	}
+
+	body, err := json.Marshal(bundle)
+	require.NoError(t, err)
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/analyses", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	err = op.HandleLaunch(c)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusCreated, rec.Code)
+
+	ctx := context.Background()
+	dep, err := clientset.AppsV1().Deployments("vice-apps").Get(ctx, "gpu-model-dep", metav1.GetOptions{})
+	require.NoError(t, err)
+
+	terms := dep.Spec.Template.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
+	require.Len(t, terms, 1)
+	require.Len(t, terms[0].MatchExpressions, 1)
+	expr := terms[0].MatchExpressions[0]
+	assert.Equal(t, "eks.amazonaws.com/instance-gpu-name", expr.Key, "affinity key should be rewritten to the cluster-local key")
+	assert.Equal(t, []string{"a10g"}, expr.Values, "model values should be translated to cluster-local values")
+}
+
 func TestHandleLaunchFullBundle(t *testing.T) {
 	op, clientset, gwClientset := newTestOperator(t, 10)
 

--- a/operator/handlers_test.go
+++ b/operator/handlers_test.go
@@ -90,6 +90,35 @@ func newTestOperator(t *testing.T, maxAnalyses int, vendor ...GPUVendor) (*Opera
 	return op, clientset, gwClientset
 }
 
+// newTestOperatorWithModels is the variant used by tests that need to
+// assert behavior driven by the operator's configured GPU model list.
+func newTestOperatorWithModels(t *testing.T, maxAnalyses int, models []string) (*Operator, *fake.Clientset, *gatewayfake.Clientset) {
+	t.Helper()
+	clientset := fake.NewSimpleClientset()
+	gwClientset := gatewayfake.NewSimpleClientset()
+	calc, err := NewCapacityCalculator(clientset, "vice-apps", maxAnalyses, "")
+	require.NoError(t, err)
+	cache := NewImageCacheManager(clientset, "vice-apps", "vice-image-pull-secret")
+	op, err := NewOperator(OperatorOptions{
+		Clientset:           clientset,
+		GatewayClient:       gwClientset.GatewayV1(),
+		Namespace:           "vice-apps",
+		GatewayNamespace:    "vice-apps",
+		GatewayName:         "vice",
+		GPUVendor:           GPUVendorNvidia,
+		GPUModels:           models,
+		CapacityCalc:        calc,
+		ImageCache:          cache,
+		LoadingServiceName:  "vice-operator-loading",
+		LoadingServicePort:  80,
+		LoadingTimeoutMs:    600000,
+		ClusterConfigSecret: "cluster-config-secret",
+		UserSuffix:          constants.DefaultUserSuffix,
+	})
+	require.NoError(t, err)
+	return op, clientset, gwClientset
+}
+
 func TestOperatorOptionsValidate(t *testing.T) {
 	// valid is the minimum set of fields that satisfies Validate; each
 	// row below mutates a single field so the assertion can isolate

--- a/operator/handlers_test.go
+++ b/operator/handlers_test.go
@@ -66,33 +66,19 @@ func newTestOperator(t *testing.T, maxAnalyses int, vendor ...GPUVendor) (*Opera
 	if len(vendor) > 0 {
 		gpuVendor = vendor[0]
 	}
-	clientset := fake.NewSimpleClientset()
-	gwClientset := gatewayfake.NewSimpleClientset()
-	calc, err := NewCapacityCalculator(clientset, "vice-apps", maxAnalyses, "")
-	require.NoError(t, err)
-	cache := NewImageCacheManager(clientset, "vice-apps", "vice-image-pull-secret")
-	op, err := NewOperator(OperatorOptions{
-		Clientset:           clientset,
-		GatewayClient:       gwClientset.GatewayV1(),
-		Namespace:           "vice-apps",
-		GatewayNamespace:    "vice-apps",
-		GatewayName:         "vice",
-		GPUVendor:           gpuVendor,
-		CapacityCalc:        calc,
-		ImageCache:          cache,
-		LoadingServiceName:  "vice-operator-loading",
-		LoadingServicePort:  80,
-		LoadingTimeoutMs:    600000,
-		ClusterConfigSecret: "cluster-config-secret",
-		UserSuffix:          constants.DefaultUserSuffix,
-	})
-	require.NoError(t, err)
-	return op, clientset, gwClientset
+	return newTestOperatorWith(t, maxAnalyses, gpuVendor, nil)
 }
 
-// newTestOperatorWithModels is the variant used by tests that need to
-// assert behavior driven by the operator's configured GPU model list.
+// newTestOperatorWithModels builds a test Operator that advertises the given
+// GPU model list (vendor fixed to NVIDIA, since models are NVIDIA-specific).
 func newTestOperatorWithModels(t *testing.T, maxAnalyses int, models []string) (*Operator, *fake.Clientset, *gatewayfake.Clientset) {
+	t.Helper()
+	return newTestOperatorWith(t, maxAnalyses, GPUVendorNvidia, models)
+}
+
+// newTestOperatorWith is the shared constructor behind newTestOperator and
+// newTestOperatorWithModels.
+func newTestOperatorWith(t *testing.T, maxAnalyses int, vendor GPUVendor, models []string) (*Operator, *fake.Clientset, *gatewayfake.Clientset) {
 	t.Helper()
 	clientset := fake.NewSimpleClientset()
 	gwClientset := gatewayfake.NewSimpleClientset()
@@ -105,7 +91,7 @@ func newTestOperatorWithModels(t *testing.T, maxAnalyses int, models []string) (
 		Namespace:           "vice-apps",
 		GatewayNamespace:    "vice-apps",
 		GatewayName:         "vice",
-		GPUVendor:           GPUVendorNvidia,
+		GPUVendor:           vendor,
 		GPUModels:           models,
 		CapacityCalc:        calc,
 		ImageCache:          cache,

--- a/operator/transforms.go
+++ b/operator/transforms.go
@@ -78,6 +78,101 @@ func TransformGPUVendor(deployment *appsv1.Deployment, vendor GPUVendor) {
 	})
 }
 
+// TransformGPUModels rewrites the bundle's required node-affinity GPU
+// model match expressions for the local cluster. Bundles arrive with the
+// canonical (GFD-style) key nvidia.com/gpu.product and canonical model
+// values (e.g. NVIDIA-A10G). Each operator translates these into the key
+// and values its cluster understands:
+//
+//   - On-prem with NVIDIA GFD: leave the key alone and pass values
+//     through untouched. Default config (key=="nvidia.com/gpu.product"
+//     and empty mapping) is treated as the identity transform so
+//     upgrading the operator without re-configuring is a no-op.
+//   - EKS Auto Mode (no GFD): set key to
+//     eks.amazonaws.com/instance-gpu-name and mapping to translate each
+//     canonical name to its EKS label value (NVIDIA-A10G → a10g, etc.).
+//
+// Values not present in mapping are dropped. If translation empties an
+// entry's Values, the whole match expression is removed so we don't
+// emit a Values: [] that would match nothing. Surrounding match
+// expressions (e.g. analysis Exists, gpu In [true]) are preserved.
+// Runs on required + preferred affinity. Modifies the deployment in
+// place. Must be called BEFORE TransformGPUVendor on AMD clusters,
+// because that pass renames nvidia.com/gpu.product → amd.com/gpu.product
+// and this transform's lookup would no longer find its key.
+func TransformGPUModels(deployment *appsv1.Deployment, key string, mapping map[string]string) {
+	if deployment == nil {
+		return
+	}
+	// Default config (canonical key, no mapping) is the identity — leave
+	// the deployment alone so untouched operators preserve today's behavior.
+	if (key == "" || key == nvidiaModelAffinityK) && len(mapping) == 0 {
+		return
+	}
+	affinity := deployment.Spec.Template.Spec.Affinity
+	if affinity == nil || affinity.NodeAffinity == nil {
+		return
+	}
+	if req := affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution; req != nil {
+		for i := range req.NodeSelectorTerms {
+			req.NodeSelectorTerms[i].MatchExpressions = rewriteGPUModelExprs(
+				req.NodeSelectorTerms[i].MatchExpressions, key, mapping,
+			)
+		}
+	}
+	for i := range affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution {
+		pref := &affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution[i]
+		pref.Preference.MatchExpressions = rewriteGPUModelExprs(
+			pref.Preference.MatchExpressions, key, mapping,
+		)
+	}
+}
+
+// rewriteGPUModelExprs returns a new slice with each nvidia.com/gpu.product
+// match expression rewritten according to `key` and `mapping`. Entries
+// whose translated value list is empty are dropped. Non-GPU-model
+// expressions pass through unchanged.
+func rewriteGPUModelExprs(exprs []apiv1.NodeSelectorRequirement, key string, mapping map[string]string) []apiv1.NodeSelectorRequirement {
+	out := make([]apiv1.NodeSelectorRequirement, 0, len(exprs))
+	for _, expr := range exprs {
+		if expr.Key != nvidiaModelAffinityK {
+			out = append(out, expr)
+			continue
+		}
+		newValues := translateValues(expr.Values, mapping)
+		if len(newValues) == 0 {
+			// All canonical values map to nothing on this cluster; drop
+			// the entire match expression so we don't end up with a
+			// Values: [] requirement that K8s treats as unsatisfiable.
+			continue
+		}
+		newExpr := expr
+		if key != "" {
+			newExpr.Key = key
+		}
+		newExpr.Values = newValues
+		out = append(out, newExpr)
+	}
+	return out
+}
+
+// translateValues maps each canonical GPU model name through mapping.
+// Values not present in mapping are dropped. An empty mapping is the
+// identity (used only on the GFD-default path, which never reaches
+// here because TransformGPUModels short-circuits earlier).
+func translateValues(values []string, mapping map[string]string) []string {
+	if len(mapping) == 0 {
+		return values
+	}
+	out := make([]string, 0, len(values))
+	for _, v := range values {
+		if mapped, ok := mapping[v]; ok {
+			out = append(out, mapped)
+		}
+	}
+	return out
+}
+
 // TransformWorkingDirStorageClass overrides the StorageClassName on the
 // per-analysis working-directory PVC (name prefix "working-dir-") with the
 // operator's configured value. app-exposer leaves StorageClassName unset so

--- a/operator/transforms.go
+++ b/operator/transforms.go
@@ -16,12 +16,12 @@ import (
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
-// GPU resource and affinity key constants used by TransformGPUVendor.
+// GPU resource and affinity key constants used by TransformGPUVendor. The
+// canonical NVIDIA GPU-model affinity key is constants.GPUModelAffinityKey.
 const (
-	nvidiaGPUResource    apiv1.ResourceName = "nvidia.com/gpu"
-	amdGPUResource       apiv1.ResourceName = "amd.com/gpu"
-	nvidiaModelAffinityK                    = "nvidia.com/gpu.product"
-	amdModelAffinityK                       = "amd.com/gpu.product"
+	nvidiaGPUResource apiv1.ResourceName = "nvidia.com/gpu"
+	amdGPUResource    apiv1.ResourceName = "amd.com/gpu"
+	amdModelAffinityK                    = "amd.com/gpu.product"
 )
 
 // GPUVendor describes which GPU vendor the operator's cluster uses.
@@ -78,35 +78,24 @@ func TransformGPUVendor(deployment *appsv1.Deployment, vendor GPUVendor) {
 	})
 }
 
-// TransformGPUModels rewrites the bundle's required node-affinity GPU
-// model match expressions for the local cluster. Bundles arrive with the
-// canonical (GFD-style) key nvidia.com/gpu.product and canonical model
-// values (e.g. NVIDIA-A10G). Each operator translates these into the key
-// and values its cluster understands:
-//
-//   - On-prem with NVIDIA GFD: leave the key alone and pass values
-//     through untouched. Default config (key=="nvidia.com/gpu.product"
-//     and empty mapping) is treated as the identity transform so
-//     upgrading the operator without re-configuring is a no-op.
-//   - EKS Auto Mode (no GFD): set key to
-//     eks.amazonaws.com/instance-gpu-name and mapping to translate each
-//     canonical name to its EKS label value (NVIDIA-A10G → a10g, etc.).
-//
-// Values not present in mapping are dropped. If translation empties an
-// entry's Values, the whole match expression is removed so we don't
-// emit a Values: [] that would match nothing. Surrounding match
-// expressions (e.g. analysis Exists, gpu In [true]) are preserved.
-// Runs on required + preferred affinity. Modifies the deployment in
-// place. Must be called BEFORE TransformGPUVendor on AMD clusters,
-// because that pass renames nvidia.com/gpu.product → amd.com/gpu.product
-// and this transform's lookup would no longer find its key.
+// TransformGPUModels rewrites the bundle's GPU-model node-affinity match
+// expressions (canonical key nvidia.com/gpu.product, canonical values like
+// NVIDIA-A10G) into the key and values the local cluster uses, across both
+// required and preferred affinity. The default config (canonical key, empty
+// mapping) is the identity, so on-prem NVIDIA-GFD operators stay no-ops; EKS
+// Auto Mode sets key to eks.amazonaws.com/instance-gpu-name with a mapping
+// like NVIDIA-A10G→a10g. Values absent from a non-empty mapping are dropped,
+// and an expression left with no values is removed so we never emit an
+// unsatisfiable Values: []. Modifies the deployment in place. Must run BEFORE
+// TransformGPUVendor, which on AMD clusters renames nvidia.com/gpu.product and
+// would hide the key from this transform's lookup.
 func TransformGPUModels(deployment *appsv1.Deployment, key string, mapping map[string]string) {
 	if deployment == nil {
 		return
 	}
 	// Default config (canonical key, no mapping) is the identity — leave
 	// the deployment alone so untouched operators preserve today's behavior.
-	if (key == "" || key == nvidiaModelAffinityK) && len(mapping) == 0 {
+	if (key == "" || key == constants.GPUModelAffinityKey) && len(mapping) == 0 {
 		return
 	}
 	affinity := deployment.Spec.Template.Spec.Affinity
@@ -135,7 +124,7 @@ func TransformGPUModels(deployment *appsv1.Deployment, key string, mapping map[s
 func rewriteGPUModelExprs(exprs []apiv1.NodeSelectorRequirement, key string, mapping map[string]string) []apiv1.NodeSelectorRequirement {
 	out := make([]apiv1.NodeSelectorRequirement, 0, len(exprs))
 	for _, expr := range exprs {
-		if expr.Key != nvidiaModelAffinityK {
+		if expr.Key != constants.GPUModelAffinityKey {
 			out = append(out, expr)
 			continue
 		}
@@ -158,8 +147,8 @@ func rewriteGPUModelExprs(exprs []apiv1.NodeSelectorRequirement, key string, map
 
 // translateValues maps each canonical GPU model name through mapping.
 // Values not present in mapping are dropped. An empty mapping is the
-// identity (used only on the GFD-default path, which never reaches
-// here because TransformGPUModels short-circuits earlier).
+// identity (values pass through unchanged) — reached when a cluster
+// renames the affinity key but keeps the canonical model values.
 func translateValues(values []string, mapping map[string]string) []string {
 	if len(mapping) == 0 {
 		return values
@@ -229,7 +218,7 @@ func rewriteNodeAffinityKeys(affinity *apiv1.Affinity) {
 // equivalent in a slice of NodeSelectorRequirements.
 func rewriteMatchExpressions(exprs []apiv1.NodeSelectorRequirement) {
 	for i := range exprs {
-		if exprs[i].Key == nvidiaModelAffinityK {
+		if exprs[i].Key == constants.GPUModelAffinityKey {
 			exprs[i].Key = amdModelAffinityK
 		}
 	}

--- a/operator/transforms_gpu_test.go
+++ b/operator/transforms_gpu_test.go
@@ -213,6 +213,128 @@ func TestTransformGPUVendor(t *testing.T) {
 	}
 }
 
+// TestTransformGPUModels verifies that per-cluster GPU-model translation
+// rewrites the key and values of the nvidia.com/gpu.product match
+// expression, drops entries whose values translate to nothing, and
+// leaves surrounding match expressions intact.
+func TestTransformGPUModels(t *testing.T) {
+	tests := []struct {
+		name         string
+		key          string
+		mapping      map[string]string
+		wantKey      string   // expected key on the model entry; "" means entry should be removed
+		wantValues   []string // expected values when the entry survives
+		wantOtherKey string   // expected key of the surrounding "gpu" match expression
+	}{
+		{
+			name:         "default config is identity",
+			key:          "",
+			mapping:      nil,
+			wantKey:      nvidiaModelAffinityK,
+			wantValues:   []string{"NVIDIA-A100"},
+			wantOtherKey: "gpu",
+		},
+		{
+			name:         "default key with mapping rewrites values only",
+			key:          "",
+			mapping:      map[string]string{"NVIDIA-A100": "renamed-a100"},
+			wantKey:      nvidiaModelAffinityK,
+			wantValues:   []string{"renamed-a100"},
+			wantOtherKey: "gpu",
+		},
+		{
+			name:         "EKS-style rewrites key and values",
+			key:          "eks.amazonaws.com/instance-gpu-name",
+			mapping:      map[string]string{"NVIDIA-A100": "a100", "NVIDIA-A10G": "a10g"},
+			wantKey:      "eks.amazonaws.com/instance-gpu-name",
+			wantValues:   []string{"a100"},
+			wantOtherKey: "gpu",
+		},
+		{
+			name:         "value not in mapping is dropped (entry removed)",
+			key:          "eks.amazonaws.com/instance-gpu-name",
+			mapping:      map[string]string{"NVIDIA-A10G": "a10g"},
+			wantKey:      "", // entry removed because A100 has no mapping
+			wantOtherKey: "gpu",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dep := makeGPUDeployment()
+			TransformGPUModels(dep, tt.key, tt.mapping)
+
+			require.NotNil(t, dep.Spec.Template.Spec.Affinity)
+			terms := dep.Spec.Template.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
+			require.Len(t, terms, 1)
+
+			var gotModel *apiv1.NodeSelectorRequirement
+			var gotOther *apiv1.NodeSelectorRequirement
+			for i, expr := range terms[0].MatchExpressions {
+				switch expr.Key {
+				case nvidiaModelAffinityK, "eks.amazonaws.com/instance-gpu-name":
+					gotModel = &terms[0].MatchExpressions[i]
+				case tt.wantOtherKey:
+					gotOther = &terms[0].MatchExpressions[i]
+				}
+			}
+
+			if tt.wantKey == "" {
+				assert.Nil(t, gotModel, "model entry should have been dropped")
+			} else {
+				require.NotNil(t, gotModel, "expected a model match expression with key %s", tt.wantKey)
+				assert.Equal(t, tt.wantKey, gotModel.Key)
+				assert.Equal(t, tt.wantValues, gotModel.Values)
+			}
+
+			require.NotNil(t, gotOther, "surrounding gpu match expression must be preserved")
+			assert.Equal(t, []string{"true"}, gotOther.Values)
+		})
+	}
+
+	t.Run("nil deployment does not panic", func(t *testing.T) {
+		TransformGPUModels(nil, "k", map[string]string{"a": "b"})
+	})
+
+	t.Run("deployment with no affinity does not panic", func(t *testing.T) {
+		dep := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "no-affinity"}}
+		TransformGPUModels(dep, "k", map[string]string{"a": "b"})
+		assert.Nil(t, dep.Spec.Template.Spec.Affinity)
+	})
+
+	t.Run("preferred-only affinity is rewritten", func(t *testing.T) {
+		dep := &appsv1.Deployment{
+			Spec: appsv1.DeploymentSpec{
+				Template: apiv1.PodTemplateSpec{
+					Spec: apiv1.PodSpec{
+						Affinity: &apiv1.Affinity{
+							NodeAffinity: &apiv1.NodeAffinity{
+								PreferredDuringSchedulingIgnoredDuringExecution: []apiv1.PreferredSchedulingTerm{{
+									Weight: 1,
+									Preference: apiv1.NodeSelectorTerm{
+										MatchExpressions: []apiv1.NodeSelectorRequirement{{
+											Key:      nvidiaModelAffinityK,
+											Operator: apiv1.NodeSelectorOpIn,
+											Values:   []string{"NVIDIA-A10G"},
+										}},
+									},
+								}},
+							},
+						},
+					},
+				},
+			},
+		}
+		TransformGPUModels(dep, "eks.amazonaws.com/instance-gpu-name", map[string]string{"NVIDIA-A10G": "a10g"})
+
+		pref := dep.Spec.Template.Spec.Affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution
+		require.Len(t, pref, 1)
+		require.Len(t, pref[0].Preference.MatchExpressions, 1)
+		assert.Equal(t, "eks.amazonaws.com/instance-gpu-name", pref[0].Preference.MatchExpressions[0].Key)
+		assert.Equal(t, []string{"a10g"}, pref[0].Preference.MatchExpressions[0].Values)
+	})
+}
+
 // TestEqualizeGPUResources verifies that mismatched GPU requests/limits are
 // equalized to the higher value for both NVIDIA and AMD vendors.
 func TestEqualizeGPUResources(t *testing.T) {

--- a/operator/transforms_gpu_test.go
+++ b/operator/transforms_gpu_test.go
@@ -3,6 +3,7 @@ package operator
 import (
 	"testing"
 
+	"github.com/cyverse-de/app-exposer/constants"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
@@ -67,7 +68,7 @@ func makeGPUDeployment() *appsv1.Deployment {
 									{
 										MatchExpressions: []apiv1.NodeSelectorRequirement{
 											{Key: "gpu", Operator: apiv1.NodeSelectorOpIn, Values: []string{"true"}},
-											{Key: nvidiaModelAffinityK, Operator: apiv1.NodeSelectorOpIn, Values: []string{"NVIDIA-A100"}},
+											{Key: constants.GPUModelAffinityKey, Operator: apiv1.NodeSelectorOpIn, Values: []string{"NVIDIA-A100"}},
 										},
 									},
 								},
@@ -94,7 +95,7 @@ func TestTransformGPUVendor(t *testing.T) {
 			deployment:        makeGPUDeployment(),
 			vendor:            GPUVendorNvidia,
 			wantGPUResource:   nvidiaGPUResource,
-			wantAffinityKey:   nvidiaModelAffinityK,
+			wantAffinityKey:   constants.GPUModelAffinityKey,
 			wantNoGPUResource: amdGPUResource,
 		},
 		{
@@ -230,7 +231,7 @@ func TestTransformGPUModels(t *testing.T) {
 			name:         "default config is identity",
 			key:          "",
 			mapping:      nil,
-			wantKey:      nvidiaModelAffinityK,
+			wantKey:      constants.GPUModelAffinityKey,
 			wantValues:   []string{"NVIDIA-A100"},
 			wantOtherKey: "gpu",
 		},
@@ -238,7 +239,7 @@ func TestTransformGPUModels(t *testing.T) {
 			name:         "default key with mapping rewrites values only",
 			key:          "",
 			mapping:      map[string]string{"NVIDIA-A100": "renamed-a100"},
-			wantKey:      nvidiaModelAffinityK,
+			wantKey:      constants.GPUModelAffinityKey,
 			wantValues:   []string{"renamed-a100"},
 			wantOtherKey: "gpu",
 		},
@@ -272,7 +273,7 @@ func TestTransformGPUModels(t *testing.T) {
 			var gotOther *apiv1.NodeSelectorRequirement
 			for i, expr := range terms[0].MatchExpressions {
 				switch expr.Key {
-				case nvidiaModelAffinityK, "eks.amazonaws.com/instance-gpu-name":
+				case constants.GPUModelAffinityKey, "eks.amazonaws.com/instance-gpu-name":
 					gotModel = &terms[0].MatchExpressions[i]
 				case tt.wantOtherKey:
 					gotOther = &terms[0].MatchExpressions[i]
@@ -313,7 +314,7 @@ func TestTransformGPUModels(t *testing.T) {
 									Weight: 1,
 									Preference: apiv1.NodeSelectorTerm{
 										MatchExpressions: []apiv1.NodeSelectorRequirement{{
-											Key:      nvidiaModelAffinityK,
+											Key:      constants.GPUModelAffinityKey,
 											Operator: apiv1.NodeSelectorOpIn,
 											Values:   []string{"NVIDIA-A10G"},
 										}},

--- a/operatorclient/scheduler.go
+++ b/operatorclient/scheduler.go
@@ -64,10 +64,11 @@ var (
 	// apart from a capacity failure.
 	ErrNoCompatibleOperator = errors.New("no operator with compatible GPU vendor")
 
-	// ErrNoCompatibleModel means every operator with capacity advertises a
-	// SupportedGPUModels list that does not intersect the analysis's
-	// requested GPU model(s). Distinct from ErrNoCompatibleOperator so the
-	// caller can tell "wrong vendor" apart from "right vendor, wrong model".
+	// ErrNoCompatibleModel means the analysis requested specific GPU
+	// model(s), at least one operator was skipped for advertising a
+	// SupportedGPUModels list that does not intersect them, and no operator
+	// could run it. Distinct from ErrNoCompatibleOperator so the caller can
+	// tell "wrong vendor" apart from "right vendor, wrong model".
 	ErrNoCompatibleModel = errors.New("no operator advertises a compatible GPU model")
 )
 

--- a/operatorclient/scheduler.go
+++ b/operatorclient/scheduler.go
@@ -63,6 +63,12 @@ var (
 	// ErrAllOperatorsExhausted so callers can tell a routing-policy failure
 	// apart from a capacity failure.
 	ErrNoCompatibleOperator = errors.New("no operator with compatible GPU vendor")
+
+	// ErrNoCompatibleModel means every operator with capacity advertises a
+	// SupportedGPUModels list that does not intersect the analysis's
+	// requested GPU model(s). Distinct from ErrNoCompatibleOperator so the
+	// caller can tell "wrong vendor" apart from "right vendor, wrong model".
+	ErrNoCompatibleModel = errors.New("no operator advertises a compatible GPU model")
 )
 
 // vendorCompatible reports whether an operator advertising vendor `have`
@@ -75,6 +81,28 @@ func vendorCompatible(want, have string) bool {
 		return true
 	}
 	return want == have
+}
+
+// modelCompatible reports whether an operator advertising `have` GPU
+// models can run a bundle requesting any of `want`. An empty `want`
+// means the bundle has no GPU model preference (any operator works).
+// An empty `have` means the operator does not filter on model (pre-
+// upgrade or model-agnostic by config); treated as compatible for
+// backwards compatibility.
+func modelCompatible(want, have []string) bool {
+	if len(want) == 0 || len(have) == 0 {
+		return true
+	}
+	supported := make(map[string]struct{}, len(have))
+	for _, m := range have {
+		supported[m] = struct{}{}
+	}
+	for _, m := range want {
+		if _, ok := supported[m]; ok {
+			return true
+		}
+	}
+	return false
 }
 
 // Scheduler manages a priority-ordered list of operator clients and
@@ -147,18 +175,21 @@ func (s *Scheduler) LaunchAnalysis(ctx context.Context, bundle *AnalysisBundle) 
 		return uuid.Nil, "", ErrNoOperators
 	}
 
-	// Track capacity-check errors, transient launch failures, and vendor
-	// mismatches separately so we can distinguish "all operators
-	// unreachable" / "all operators at capacity" / "no compatible vendor"
-	// and preserve the last underlying error for diagnostics.
+	// Track capacity-check errors, transient launch failures, vendor
+	// mismatches, and GPU-model mismatches separately so we can
+	// distinguish "all operators unreachable" / "all operators at
+	// capacity" / "no compatible vendor" / "no compatible model" and
+	// preserve the last underlying error for diagnostics.
 	var (
 		capacityErrors   int
 		transientErrors  int
 		vendorMismatches int
+		modelMismatches  int
 		lastTransient    error
 	)
 
 	wantVendor := bundle.RequestedGPUVendor()
+	wantModels := bundle.RequestedGPUModels()
 
 	for _, op := range clients {
 		// Check capacity first.
@@ -182,6 +213,18 @@ func (s *Scheduler) LaunchAnalysis(ctx context.Context, bundle *AnalysisBundle) 
 			vendorMismatches++
 			log.Infof("operator %s vendor mismatch (analysis needs %s, operator is %s); skipping",
 				op.Name(), wantVendor, cap.GPUVendor)
+			continue
+		}
+
+		// Skip operators whose advertised GPU model set doesn't
+		// intersect the bundle's requested models. Empty wantModels
+		// (no model preference) and empty cap.SupportedGPUModels
+		// (operator pre-dates the field or doesn't filter) both mean
+		// "any" and pass through.
+		if !modelCompatible(wantModels, cap.SupportedGPUModels) {
+			modelMismatches++
+			log.Infof("operator %s model mismatch (analysis needs %v, operator supports %v); skipping",
+				op.Name(), wantModels, cap.SupportedGPUModels)
 			continue
 		}
 
@@ -220,10 +263,18 @@ func (s *Scheduler) LaunchAnalysis(ctx context.Context, bundle *AnalysisBundle) 
 			wantVendor, bundle.AnalysisID, ErrNoCompatibleOperator)
 	}
 
+	// No operator advertised a compatible GPU model. Surface this distinctly
+	// so callers can tell "right vendor, wrong model" apart from
+	// ErrNoCompatibleOperator and ErrAllOperatorsExhausted.
+	if len(wantModels) > 0 && modelMismatches > 0 && capacityErrors+vendorMismatches+modelMismatches == len(clients) {
+		return uuid.Nil, "", fmt.Errorf("no operator with model %v for analysis %s: %w",
+			wantModels, bundle.AnalysisID, ErrNoCompatibleModel)
+	}
+
 	// Every operator that passed capacity check then failed the launch for
 	// transient reasons. Surface the last underlying error so the caller
 	// can distinguish it from a real "all at capacity" situation.
-	if transientErrors > 0 && capacityErrors+transientErrors+vendorMismatches == len(clients) {
+	if transientErrors > 0 && capacityErrors+transientErrors+vendorMismatches+modelMismatches == len(clients) {
 		return uuid.Nil, "", fmt.Errorf("all %d operators unhealthy; last error: %w", len(clients), lastTransient)
 	}
 

--- a/operatorclient/scheduler_test.go
+++ b/operatorclient/scheduler_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/oauth2"
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 // schedulerWithConfigs builds a Scheduler whose operators come from the
@@ -48,6 +50,13 @@ func mockOperatorServerWithVendor(capacitySlots int, vendor string) *httptest.Se
 	return mockOperatorServerWithStatuses(capacitySlots, false, 0, 0, vendor)
 }
 
+// mockOperatorServerWithModels is a mock that advertises a specific set
+// of supported GPU models (and an Nvidia vendor) and is otherwise healthy
+// with the given capacity.
+func mockOperatorServerWithModels(capacitySlots int, models []string) *httptest.Server {
+	return mockOperatorServerFull(capacitySlots, false, 0, 0, "nvidia", models)
+}
+
 // mockOperatorServerWithStatuses is the explicit variant that also lets a
 // test inject non-2xx responses for the capacity and launch endpoints —
 // used by cases that exercise error-classification paths in the scheduler.
@@ -56,6 +65,14 @@ func mockOperatorServerWithVendor(capacitySlots int, vendor string) *httptest.Se
 // CapacityResponse.GPUVendor field; "" means "operator does not report
 // a vendor" (treated as compatible by the scheduler).
 func mockOperatorServerWithStatuses(capacitySlots int, rejectLaunch bool, capacityStatus, launchStatus int, vendor string) *httptest.Server {
+	return mockOperatorServerFull(capacitySlots, rejectLaunch, capacityStatus, launchStatus, vendor, nil)
+}
+
+// mockOperatorServerFull is the most explicit form: same as
+// mockOperatorServerWithStatuses plus a SupportedGPUModels list to
+// advertise. The narrower helpers above delegate here so the per-test
+// signatures stay readable.
+func mockOperatorServerFull(capacitySlots int, rejectLaunch bool, capacityStatus, launchStatus int, vendor string, models []string) *httptest.Server {
 	var launchCount atomic.Int32
 
 	mux := http.NewServeMux()
@@ -65,10 +82,11 @@ func mockOperatorServerWithStatuses(capacitySlots int, rejectLaunch bool, capaci
 			return
 		}
 		resp := CapacityResponse{
-			MaxAnalyses:     10,
-			RunningAnalyses: 10 - capacitySlots,
-			AvailableSlots:  capacitySlots,
-			GPUVendor:       vendor,
+			MaxAnalyses:        10,
+			RunningAnalyses:    10 - capacitySlots,
+			AvailableSlots:     capacitySlots,
+			GPUVendor:          vendor,
+			SupportedGPUModels: models,
 		}
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(resp) //nolint:errcheck
@@ -355,6 +373,107 @@ func TestSchedulerLaunchOperatorWithoutVendorIsCompatible(t *testing.T) {
 	_, name, err := scheduler.LaunchAnalysis(context.Background(), bundle)
 	require.NoError(t, err)
 	assert.Equal(t, "no-vendor", name)
+}
+
+// gpuModelLaunchBundle builds a bundle whose deployment carries the given
+// GPU model node-affinity values and (when nvidiaGPU is true) an
+// nvidia.com/gpu resource request. Used by the model-routing scheduler
+// tests so the bundle exercises both RequestedGPUVendor (still nvidia)
+// and RequestedGPUModels (the supplied list).
+func gpuModelLaunchBundle(models []string) *AnalysisBundle {
+	b := gpuModelBundle([][]string{models})
+	// Add an nvidia.com/gpu request so the vendor check sees the bundle as
+	// an Nvidia GPU job; otherwise modelCompatible's "no GPU requirement"
+	// short-circuit would never trip the vendor check at all.
+	b.Deployment.Spec.Template.Spec.Containers = []apiv1.Container{{
+		Name: "main",
+		Resources: apiv1.ResourceRequirements{
+			Requests: apiv1.ResourceList{apiv1.ResourceName(gpuResourceNvidia): resource.MustParse("1")},
+		},
+	}}
+	return b
+}
+
+// TestSchedulerLaunchModelMismatchAllDisjoint covers the case where the
+// analysis requests a GPU model that no operator advertises. The scheduler
+// must surface ErrNoCompatibleModel — distinct from
+// ErrNoCompatibleOperator so callers can tell "right vendor, wrong model"
+// apart from "wrong vendor".
+func TestSchedulerLaunchModelMismatchAllDisjoint(t *testing.T) {
+	srv0 := mockOperatorServerWithModels(5, []string{"NVIDIA-A10G"})
+	defer srv0.Close()
+	srv1 := mockOperatorServerWithModels(5, []string{"NVIDIA-L4"})
+	defer srv1.Close()
+
+	scheduler := schedulerWithConfigs(t, []OperatorConfig{
+		{Name: "op-a10g", URL: srv0.URL},
+		{Name: "op-l4", URL: srv1.URL},
+	})
+
+	bundle := gpuModelLaunchBundle([]string{"NVIDIA-H100"})
+	_, _, err := scheduler.LaunchAnalysis(context.Background(), bundle)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrNoCompatibleModel)
+	assert.Contains(t, err.Error(), "NVIDIA-H100", "error must name the requested model")
+}
+
+// TestSchedulerLaunchModelMismatchSkipsToCompatible exercises the
+// "first operator's model doesn't match, second one does" path. The
+// scheduler must skip the A10G-only operator and land on the L4 one.
+func TestSchedulerLaunchModelMismatchSkipsToCompatible(t *testing.T) {
+	srv0 := mockOperatorServerWithModels(5, []string{"NVIDIA-A10G"})
+	defer srv0.Close()
+	srv1 := mockOperatorServerWithModels(5, []string{"NVIDIA-L4", "NVIDIA-L40S"})
+	defer srv1.Close()
+
+	scheduler := schedulerWithConfigs(t, []OperatorConfig{
+		{Name: "op-a10g", URL: srv0.URL},
+		{Name: "op-l4", URL: srv1.URL},
+	})
+
+	bundle := gpuModelLaunchBundle([]string{"NVIDIA-L4"})
+	_, name, err := scheduler.LaunchAnalysis(context.Background(), bundle)
+	require.NoError(t, err)
+	assert.Equal(t, "op-l4", name, "must skip A10G-only operator and land on the one that advertises L4")
+}
+
+// TestSchedulerLaunchOperatorWithoutModelsIsCompatible covers the
+// backwards-compatibility case: an operator that has not been upgraded
+// reports an empty SupportedGPUModels list. The scheduler must treat
+// that as compatible regardless of what model the bundle requests,
+// since "I don't advertise" is indistinguishable from
+// "I support everything" for routing-policy purposes.
+func TestSchedulerLaunchOperatorWithoutModelsIsCompatible(t *testing.T) {
+	srv0 := mockOperatorServerWithVendor(5, "nvidia")
+	defer srv0.Close()
+
+	scheduler := schedulerWithConfigs(t, []OperatorConfig{
+		{Name: "no-models", URL: srv0.URL},
+	})
+
+	bundle := gpuModelLaunchBundle([]string{"NVIDIA-A10G"})
+	_, name, err := scheduler.LaunchAnalysis(context.Background(), bundle)
+	require.NoError(t, err)
+	assert.Equal(t, "no-models", name)
+}
+
+// TestSchedulerLaunchNoModelRequestSkipsModelCheck covers the common
+// "this analysis has no model preference" case. The scheduler must NOT
+// reject operators just because the deployment has no model affinity at
+// all — model filtering applies only when the bundle requests one.
+func TestSchedulerLaunchNoModelRequestSkipsModelCheck(t *testing.T) {
+	srv0 := mockOperatorServerWithModels(5, []string{"NVIDIA-A10G"})
+	defer srv0.Close()
+
+	scheduler := schedulerWithConfigs(t, []OperatorConfig{
+		{Name: "op-a10g", URL: srv0.URL},
+	})
+
+	// Bundle has an Nvidia GPU request but no model affinity.
+	bundle := gpuBundle("nvidia.com/gpu", "main", "requests")
+	_, name, err := scheduler.LaunchAnalysis(context.Background(), bundle)
+	require.NoError(t, err)
+	assert.Equal(t, "op-a10g", name)
 }
 
 func TestSchedulerNoOperators(t *testing.T) {

--- a/operatorclient/scheduler_test.go
+++ b/operatorclient/scheduler_test.go
@@ -383,8 +383,9 @@ func TestSchedulerLaunchOperatorWithoutVendorIsCompatible(t *testing.T) {
 func gpuModelLaunchBundle(models []string) *AnalysisBundle {
 	b := gpuModelBundle([][]string{models})
 	// Add an nvidia.com/gpu request so the vendor check sees the bundle as
-	// an Nvidia GPU job; otherwise modelCompatible's "no GPU requirement"
-	// short-circuit would never trip the vendor check at all.
+	// an Nvidia GPU job; otherwise RequestedGPUVendor returns "" and
+	// vendorCompatible treats every operator as a match, so the vendor
+	// check is never exercised.
 	b.Deployment.Spec.Template.Spec.Containers = []apiv1.Container{{
 		Name: "main",
 		Resources: apiv1.ResourceRequirements{
@@ -408,6 +409,29 @@ func TestSchedulerLaunchModelMismatchAllDisjoint(t *testing.T) {
 	scheduler := schedulerWithConfigs(t, []OperatorConfig{
 		{Name: "op-a10g", URL: srv0.URL},
 		{Name: "op-l4", URL: srv1.URL},
+	})
+
+	bundle := gpuModelLaunchBundle([]string{"NVIDIA-H100"})
+	_, _, err := scheduler.LaunchAnalysis(context.Background(), bundle)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrNoCompatibleModel)
+	assert.Contains(t, err.Error(), "NVIDIA-H100", "error must name the requested model")
+}
+
+// TestSchedulerLaunchMixedVendorAndModelMismatch covers a fleet where one
+// operator is the wrong vendor and another is the right vendor but the wrong
+// model, while the analysis requests a model no operator can satisfy. The
+// model guard counts the vendor-mismatched operator too, so the mixed case
+// still resolves to the most specific routing error, ErrNoCompatibleModel.
+func TestSchedulerLaunchMixedVendorAndModelMismatch(t *testing.T) {
+	srvAMD := mockOperatorServerWithVendor(5, "amd")
+	defer srvAMD.Close()
+	srvL4 := mockOperatorServerWithModels(5, []string{"NVIDIA-L4"})
+	defer srvL4.Close()
+
+	scheduler := schedulerWithConfigs(t, []OperatorConfig{
+		{Name: "op-amd", URL: srvAMD.URL},
+		{Name: "op-l4", URL: srvL4.URL},
 	})
 
 	bundle := gpuModelLaunchBundle([]string{"NVIDIA-H100"})

--- a/operatorclient/types.go
+++ b/operatorclient/types.go
@@ -51,16 +51,20 @@ type AnalysisBundle struct {
 // place. GPUVendor is the cluster's configured GPU vendor (e.g.
 // "nvidia", "amd"); empty when the operator has no GPU configured or
 // pre-dates the field, in which case the scheduler treats it as
-// vendor-agnostic for backwards compatibility.
+// vendor-agnostic for backwards compatibility. SupportedGPUModels lists
+// canonical GFD-style model names (e.g. "NVIDIA-A10G", "NVIDIA-L4") that
+// this cluster can deliver; empty means the operator does not filter on
+// model and is treated as model-agnostic for backwards compatibility.
 type CapacityResponse struct {
-	MaxAnalyses       int    `json:"maxAnalyses"`
-	RunningAnalyses   int    `json:"runningAnalyses"`
-	AvailableSlots    int    `json:"availableSlots"`
-	AllocatableCPU    int64  `json:"allocatableCPU"`    // millicores
-	AllocatableMemory int64  `json:"allocatableMemory"` // bytes
-	UsedCPU           int64  `json:"usedCPU"`           // millicores
-	UsedMemory        int64  `json:"usedMemory"`        // bytes
-	GPUVendor         string `json:"gpuVendor,omitempty"`
+	MaxAnalyses        int      `json:"maxAnalyses"`
+	RunningAnalyses    int      `json:"runningAnalyses"`
+	AvailableSlots     int      `json:"availableSlots"`
+	AllocatableCPU     int64    `json:"allocatableCPU"`    // millicores
+	AllocatableMemory  int64    `json:"allocatableMemory"` // bytes
+	UsedCPU            int64    `json:"usedCPU"`           // millicores
+	UsedMemory         int64    `json:"usedMemory"`        // bytes
+	GPUVendor          string   `json:"gpuVendor,omitempty"`
+	SupportedGPUModels []string `json:"supportedGPUModels,omitempty"`
 }
 
 // HasCapacity reports whether this operator can accept a new analysis.
@@ -89,6 +93,12 @@ const (
 
 	gpuVendorNvidia = "nvidia"
 	gpuVendorAMD    = "amd"
+
+	// gpuModelAffinityKey is the canonical (GFD-style) node label key that
+	// app-exposer emits as a required match expression when an analysis
+	// has GPU model preferences. Each operator may later rewrite this key
+	// for its cluster's label scheme.
+	gpuModelAffinityKey = "nvidia.com/gpu.product"
 )
 
 // RequestedGPUVendor inspects the bundle's containers (and init
@@ -125,6 +135,42 @@ func vendorFromResources(rl apiv1.ResourceList) string {
 		}
 	}
 	return ""
+}
+
+// RequestedGPUModels returns the union of canonical GPU model names the
+// bundle's required node affinity asks for (key == "nvidia.com/gpu.product",
+// operator In). Returns an empty slice when the bundle has no model
+// constraint. Preferred-only affinities are ignored on purpose — the
+// scheduler filters strictly on what the analysis _requires_.
+func (b *AnalysisBundle) RequestedGPUModels() []string {
+	if b == nil || b.Deployment == nil {
+		return nil
+	}
+	affinity := b.Deployment.Spec.Template.Spec.Affinity
+	if affinity == nil || affinity.NodeAffinity == nil {
+		return nil
+	}
+	required := affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution
+	if required == nil {
+		return nil
+	}
+	seen := make(map[string]struct{})
+	var out []string
+	for _, term := range required.NodeSelectorTerms {
+		for _, expr := range term.MatchExpressions {
+			if expr.Key != gpuModelAffinityKey || expr.Operator != apiv1.NodeSelectorOpIn {
+				continue
+			}
+			for _, v := range expr.Values {
+				if _, dup := seen[v]; dup {
+					continue
+				}
+				seen[v] = struct{}{}
+				out = append(out, v)
+			}
+		}
+	}
+	return out
 }
 
 // Validate checks the bundle's top-level required fields and then

--- a/operatorclient/types.go
+++ b/operatorclient/types.go
@@ -93,12 +93,6 @@ const (
 
 	gpuVendorNvidia = "nvidia"
 	gpuVendorAMD    = "amd"
-
-	// gpuModelAffinityKey is the canonical (GFD-style) node label key that
-	// app-exposer emits as a required match expression when an analysis
-	// has GPU model preferences. Each operator may later rewrite this key
-	// for its cluster's label scheme.
-	gpuModelAffinityKey = "nvidia.com/gpu.product"
 )
 
 // RequestedGPUVendor inspects the bundle's containers (and init
@@ -158,7 +152,7 @@ func (b *AnalysisBundle) RequestedGPUModels() []string {
 	var out []string
 	for _, term := range required.NodeSelectorTerms {
 		for _, expr := range term.MatchExpressions {
-			if expr.Key != gpuModelAffinityKey || expr.Operator != apiv1.NodeSelectorOpIn {
+			if expr.Key != constants.GPUModelAffinityKey || expr.Operator != apiv1.NodeSelectorOpIn {
 				continue
 			}
 			for _, v := range expr.Values {

--- a/operatorclient/types_test.go
+++ b/operatorclient/types_test.go
@@ -253,7 +253,7 @@ func gpuModelBundle(terms [][]string) *AnalysisBundle {
 		for _, vals := range terms {
 			nst = append(nst, apiv1.NodeSelectorTerm{
 				MatchExpressions: []apiv1.NodeSelectorRequirement{{
-					Key:      gpuModelAffinityKey,
+					Key:      constants.GPUModelAffinityKey,
 					Operator: apiv1.NodeSelectorOpIn,
 					Values:   vals,
 				}},
@@ -302,7 +302,7 @@ func TestRequestedGPUModels(t *testing.T) {
 										Weight: 1,
 										Preference: apiv1.NodeSelectorTerm{
 											MatchExpressions: []apiv1.NodeSelectorRequirement{{
-												Key:      gpuModelAffinityKey,
+												Key:      constants.GPUModelAffinityKey,
 												Operator: apiv1.NodeSelectorOpIn,
 												Values:   []string{"NVIDIA-A10G"},
 											}},

--- a/operatorclient/types_test.go
+++ b/operatorclient/types_test.go
@@ -240,3 +240,97 @@ func TestRequestedGPUVendor(t *testing.T) {
 		assert.Equal(t, "", b.RequestedGPUVendor())
 	})
 }
+
+// gpuModelBundle builds an AnalysisBundle whose deployment carries the
+// given GPU model match expressions on its required node affinity. Each
+// entry in `terms` becomes a separate NodeSelectorTerm; values within a
+// term become a single In match expression with key
+// nvidia.com/gpu.product. Used to drive RequestedGPUModels test cases.
+func gpuModelBundle(terms [][]string) *AnalysisBundle {
+	dep := &appsv1.Deployment{Spec: appsv1.DeploymentSpec{Template: apiv1.PodTemplateSpec{}}}
+	if len(terms) > 0 {
+		nst := make([]apiv1.NodeSelectorTerm, 0, len(terms))
+		for _, vals := range terms {
+			nst = append(nst, apiv1.NodeSelectorTerm{
+				MatchExpressions: []apiv1.NodeSelectorRequirement{{
+					Key:      gpuModelAffinityKey,
+					Operator: apiv1.NodeSelectorOpIn,
+					Values:   vals,
+				}},
+			})
+		}
+		dep.Spec.Template.Spec.Affinity = &apiv1.Affinity{
+			NodeAffinity: &apiv1.NodeAffinity{
+				RequiredDuringSchedulingIgnoredDuringExecution: &apiv1.NodeSelector{
+					NodeSelectorTerms: nst,
+				},
+			},
+		}
+	}
+	return &AnalysisBundle{AnalysisID: AnalysisID("test"), Deployment: dep}
+}
+
+func TestRequestedGPUModels(t *testing.T) {
+	tests := []struct {
+		name  string
+		terms [][]string
+		want  []string
+	}{
+		{"no affinity returns nil", nil, nil},
+		{"single model", [][]string{{"NVIDIA-A10G"}}, []string{"NVIDIA-A10G"}},
+		{"multiple values in one term", [][]string{{"NVIDIA-A10G", "NVIDIA-L4"}}, []string{"NVIDIA-A10G", "NVIDIA-L4"}},
+		{"multiple terms unioned and deduped", [][]string{{"NVIDIA-A10G"}, {"NVIDIA-A10G", "NVIDIA-L4"}}, []string{"NVIDIA-A10G", "NVIDIA-L4"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := gpuModelBundle(tt.terms)
+			assert.Equal(t, tt.want, b.RequestedGPUModels())
+		})
+	}
+
+	t.Run("preferred-only affinity is ignored", func(t *testing.T) {
+		b := &AnalysisBundle{
+			AnalysisID: "test",
+			Deployment: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Template: apiv1.PodTemplateSpec{
+						Spec: apiv1.PodSpec{
+							Affinity: &apiv1.Affinity{
+								NodeAffinity: &apiv1.NodeAffinity{
+									PreferredDuringSchedulingIgnoredDuringExecution: []apiv1.PreferredSchedulingTerm{{
+										Weight: 1,
+										Preference: apiv1.NodeSelectorTerm{
+											MatchExpressions: []apiv1.NodeSelectorRequirement{{
+												Key:      gpuModelAffinityKey,
+												Operator: apiv1.NodeSelectorOpIn,
+												Values:   []string{"NVIDIA-A10G"},
+											}},
+										},
+									}},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+		assert.Nil(t, b.RequestedGPUModels())
+	})
+
+	t.Run("non-In operator is ignored", func(t *testing.T) {
+		b := gpuModelBundle([][]string{{"NVIDIA-A10G"}})
+		b.Deployment.Spec.Template.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchExpressions[0].Operator = apiv1.NodeSelectorOpNotIn
+		assert.Nil(t, b.RequestedGPUModels())
+	})
+
+	t.Run("nil bundle returns nil", func(t *testing.T) {
+		var b *AnalysisBundle
+		assert.Nil(t, b.RequestedGPUModels())
+	})
+
+	t.Run("bundle with no deployment returns nil", func(t *testing.T) {
+		b := &AnalysisBundle{AnalysisID: "test"}
+		assert.Nil(t, b.RequestedGPUModels())
+	})
+}

--- a/operatordocs/operator_docs.go
+++ b/operatordocs/operator_docs.go
@@ -1327,6 +1327,12 @@ const docTemplateoperator = `{
                 "runningAnalyses": {
                     "type": "integer"
                 },
+                "supportedGPUModels": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "usedCPU": {
                     "description": "millicores",
                     "type": "integer"

--- a/operatordocs/operator_swagger.json
+++ b/operatordocs/operator_swagger.json
@@ -1320,6 +1320,12 @@
                 "runningAnalyses": {
                     "type": "integer"
                 },
+                "supportedGPUModels": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "usedCPU": {
                     "description": "millicores",
                     "type": "integer"

--- a/operatordocs/operator_swagger.yaml
+++ b/operatordocs/operator_swagger.yaml
@@ -298,6 +298,10 @@ definitions:
         type: integer
       runningAnalyses:
         type: integer
+      supportedGPUModels:
+        items:
+          type: string
+        type: array
       usedCPU:
         description: millicores
         type: integer


### PR DESCRIPTION
## Summary

Routes VICE launches to operators by GPU **model** capability, in addition to the existing vendor check, and translates each bundle's canonical GPU-model node affinity into the key/values the local cluster understands. Unblocks GPU launches on EKS, where the apps-DB-supplied `NVIDIA-A16` affinity has no AWS-side match and EKS Auto Mode doesn't run NVIDIA GPU Feature Discovery.

Three stages, one PR:

- **Stage A — operators advertise.** `CapacityResponse` gains `SupportedGPUModels []string`; new repeatable `--gpu-model` flag on vice-operator.
- **Stage B — scheduler filters.** New `AnalysisBundle.RequestedGPUModels()` plus a model-match step in `LaunchAnalysis` after the vendor check. Empty supported list = "any model" (backward compat). Adds `ErrNoCompatibleModel` mirroring `ErrNoCompatibleOperator`.
- **Stage C — operator translates.** New `TransformGPUModels(deployment, key, mapping)` runs before `TransformGPUVendor` and rewrites `nvidia.com/gpu.product` match expressions for the local cluster. New `--gpu-model-affinity-key` and repeatable `--gpu-model-mapping=NAME:VALUE` flags. Default config (canonical key + empty mapping) is the identity transform, so existing on-prem operators stay no-ops.

## EKS configuration (separate PR in the deployments repo, `gpu-model-routing` branch)

```
--gpu-model=NVIDIA-A10G --gpu-model=NVIDIA-L4 --gpu-model=NVIDIA-L40S
--gpu-model-mapping=NVIDIA-A10G:a10g --gpu-model-mapping=NVIDIA-L4:l4 --gpu-model-mapping=NVIDIA-L40S:l40s
--gpu-model-affinity-key=eks.amazonaws.com/instance-gpu-name
```

The EKS GPU NodePool also needs `analysis`, `gpu`, and `eks.amazonaws.com/instance-gpu-name` added to `spec.template.spec.requirements` so Karpenter treats them as known labels. That's the other half of the EKS-side fix and lives in the Ansible role, not here.

## Plan

`plans/let-s-plan-out-3-witty-riddle.md` in my local plans dir; can attach if useful.

## Test plan

- [ ] `just app-exposer && just vice-operator` — both build.
- [ ] `just test` — passes including new tests in `operator/`, `operatorclient/`, `cmd/vice-operator/`.
- [ ] `golangci-lint run` — clean.
- [ ] After Ansible-side companion PR lands and EKS operator is redeployed: `curl https://<operator>/capacity` shows `supportedGPUModels`; relaunching the stuck `jupyter-lab-pytorch-gpu` analysis produces a deployment whose required affinity is `eks.amazonaws.com/instance-gpu-name In [a10g]` and Karpenter provisions a g5 node.
- [ ] On-prem regression: with no new flags, an A16-tagged analysis still produces `nvidia.com/gpu.product In [NVIDIA-A16]` and schedules onto A16 nodes.
- [ ] Routing test: with on-prem advertising `[NVIDIA-A16]` and EKS advertising `[NVIDIA-A10G,NVIDIA-L4,NVIDIA-L40S]`, an A16-only analysis lands on-prem and an A10G-only analysis lands on EKS regardless of priority order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)