### PR TITLE
Probe vice-proxy /url-ready to stop ProbeWarning spam

### DIFF
--- a/incluster/deployments.go
+++ b/incluster/deployments.go
@@ -292,7 +292,10 @@ func (i *Incluster) deploymentContainers(job *model.Job) []apiv1.Container {
 				HTTPGet: &apiv1.HTTPGetAction{
 					Port:   intstr.FromInt(int(constants.VICEProxyPort)),
 					Scheme: apiv1.URISchemeHTTP,
-					Path:   "/",
+					// vice-proxy's unauthenticated health endpoint. Probing "/"
+					// instead returns a cross-host redirect to Keycloak, which the
+					// kubelet won't follow and logs as a ProbeWarning every period.
+					Path: "/url-ready",
 				},
 			},
 		},

--- a/incluster/deployments_test.go
+++ b/incluster/deployments_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/cyverse-de/app-exposer/constants"
+	"github.com/cyverse-de/model/v10"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
@@ -116,4 +117,27 @@ func TestViceProxyCommand(t *testing.T) {
 
 	// The command should just be the binary name with no args.
 	assert.Equal(t, []string{"vice-proxy"}, command)
+}
+
+// The vice-proxy readiness probe must hit /url-ready rather than "/", which
+// redirects unauthenticated requests to Keycloak and spams ProbeWarning events.
+func TestViceProxyReadinessProbePath(t *testing.T) {
+	i := New(baseInit(), nil, nil, nil, nil)
+	job := &model.Job{Steps: make([]model.Step, 1)}
+	job.Steps[0].Component.Container.Ports = []model.Ports{{ContainerPort: 7681}}
+
+	containers := i.deploymentContainers(job)
+
+	var proxy *apiv1.Container
+	for idx := range containers {
+		if containers[idx].Name == constants.VICEProxyContainerName {
+			proxy = &containers[idx]
+			break
+		}
+	}
+	require.NotNil(t, proxy, "vice-proxy container not found")
+	require.NotNil(t, proxy.ReadinessProbe)
+	require.NotNil(t, proxy.ReadinessProbe.HTTPGet)
+	assert.Equal(t, "/url-ready", proxy.ReadinessProbe.HTTPGet.Path)
+	assert.Equal(t, int(constants.VICEProxyPort), proxy.ReadinessProbe.HTTPGet.Port.IntValue())
 }


### PR DESCRIPTION
## Problem

When a VICE analysis launches, `kubectl describe pod` (and the event stream we watch while debugging) fills with repeating warnings for the life of the pod:

```
Warning  ProbeWarning  kubelet  Readiness probe warning: Probe terminated redirects,
  Response body: <a href="https://qa-auth.cyverse.org/.../auth?client_id=vice-users&...">Temporary Redirect</a>.
```

The `vice-proxy` container's readiness probe GETs `/` on port 60002. For an unauthenticated request the proxy returns a 307 redirect to Keycloak — a *different host* — which the kubelet's HTTP prober refuses to follow, so it logs a `ProbeWarning` every period. The probe still passes (3xx < 400), so it's harmless, just noisy.

## Fix

Point the probe at vice-proxy's dedicated **unauthenticated** health endpoint, `/url-ready` (`vice-proxy/main.go` registers it as a health check). It returns `200 {"ready":true}` / `406` and never redirects, so the `ProbeWarning` events stop.

Pod readiness timing is unchanged: the `analysis` container's own `:7681` probe already gates readiness on the backend being up, and `/url-ready` checks that same backend.

## Testing

- `go test ./incluster/...` — added `TestViceProxyReadinessProbePath` asserting the proxy probe targets `/url-ready` on the proxy port.
- `golangci-lint run ./incluster/...` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)