### PR TITLE
Add cron mode image cache for ECR pull-through on EKS Auto Mode

### DIFF
--- a/cmd/vice-operator/main.go
+++ b/cmd/vice-operator/main.go
@@ -81,6 +81,7 @@ func main() {
 		clusterName           string
 		imageCacheMode        string
 		imageCacheSchedule    string
+		reposFile             string
 	)
 
 	flag.StringVar(&kubeconfig, "kubeconfig", "", "Path to kubeconfig (empty for in-cluster)")
@@ -139,8 +140,9 @@ func main() {
 	flag.StringVar(&statusLeaseNamespace, "status-lease-namespace", "", "Namespace for the status-publisher coordination Lease (defaults to --namespace)")
 	flag.StringVar(&statusLeaseName, "status-lease-name", "vice-operator-status-publisher", "Name of the coordination Lease used to elect the status-publisher leader")
 	flag.StringVar(&clusterName, "cluster-name", "", "Cluster identifier sent as the Host field on status updates (defaults to the operator's hostname)")
-	flag.StringVar(&imageCacheMode, "image-cache-mode", "daemonset", "Image cache implementation: 'daemonset' for one DaemonSet per image (node-local containerd warming) or 'cron' for one CronJob per image (e.g. periodic pulls routed through an ECR pull-through cache on EKS Auto Mode)")
+	flag.StringVar(&imageCacheMode, "image-cache-mode", "daemonset", "Image cache implementation: 'daemonset' for one DaemonSet per image (node-local containerd warming), 'cron' for one CronJob per image (periodic pulls), or 'manual-mirror' for read-only mapping driven by --repos-file (rewrites bundle image refs at launch time)")
 	flag.StringVar(&imageCacheSchedule, "image-cache-schedule", "0 2 * * *", "Cron schedule applied to every cached image when --image-cache-mode=cron (5-field standard cron expression in UTC)")
+	flag.StringVar(&reposFile, "repos-file", "", "Path to a JSON object mapping upstream image refs to mirrored refs (required when --image-cache-mode=manual-mirror; rejected otherwise)")
 	flag.Parse()
 
 	// Allow secrets to come from environment variables when not set on the
@@ -366,7 +368,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("creating capacity calculator: %v", err)
 	}
-	imageCache, err := buildImageCache(imageCacheMode, imageCacheSchedule, clientset, namespace, imagePullSecret)
+	imageCache, imageRewriter, err := buildImageCache(imageCacheMode, imageCacheSchedule, reposFile, clientset, namespace, imagePullSecret)
 	if err != nil {
 		log.Fatalf("%v", err)
 	}
@@ -382,6 +384,7 @@ func main() {
 		GPUModelMapping:     gpuModelMapping,
 		CapacityCalc:        capacityCalc,
 		ImageCache:          imageCache,
+		ImageRewriter:       imageRewriter,
 		LoadingServiceName:  loadingServiceName,
 		LoadingServicePort:  int32(loadingServicePort),
 		LoadingTimeoutMs:    loadingTimeoutMs,

--- a/cmd/vice-operator/main.go
+++ b/cmd/vice-operator/main.go
@@ -79,6 +79,8 @@ func main() {
 		statusLeaseNamespace  string
 		statusLeaseName       string
 		clusterName           string
+		imageCacheMode        string
+		imageCacheSchedule    string
 	)
 
 	flag.StringVar(&kubeconfig, "kubeconfig", "", "Path to kubeconfig (empty for in-cluster)")
@@ -137,6 +139,8 @@ func main() {
 	flag.StringVar(&statusLeaseNamespace, "status-lease-namespace", "", "Namespace for the status-publisher coordination Lease (defaults to --namespace)")
 	flag.StringVar(&statusLeaseName, "status-lease-name", "vice-operator-status-publisher", "Name of the coordination Lease used to elect the status-publisher leader")
 	flag.StringVar(&clusterName, "cluster-name", "", "Cluster identifier sent as the Host field on status updates (defaults to the operator's hostname)")
+	flag.StringVar(&imageCacheMode, "image-cache-mode", "daemonset", "Image cache implementation: 'daemonset' for one DaemonSet per image (node-local containerd warming) or 'cron' for one CronJob per image (e.g. periodic pulls routed through an ECR pull-through cache on EKS Auto Mode)")
+	flag.StringVar(&imageCacheSchedule, "image-cache-schedule", "0 2 * * *", "Cron schedule applied to every cached image when --image-cache-mode=cron (5-field standard cron expression in UTC)")
 	flag.Parse()
 
 	// Allow secrets to come from environment variables when not set on the
@@ -362,7 +366,10 @@ func main() {
 	if err != nil {
 		log.Fatalf("creating capacity calculator: %v", err)
 	}
-	imageCache := operator.NewImageCacheManager(clientset, namespace, imagePullSecret)
+	imageCache, err := buildImageCache(imageCacheMode, imageCacheSchedule, clientset, namespace, imagePullSecret)
+	if err != nil {
+		log.Fatalf("%v", err)
+	}
 	op, err := operator.NewOperator(operator.OperatorOptions{
 		Clientset:           clientset,
 		GatewayClient:       gwClient,

--- a/cmd/vice-operator/startup.go
+++ b/cmd/vice-operator/startup.go
@@ -9,11 +9,30 @@ import (
 
 	"github.com/coreos/go-oidc/v3/oidc"
 	"github.com/cyverse-de/app-exposer/operator"
+	"github.com/robfig/cron/v3"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	gatewayclient "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned/typed/apis/v1"
 )
+
+// buildImageCache returns the ImageCacheManager implementation selected by
+// the --image-cache-mode flag. The cron mode validates the schedule
+// expression up front so a misconfigured flag fails at boot rather than at
+// the first ensure call.
+func buildImageCache(mode, schedule string, clientset kubernetes.Interface, namespace, imagePullSecret string) (operator.ImageCacheManager, error) {
+	switch mode {
+	case "daemonset":
+		return operator.NewDaemonSetImageCacheManager(clientset, namespace, imagePullSecret), nil
+	case "cron":
+		if _, err := cron.ParseStandard(schedule); err != nil {
+			return nil, fmt.Errorf("invalid --image-cache-schedule %q: %w", schedule, err)
+		}
+		return operator.NewCronJobImageCacheManager(clientset, namespace, imagePullSecret, schedule), nil
+	default:
+		return nil, fmt.Errorf("invalid --image-cache-mode %q (want \"daemonset\" or \"cron\")", mode)
+	}
+}
 
 // buildKubeClients constructs the Kubernetes core and Gateway API clients.
 // An empty kubeconfig falls back to in-cluster config.

--- a/cmd/vice-operator/startup.go
+++ b/cmd/vice-operator/startup.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"strings"
@@ -25,12 +26,12 @@ func buildImageCache(mode, schedule, reposFile string, clientset kubernetes.Inte
 	switch mode {
 	case "daemonset":
 		if reposFile != "" {
-			return nil, nil, fmt.Errorf("--repos-file is only valid with --image-cache-mode=manual-mirror")
+			return nil, nil, errors.New("--repos-file is only valid with --image-cache-mode=manual-mirror")
 		}
 		return operator.NewDaemonSetImageCacheManager(clientset, namespace, imagePullSecret), nil, nil
 	case "cron":
 		if reposFile != "" {
-			return nil, nil, fmt.Errorf("--repos-file is only valid with --image-cache-mode=manual-mirror")
+			return nil, nil, errors.New("--repos-file is only valid with --image-cache-mode=manual-mirror")
 		}
 		if _, err := cron.ParseStandard(schedule); err != nil {
 			return nil, nil, fmt.Errorf("invalid --image-cache-schedule %q: %w", schedule, err)

--- a/cmd/vice-operator/startup.go
+++ b/cmd/vice-operator/startup.go
@@ -16,21 +16,38 @@ import (
 	gatewayclient "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned/typed/apis/v1"
 )
 
-// buildImageCache returns the ImageCacheManager implementation selected by
-// the --image-cache-mode flag. The cron mode validates the schedule
-// expression up front so a misconfigured flag fails at boot rather than at
-// the first ensure call.
-func buildImageCache(mode, schedule string, clientset kubernetes.Interface, namespace, imagePullSecret string) (operator.ImageCacheManager, error) {
+// buildImageCache returns the ImageCacheManager (and, where applicable, an
+// ImageRewriter) selected by the --image-cache-mode flag. Cron mode
+// validates the schedule up front; manual-mirror mode loads and validates
+// the repos file up front. Misconfigurations fail fast at startup rather
+// than at first use.
+func buildImageCache(mode, schedule, reposFile string, clientset kubernetes.Interface, namespace, imagePullSecret string) (operator.ImageCacheManager, operator.ImageRewriter, error) {
 	switch mode {
 	case "daemonset":
-		return operator.NewDaemonSetImageCacheManager(clientset, namespace, imagePullSecret), nil
-	case "cron":
-		if _, err := cron.ParseStandard(schedule); err != nil {
-			return nil, fmt.Errorf("invalid --image-cache-schedule %q: %w", schedule, err)
+		if reposFile != "" {
+			return nil, nil, fmt.Errorf("--repos-file is only valid with --image-cache-mode=manual-mirror")
 		}
-		return operator.NewCronJobImageCacheManager(clientset, namespace, imagePullSecret, schedule), nil
+		return operator.NewDaemonSetImageCacheManager(clientset, namespace, imagePullSecret), nil, nil
+	case "cron":
+		if reposFile != "" {
+			return nil, nil, fmt.Errorf("--repos-file is only valid with --image-cache-mode=manual-mirror")
+		}
+		if _, err := cron.ParseStandard(schedule); err != nil {
+			return nil, nil, fmt.Errorf("invalid --image-cache-schedule %q: %w", schedule, err)
+		}
+		return operator.NewCronJobImageCacheManager(clientset, namespace, imagePullSecret, schedule), nil, nil
+	case "manual-mirror":
+		if reposFile == "" {
+			return nil, nil, fmt.Errorf("--repos-file is required when --image-cache-mode=manual-mirror")
+		}
+		mappings, err := operator.LoadImageMirrorMap(reposFile)
+		if err != nil {
+			return nil, nil, err
+		}
+		mgr := operator.NewManualMirrorImageCacheManager(mappings)
+		return mgr, mgr, nil
 	default:
-		return nil, fmt.Errorf("invalid --image-cache-mode %q (want \"daemonset\" or \"cron\")", mode)
+		return nil, nil, fmt.Errorf("invalid --image-cache-mode %q (want \"daemonset\", \"cron\", or \"manual-mirror\")", mode)
 	}
 }
 

--- a/docs/superpowers/specs/2026-05-27-image-cache-cron-mode-ecr.md
+++ b/docs/superpowers/specs/2026-05-27-image-cache-cron-mode-ecr.md
@@ -157,8 +157,12 @@ Job operations. Add to the `batch` apiGroup:
 ```yaml
 - apiGroups: ["batch"]
   resources: ["cronjobs", "jobs"]
-  verbs: ["get", "list", "watch", "create", "update", "delete"]
+  verbs: ["get", "list", "create", "update", "delete"]
 ```
+
+`watch` is intentionally omitted — the operator never opens a watch stream
+on CronJobs or Jobs, and granting the verb would unnecessarily widen the
+service account's reach. Add it later if an informer is introduced.
 
 This is a deployment-manifest change in the cluster's vice-operator
 install, not a code change in app-exposer. Roll it out before flipping

--- a/docs/superpowers/specs/2026-05-27-image-cache-cron-mode-ecr.md
+++ b/docs/superpowers/specs/2026-05-27-image-cache-cron-mode-ecr.md
@@ -1,0 +1,210 @@
+# Image Cache — Cron Mode for EKS Auto Mode + ECR Pull-Through Cache
+
+## Context
+
+The original image cache design (see
+`2026-03-17-image-cache-design.md`) ships one DaemonSet per cached image
+so each node's containerd has the image warm before a VICE pod schedules.
+That works on self-managed clusters where nodes are long-lived.
+
+On **EKS Auto Mode**, AWS manages the node pool and recycles nodes
+aggressively (default ~14-day max lifetime, plus consolidation churn).
+A node-local cache barely pays back its cost before the node is replaced.
+Worse, every new node has to re-pull every image, and we are paying
+DaemonSet pod overhead per-image-per-node continuously, for cache
+populations that only matter at the moment a VICE pod actually starts.
+
+The supported AWS pattern for warming images in Auto Mode is **ECR
+pull-through cache**: ECR proxies pulls from an upstream registry (Harbor,
+Docker Hub, k8s.gcr.io) and stores the result. EKS Auto Mode nodes are
+configured to resolve pulls through ECR transparently, so a pod that
+references `harbor.cyverse.org/de/vice-proxy:latest` ends up pulling the
+ECR-cached copy with no image-reference rewriting needed at the pod
+level.
+
+To keep ECR's copy fresh we need vice-operator to *periodically* pull
+each image so the corresponding repository in ECR gets refreshed before
+its layers expire. CronJobs are the right K8s primitive for that.
+
+## Approach
+
+Add a second `ImageCacheManager` implementation
+(`CronJobImageCacheManager`) selected by a `--image-cache-mode` flag:
+
+- `daemonset` (default) — existing DaemonSet behavior, unchanged.
+- `cron` — one CronJob per cached image, firing on a globally configured
+  schedule (`--image-cache-schedule`, default `0 2 * * *` UTC).
+
+The vice-operator HTTP API is unchanged. Both implementations satisfy the
+same interface; handlers don't branch.
+
+### CronJob structure
+
+For each cached image:
+
+```yaml
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: image-cache-<slug>
+  namespace: vice-apps
+  labels:
+    managed-by: vice-operator
+    purpose: image-cache
+    image-cache-id: <slug>
+  annotations:
+    de.cyverse.org/cached-image: "harbor.cyverse.org/de/vice-proxy:latest"
+spec:
+  schedule: "0 2 * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 1
+  jobTemplate:
+    spec:
+      backoffLimit: 0
+      template:
+        metadata:
+          labels:
+            managed-by: vice-operator
+            purpose: image-cache
+            image-cache-id: <slug>
+        spec:
+          restartPolicy: Never
+          imagePullSecrets:
+            - name: vice-image-pull-secret
+          containers:
+            - name: pull
+              image: harbor.cyverse.org/de/vice-proxy:latest
+              command: ["true"]
+              imagePullPolicy: Always
+              resources:
+                requests: {cpu: 1m, memory: 64Mi}
+                limits:   {cpu: 10m, memory: 64Mi}
+          tolerations:
+            - {key: analysis, operator: Exists}
+            - {key: gpu, operator: Equal, value: "true", effect: NoSchedule}
+```
+
+Notes:
+
+- **Single container, no pause sidecar.** A Job pod doesn't need a
+  long-running main container the way a DaemonSet pod does.
+- **`backoffLimit: 0`.** A failed pull is not worth retrying within the
+  same scheduling tick; the next cron firing is the retry.
+- **History limits = 1.** We keep one most-recent success and one
+  most-recent failure so the status API can report the latest outcome
+  without listing Jobs.
+- **`ConcurrencyPolicy: Forbid`.** Never overlap pulls of the same image.
+- **No image-reference rewriting.** The original image string goes into
+  the Job. Node-level containerd config (provisioned by Auto Mode) routes
+  the pull through the ECR pull-through cache repo transparently.
+
+### Refresh semantics
+
+`POST /image-cache/refresh` in cron mode creates a one-off Job from the
+CronJob's job template (with `GenerateName: image-cache-<slug>-r-` and
+`TTLSecondsAfterFinished: 300`). The CronJob continues firing on its
+normal schedule afterwards. This preserves "refresh means re-pull now"
+across both modes.
+
+The refresh Job carries an OwnerReference back to its CronJob so K8s
+garbage-collects orphans when the CronJob is deleted.
+
+### Status mapping
+
+CronJob state collapses to the same `(ready, desired, status)` shape that
+DaemonSet mode returns, so the API response schema is identical:
+
+| CronJob state                  | ready | desired | status               |
+|--------------------------------|-------|---------|----------------------|
+| Suspended                      | 0     | 0       | `error`              |
+| Never run yet                  | 0     | 1       | `pulling`            |
+| Last scheduled run succeeded   | 1     | 1       | `ready`              |
+| Last scheduled run failed      | 0     | 1       | `cached-with-errors` |
+
+"Last scheduled run succeeded" is computed by comparing
+`Status.LastScheduleTime` and `Status.LastSuccessfulTime` — no Jobs API
+fan-out needed.
+
+### Deletion
+
+`DELETE /image-cache/:id` in cron mode deletes only the CronJob. **It
+does not evict the image from ECR.** Image eviction is handled by ECR
+lifecycle policies, configured outside vice-operator (per repository,
+typically by age and pull-recency). This matches the design intent: the
+operator's job is to *populate* the cache; ECR is the storage system.
+
+## Configuration
+
+Two new vice-operator CLI flags:
+
+- `--image-cache-mode` (string, default `"daemonset"`). Accepts
+  `daemonset` or `cron`. Invalid value is a fatal startup error.
+- `--image-cache-schedule` (string, default `"0 2 * * *"`). Standard
+  5-field cron expression in UTC, applied to every cached image. Parsed
+  at startup with `robfig/cron/v3`; an invalid expression is a fatal
+  startup error (better than letting K8s reject CronJobs at every
+  ensure call).
+
+All other image-cache configuration is unchanged — `--image-pull-secret`,
+`--namespace`, etc. work the same way in both modes.
+
+## RBAC
+
+Cron mode requires the vice-operator ClusterRole to permit CronJob and
+Job operations. Add to the `batch` apiGroup:
+
+```yaml
+- apiGroups: ["batch"]
+  resources: ["cronjobs", "jobs"]
+  verbs: ["get", "list", "watch", "create", "update", "delete"]
+```
+
+This is a deployment-manifest change in the cluster's vice-operator
+install, not a code change in app-exposer. Roll it out before flipping
+the mode flag.
+
+## Code layout
+
+After this change, the `operator/` package has three image-cache files:
+
+- `imagecache.go` — request/response types, the `ImageCacheManager`
+  interface, shared helpers (`slugifyImage`, `validateImageRef`,
+  `deriveCacheStatus`), constants.
+- `imagecache_daemonset.go` — `DaemonSetImageCacheManager` (the original
+  implementation, renamed).
+- `imagecache_cronjob.go` — `CronJobImageCacheManager`.
+
+Tests are split the same way: `imagecache_test.go` holds shared-helper
+and handler tests; `imagecache_daemonset_test.go` and
+`imagecache_cronjob_test.go` hold backend-specific tests.
+
+`cmd/vice-operator/startup.go` gains a `buildImageCache` helper that
+inspects the mode flag and returns the matching implementation.
+
+## Out of scope
+
+- ECR repository creation and pull-through cache rule provisioning
+  (handled by Terraform/IaC outside this codebase).
+- ECR lifecycle policies (also IaC).
+- Per-image schedule overrides — the global flag is sufficient for the
+  expected usage pattern (warm a small fixed set of VICE base images
+  once per day).
+- Switching modes at runtime — mode is fixed at process startup. A mode
+  change requires a vice-operator restart, which is acceptable since
+  mode changes happen at most once per cluster lifecycle.
+
+## Verification
+
+See the implementation plan for the full test matrix. End-to-end
+verification at deploy time on an EKS Auto Mode cluster:
+
+1. Provision an ECR pull-through cache rule for Harbor (or whatever
+   upstream registries the VICE base images live on).
+2. Deploy vice-operator with `--image-cache-mode=cron`.
+3. `PUT /image-cache` with a VICE base image; wait for the cron to
+   fire.
+4. Confirm the image appears in the matching ECR repository
+   (`aws ecr describe-images` or the AWS console).
+5. `POST /image-cache/refresh` triggers an immediate Job; confirm the
+   Job completes and ECR's `imagePushedAt` advances.

--- a/docs/superpowers/specs/2026-05-27-image-cache-manual-mirror.md
+++ b/docs/superpowers/specs/2026-05-27-image-cache-manual-mirror.md
@@ -1,0 +1,168 @@
+# Image Cache — Manual-Mirror Mode for direct-push ECR
+
+## Context
+
+The cron-mode design (see `2026-05-27-image-cache-cron-mode-ecr.md`)
+assumed AWS ECR could be configured as a pull-through cache fronting our
+self-hosted Harbor at `harbor.cyverse.org`. AWS does not support
+self-hosted registries as pull-through upstreams; the supported list is
+fixed (`ecr`, `ecr-public`, `docker-hub`, `quay`, `k8s`,
+`github-container-registry`, `azure-container-registry`,
+`gitlab-container-registry`, `chainguard`). `create-pull-through-cache-rule`
+rejects `harbor.cyverse.org` with `UnsupportedUpstreamRegistryException`.
+
+Our adopted path is direct push: an out-of-band mirror job pushes VICE
+images into per-cluster ECR repos. The repos are created by
+`deployments/ansible/scripts/setup-ecr-repos.sh`; the images themselves
+are mirrored by `mirror-images-to-ecr.sh`. EKS Auto Mode nodes pull from
+those ECR repos directly — no pull-through, no node-local DaemonSet cache.
+
+What's missing in vice-operator: analysis bundles arriving at
+`POST /vice/launch` still reference the original Harbor coordinates
+(`harbor.cyverse.org/de/vice-proxy:latest`). The operator needs to rewrite
+those image strings at launch time to the mirrored ECR coordinates so K8s
+ends up pulling from ECR, not Harbor.
+
+Cron mode is the closest existing mode but doesn't rewrite bundle images
+— it manages CronJobs, not launch-time refs. Rather than retrofit cron
+mode (which we want to keep as-is in case ECR adds Harbor support later),
+we add a third mode dedicated to this workflow: `manual-mirror`.
+
+## Approach
+
+A third value for `--image-cache-mode`. The backing implementation
+contributes two things:
+
+- A **read-only `ImageCacheManager`** that exposes the mapping through
+  the existing `GET /image-cache` and `GET /image-cache/:id` endpoints,
+  so admins can introspect what's configured. The mutating endpoints
+  (`PUT`, `DELETE`, refresh) return **400** with a message pointing at
+  `--repos-file`, since the operator can't update the mapping at runtime.
+
+- An **`ImageRewriter`** that runs as one more bundle transform in
+  `HandleLaunch`, alongside the existing `TransformGPUModels` /
+  `TransformGPUVendor` / etc. It walks the deployment's containers and
+  init-containers and swaps image refs that have a mapping.
+
+## Configuration
+
+Two flags are now relevant to mode selection:
+
+| Flag | Required when | Notes |
+|---|---|---|
+| `--image-cache-mode` | always | `daemonset` (default), `cron`, or `manual-mirror`. |
+| `--repos-file` | mode = `manual-mirror` | Path to a JSON file mapping upstream image refs to mirrored refs. Setting this in any other mode is a startup error. |
+
+The mapping file is parsed once at startup; the operator must be
+restarted to pick up changes. This matches the K8s ConfigMap reload
+pattern most clusters already use.
+
+## Mapping file format
+
+A flat JSON object: keys are upstream image refs as bundles will reference
+them, values are fully-qualified mirrored refs as K8s should ultimately
+pull. Both keys and values are validated against the same
+`imageRefPattern` regex used for `PUT /image-cache` inputs (rejects
+whitespace, shell-unsafe characters, and refs over 1024 chars).
+
+```json
+{
+  "harbor.cyverse.org/de/vice-proxy:latest":
+    "123456789012.dkr.ecr.us-east-1.amazonaws.com/de/vice-proxy:latest",
+  "harbor.cyverse.org/de/porklock:latest":
+    "123456789012.dkr.ecr.us-east-1.amazonaws.com/de/porklock:latest",
+  "harbor.cyverse.org/de/vice-default-backend:qa":
+    "123456789012.dkr.ecr.us-east-1.amazonaws.com/de/vice-default-backend:qa"
+}
+```
+
+The operator stays registry-agnostic — values are fully qualified, so the
+same code works with ECR, GHCR, or any future mirror target. Empty maps
+are rejected at startup; empty keys or values are rejected at startup.
+
+## Behavior at launch time
+
+When `HandleLaunch` processes an `AnalysisBundle`:
+
+1. Existing transforms run as today (hostname rewriting, gateway namespace
+   substitution, vice-proxy args, GPU model mapping, GPU vendor).
+2. If the operator has an `ImageRewriter` (only in manual-mirror mode), a
+   new `TransformImageRefs` walks the bundle's
+   `Deployment.Spec.Template.Spec.InitContainers[*].Image` and
+   `Containers[*].Image`, substituting each image that has a mapping.
+3. `applyBundle` runs unchanged — by the time it creates the Deployment,
+   the image fields already carry the mirrored coordinates.
+
+**Unmapped images pass through unchanged.** This deliberately avoids
+making the operator a policy gate: if a bundle includes some new image we
+haven't mirrored yet, the launch proceeds and K8s reports the usual
+`ImagePullBackOff` if the upstream is unreachable from the cluster.
+Adding pre-flight rejection would force every image change to be paired
+with a mapping update before deploys could succeed, which is more
+friction than it's worth for the failure modes we actually see.
+
+The transform logs the substitution count at info level when it's
+non-zero, so the absence of a log line confirms no rewriting happened —
+useful when debugging "did the new image take effect" questions.
+
+## Cache API in manual-mirror mode
+
+| Endpoint | Behavior |
+|---|---|
+| `GET /image-cache` | Returns one `ImageCacheStatus` per mapping entry. `Image` is the upstream key (what bundles reference), `ID` is its slug, `Status` is `"ready"`, `Ready=Desired=1`. |
+| `GET /image-cache/:id` | Reverse-lookup by slug. 404 if the slug doesn't match any entry. |
+| `PUT /image-cache` | 400. Body: `"image cache is externally managed in this mode; update the --repos-file and restart instead"`. |
+| `DELETE /image-cache` | 400, same body. |
+| `DELETE /image-cache/:id` | 400, same body. |
+| `POST /image-cache/refresh` | 400, same body. |
+
+The handler short-circuits on `o.imageCache.ReadOnly()` before reaching
+the manager, so callers get a single 400 rather than the bulk handler's
+207 Multi-Status with per-image errors.
+
+## Code layout
+
+| File | Role |
+|---|---|
+| `operator/imagecache.go` | `ImageCacheManager` interface gains `ReadOnly()`; new `ImageRewriter` interface and `ErrCacheReadOnly` sentinel. |
+| `operator/imagecache_daemonset.go` | `ReadOnly()` returns `false`. |
+| `operator/imagecache_cronjob.go` | `ReadOnly()` returns `false`. |
+| `operator/imagecache_manual_mirror.go` | `ManualMirrorImageCacheManager` (implements both interfaces) and `LoadImageMirrorMap`. |
+| `operator/transform_images.go` | `TransformImageRefs(deployment, rewriter)` walks containers/init-containers. |
+| `operator/imagecache_handlers.go` | Mutating handlers pre-check `ReadOnly()` and bail with 400. `HandleGetCachedImage` recognizes the manual-mirror not-found sentinel for the 404 path. |
+| `operator/handlers.go` | New `imageRewriter` field on `Operator`; `HandleLaunch` calls `TransformImageRefs` when set. |
+| `cmd/vice-operator/main.go` | New `--repos-file` flag. |
+| `cmd/vice-operator/startup.go` | `buildImageCache` extended to return an `ImageRewriter`; manual-mirror branch validates the file at startup. |
+
+## Out of scope
+
+- **Hot reload** of the mapping file. Restart the operator pod to pick
+  up changes. Standard ConfigMap-mount conventions cover the rollout.
+- **Per-cluster mappings.** A single file per operator. If multiple
+  clusters need different mappings, run separate operator deployments
+  with separate `--repos-file` paths.
+- **Mirror-state checks.** The operator trusts that the file's values
+  exist in the target registry. If a mirrored ref is wrong or missing,
+  the launch will proceed and the analysis pod will land in
+  `ImagePullBackOff` — the same failure mode as a typo'd image in the
+  bundle today.
+
+## Verification
+
+End-to-end on the `ua-ai-sandboxes` cluster:
+
+1. Run `setup-ecr-repos.sh` and `mirror-images-to-ecr.sh` (deployments
+   repo) to populate the per-cluster ECR repos.
+2. Render a `repos.json` mapping each upstream Harbor ref to its mirrored
+   ECR ref.
+3. Start vice-operator with
+   `--image-cache-mode=manual-mirror --repos-file=/etc/vice/repos.json`.
+4. Submit an analysis whose bundle's deployment references a Harbor image
+   in the map. Confirm the resulting `Deployment` in K8s shows the ECR
+   coordinates and the operator log emits
+   `rewrote N image ref(s) for analysis <id>`.
+5. Submit an analysis with an unmapped image. Confirm the deployment is
+   created with the upstream ref unchanged and no rewrite log line.
+6. `curl GET /image-cache` and confirm the response lists the mapping
+   entries. Attempt `PUT /image-cache` and confirm 400 with the
+   externally-managed message.

--- a/go.mod
+++ b/go.mod
@@ -40,6 +40,7 @@ require (
 	github.com/lib/pq v1.10.9
 	github.com/nats-io/nats.go v1.41.0
 	github.com/pkg/errors v0.9.1
+	github.com/robfig/cron/v3 v3.0.1
 	github.com/sirupsen/logrus v1.9.3
 	github.com/stretchr/testify v1.11.1
 	github.com/swaggo/echo-swagger v1.4.1
@@ -152,7 +153,6 @@ require (
 	github.com/prometheus/procfs v0.17.0 // indirect
 	github.com/rabbitmq/amqp091-go v1.10.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
-	github.com/robfig/cron/v3 v3.0.1 // indirect
 	github.com/sagikazarmark/locafero v0.12.0 // indirect
 	github.com/segmentio/fasthash v1.0.3 // indirect
 	github.com/sethvargo/go-limiter v1.0.0 // indirect

--- a/operator/handlers.go
+++ b/operator/handlers.go
@@ -58,6 +58,7 @@ type Operator struct {
 	gpuModelMapping     map[string]string // Canonical NVIDIA-* model name → cluster-side value (e.g. NVIDIA-A10G → a10g on EKS).
 	capacityCalc        *CapacityCalculator
 	imageCache          ImageCacheManager
+	imageRewriter       ImageRewriter // optional; manual-mirror mode supplies one
 	loadingServiceName  string
 	loadingServicePort  int32
 	loadingTimeoutMs    int64
@@ -85,6 +86,7 @@ type OperatorOptions struct {
 	GPUModelMapping     map[string]string // Canonical NVIDIA-* model name → cluster-side value (e.g. NVIDIA-A10G → a10g on EKS).
 	CapacityCalc        *CapacityCalculator
 	ImageCache          ImageCacheManager
+	ImageRewriter       ImageRewriter // optional; nil disables image-ref rewriting at launch time
 	LoadingServiceName  string
 	LoadingServicePort  int32
 	LoadingTimeoutMs    int64
@@ -141,6 +143,7 @@ func NewOperator(opts OperatorOptions) (*Operator, error) {
 		gpuModelMapping:     opts.GPUModelMapping,
 		capacityCalc:        opts.CapacityCalc,
 		imageCache:          opts.ImageCache,
+		imageRewriter:       opts.ImageRewriter,
 		loadingServiceName:  opts.LoadingServiceName,
 		loadingServicePort:  opts.LoadingServicePort,
 		loadingTimeoutMs:    opts.LoadingTimeoutMs,
@@ -280,6 +283,15 @@ func (o *Operator) HandleLaunch(c echo.Context) error {
 
 	// Rewrite GPU resource names to match the cluster's GPU vendor.
 	TransformGPUVendor(bundle.Deployment, o.gpuVendor)
+
+	// In manual-mirror mode, swap upstream image refs in the deployment's
+	// containers for their mirrored counterparts. Other modes contribute
+	// no rewriter; the bundle's images pass through unchanged.
+	if o.imageRewriter != nil {
+		if n := TransformImageRefs(bundle.Deployment, o.imageRewriter); n > 0 {
+			log.Infof("rewrote %d image ref(s) for analysis %s", n, bundle.AnalysisID)
+		}
+	}
 
 	// Apply all resources via upsert pattern.
 	if err := o.applyBundle(ctx, &bundle); err != nil {

--- a/operator/handlers.go
+++ b/operator/handlers.go
@@ -57,7 +57,7 @@ type Operator struct {
 	gpuModelAffinityKey string            // Node-label key this cluster uses for GPU-model affinity; empty means use the canonical nvidia.com/gpu.product.
 	gpuModelMapping     map[string]string // Canonical NVIDIA-* model name → cluster-side value (e.g. NVIDIA-A10G → a10g on EKS).
 	capacityCalc        *CapacityCalculator
-	imageCache          *ImageCacheManager
+	imageCache          ImageCacheManager
 	loadingServiceName  string
 	loadingServicePort  int32
 	loadingTimeoutMs    int64
@@ -84,7 +84,7 @@ type OperatorOptions struct {
 	GPUModelAffinityKey string            // Node-label key this cluster uses for GPU-model affinity; empty means use the canonical nvidia.com/gpu.product.
 	GPUModelMapping     map[string]string // Canonical NVIDIA-* model name → cluster-side value (e.g. NVIDIA-A10G → a10g on EKS).
 	CapacityCalc        *CapacityCalculator
-	ImageCache          *ImageCacheManager
+	ImageCache          ImageCacheManager
 	LoadingServiceName  string
 	LoadingServicePort  int32
 	LoadingTimeoutMs    int64

--- a/operator/handlers.go
+++ b/operator/handlers.go
@@ -288,9 +288,7 @@ func (o *Operator) HandleLaunch(c echo.Context) error {
 	// containers for their mirrored counterparts. Other modes contribute
 	// no rewriter; the bundle's images pass through unchanged.
 	if o.imageRewriter != nil {
-		if n := TransformImageRefs(bundle.Deployment, o.imageRewriter); n > 0 {
-			log.Infof("rewrote %d image ref(s) for analysis %s", n, bundle.AnalysisID)
-		}
+		TransformImageRefs(bundle.Deployment, o.imageRewriter)
 	}
 
 	// Apply all resources via upsert pattern.

--- a/operator/handlers_test.go
+++ b/operator/handlers_test.go
@@ -76,6 +76,37 @@ func newTestOperatorWithModels(t *testing.T, maxAnalyses int, models []string) (
 	return newTestOperatorWith(t, maxAnalyses, GPUVendorNvidia, models)
 }
 
+// newManualMirrorTestOperator builds a test Operator whose ImageCache and
+// ImageRewriter are both a ManualMirrorImageCacheManager wrapping the given
+// mappings. Used to exercise the read-only cache surface and the
+// launch-time image-rewriting path.
+func newManualMirrorTestOperator(t *testing.T, mappings map[string]string) *Operator {
+	t.Helper()
+	clientset := fake.NewSimpleClientset()
+	gwClientset := gatewayfake.NewSimpleClientset()
+	calc, err := NewCapacityCalculator(clientset, "vice-apps", 10, "")
+	require.NoError(t, err)
+	mgr := NewManualMirrorImageCacheManager(mappings)
+	op, err := NewOperator(OperatorOptions{
+		Clientset:           clientset,
+		GatewayClient:       gwClientset.GatewayV1(),
+		Namespace:           "vice-apps",
+		GatewayNamespace:    "vice-apps",
+		GatewayName:         "vice",
+		GPUVendor:           GPUVendorNvidia,
+		CapacityCalc:        calc,
+		ImageCache:          mgr,
+		ImageRewriter:       mgr,
+		LoadingServiceName:  "vice-operator-loading",
+		LoadingServicePort:  80,
+		LoadingTimeoutMs:    600000,
+		ClusterConfigSecret: "cluster-config-secret",
+		UserSuffix:          constants.DefaultUserSuffix,
+	})
+	require.NoError(t, err)
+	return op
+}
+
 // newTestOperatorWith is the shared constructor behind newTestOperator and
 // newTestOperatorWithModels.
 func newTestOperatorWith(t *testing.T, maxAnalyses int, vendor GPUVendor, models []string) (*Operator, *fake.Clientset, *gatewayfake.Clientset) {

--- a/operator/handlers_test.go
+++ b/operator/handlers_test.go
@@ -84,7 +84,7 @@ func newTestOperatorWith(t *testing.T, maxAnalyses int, vendor GPUVendor, models
 	gwClientset := gatewayfake.NewSimpleClientset()
 	calc, err := NewCapacityCalculator(clientset, "vice-apps", maxAnalyses, "")
 	require.NoError(t, err)
-	cache := NewImageCacheManager(clientset, "vice-apps", "vice-image-pull-secret")
+	cache := NewDaemonSetImageCacheManager(clientset, "vice-apps", "vice-image-pull-secret")
 	op, err := NewOperator(OperatorOptions{
 		Clientset:           clientset,
 		GatewayClient:       gwClientset.GatewayV1(),
@@ -117,7 +117,7 @@ func TestOperatorOptionsValidate(t *testing.T) {
 			GatewayClient: gw.GatewayV1(),
 			Namespace:     "vice-apps",
 			CapacityCalc:  &CapacityCalculator{},
-			ImageCache:    &ImageCacheManager{},
+			ImageCache:    &DaemonSetImageCacheManager{},
 		}
 	}
 

--- a/operator/imagecache.go
+++ b/operator/imagecache.go
@@ -7,19 +7,11 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
-	"time"
-
-	appsv1 "k8s.io/api/apps/v1"
-	apiv1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/resource"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/client-go/kubernetes"
 )
 
 const (
-	// Labels and annotations used to identify image cache DaemonSets.
+	// Labels and annotations used to identify image cache resources
+	// (DaemonSets or CronJobs).
 	labelManagedBy    = "managed-by"
 	labelPurpose      = "purpose"
 	labelImageCacheID = "image-cache-id"
@@ -28,15 +20,16 @@ const (
 	valueManagedBy = "vice-operator"
 	valuePurpose   = "image-cache"
 
-	// dsNamePrefix is prepended to every cache DaemonSet name.
-	dsNamePrefix = "image-cache-"
+	// cacheNamePrefix is prepended to every cache resource name (DaemonSet
+	// or CronJob), keeping the slug ID the same across modes.
+	cacheNamePrefix = "image-cache-"
 
 	// slugHashLen is the number of hex characters from the SHA-256 hash
 	// appended to slugs for uniqueness (12 hex chars = 48 bits).
 	slugHashLen = 12
 
 	// pauseImage is the minimal container that runs as the main container
-	// in cache DaemonSets.
+	// in cache DaemonSets. Cron mode uses a Job and does not need it.
 	pauseImage = "registry.k8s.io/pause:3.10"
 )
 
@@ -77,22 +70,17 @@ type ImageCacheListResponse struct {
 	Images []ImageCacheStatus `json:"images"`
 }
 
-// ImageCacheManager manages image cache DaemonSets in a namespace.
-type ImageCacheManager struct {
-	clientset           kubernetes.Interface
-	namespace           string
-	imagePullSecretName string
-}
-
-// NewImageCacheManager creates a manager that controls image cache DaemonSets
-// within the given namespace. If imagePullSecretName is empty, cache DaemonSets
-// will not reference an image pull secret (suitable for public images only).
-func NewImageCacheManager(clientset kubernetes.Interface, namespace, imagePullSecretName string) *ImageCacheManager {
-	return &ImageCacheManager{
-		clientset:           clientset,
-		namespace:           namespace,
-		imagePullSecretName: imagePullSecretName,
-	}
+// ImageCacheManager is the interface implemented by both backends: the
+// DaemonSet-per-image cache (node-local containerd warming) and the
+// CronJob-per-image cache (periodic pulls routed through an upstream
+// pull-through registry such as AWS ECR in EKS Auto Mode).
+type ImageCacheManager interface {
+	EnsureImageCached(ctx context.Context, image string) error
+	RefreshCachedImage(ctx context.Context, image string) error
+	RemoveCachedImage(ctx context.Context, image string) error
+	RemoveCachedImageByID(ctx context.Context, id string) error
+	ListCachedImages(ctx context.Context) ([]ImageCacheStatus, error)
+	GetCachedImageStatus(ctx context.Context, id string) (*ImageCacheStatus, error)
 }
 
 // validateImageRef checks that an image reference is minimally valid.
@@ -104,16 +92,6 @@ func validateImageRef(image string) error {
 		return fmt.Errorf("invalid image reference: %q", image)
 	}
 	return nil
-}
-
-// imagePullSecrets returns the image pull secrets list for cache DaemonSets.
-// Returns nil when no secret name is configured, which omits the field from
-// the pod spec entirely (allowing public images to be cached without credentials).
-func (m *ImageCacheManager) imagePullSecrets() []apiv1.LocalObjectReference {
-	if m.imagePullSecretName == "" {
-		return nil
-	}
-	return []apiv1.LocalObjectReference{{Name: m.imagePullSecretName}}
 }
 
 // slugifyImage produces a deterministic, K8s-safe name component from an image
@@ -131,8 +109,8 @@ func slugifyImage(image string) string {
 	slug = collapseRuns(slug, '-')
 	slug = strings.Trim(slug, "-")
 
-	// Truncate so dsNamePrefix + slug + "-" + hash fits in 253 chars.
-	maxSlugLen := 253 - len(dsNamePrefix) - 1 - slugHashLen
+	// Truncate so cacheNamePrefix + slug + "-" + hash fits in 253 chars.
+	maxSlugLen := 253 - len(cacheNamePrefix) - 1 - slugHashLen
 	if len(slug) > maxSlugLen {
 		slug = slug[:maxSlugLen]
 		slug = strings.TrimRight(slug, "-")
@@ -156,211 +134,15 @@ func collapseRuns(s string, c byte) string {
 	return b.String()
 }
 
-// buildCacheDaemonSet constructs a DaemonSet that pre-pulls the given image
-// onto every node. The init container references the target image and runs
-// "true" to exit immediately; K8s pulls the image before running the command.
+// deriveCacheStatus computes the cache status string from "ready" and
+// "desired" counts. Both backends populate these fields; in cron mode they
+// take values 0 or 1 derived from CronJob success state. Evaluated in order:
+// error, ready, cached-with-errors, pulling.
 //
-// For distroless or scratch-based images that lack "true", the init container
-// will fail with CrashLoopBackOff. This is expected — the image is still pulled
-// and cached on each node. The status API reports these as "cached-with-errors".
-func (m *ImageCacheManager) buildCacheDaemonSet(image, slug string) *appsv1.DaemonSet {
-	// dsLabels is named to avoid shadowing the imported "k8s.io/apimachinery/pkg/labels" package.
-	dsLabels := map[string]string{
-		labelManagedBy:    valueManagedBy,
-		labelPurpose:      valuePurpose,
-		labelImageCacheID: slug,
-	}
-
-	// The init container needs enough memory to start the entrypoint process
-	// (even just "true") without being OOM-killed. The pause container is a
-	// tiny static binary and can run with minimal resources.
-	initResources := apiv1.ResourceRequirements{
-		Requests: apiv1.ResourceList{
-			apiv1.ResourceCPU:    resource.MustParse("1m"),
-			apiv1.ResourceMemory: resource.MustParse("64Mi"),
-		},
-		Limits: apiv1.ResourceList{
-			apiv1.ResourceCPU:    resource.MustParse("10m"),
-			apiv1.ResourceMemory: resource.MustParse("64Mi"),
-		},
-	}
-	pauseResources := apiv1.ResourceRequirements{
-		Requests: apiv1.ResourceList{
-			apiv1.ResourceCPU:    resource.MustParse("1m"),
-			apiv1.ResourceMemory: resource.MustParse("16Mi"),
-		},
-		Limits: apiv1.ResourceList{
-			apiv1.ResourceCPU:    resource.MustParse("1m"),
-			apiv1.ResourceMemory: resource.MustParse("16Mi"),
-		},
-	}
-
-	return &appsv1.DaemonSet{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      dsNamePrefix + slug,
-			Namespace: m.namespace,
-			Labels:    dsLabels,
-			Annotations: map[string]string{
-				annotationImage: image,
-			},
-		},
-		Spec: appsv1.DaemonSetSpec{
-			Selector: &metav1.LabelSelector{
-				MatchLabels: dsLabels,
-			},
-			Template: apiv1.PodTemplateSpec{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: dsLabels,
-				},
-				Spec: apiv1.PodSpec{
-					ImagePullSecrets: m.imagePullSecrets(),
-					InitContainers: []apiv1.Container{
-						{
-							Name:            "pull",
-							Image:           image,
-							Command:         []string{"true"},
-							ImagePullPolicy: apiv1.PullAlways,
-							Resources:       initResources,
-						},
-					},
-					Containers: []apiv1.Container{
-						{
-							Name:            "pause",
-							Image:           pauseImage,
-							ImagePullPolicy: apiv1.PullIfNotPresent,
-							Resources:       pauseResources,
-						},
-					},
-					Tolerations: []apiv1.Toleration{
-						{
-							Key:      "analysis",
-							Operator: apiv1.TolerationOpExists,
-						},
-						{
-							Key:      "gpu",
-							Operator: apiv1.TolerationOpEqual,
-							Value:    "true",
-							Effect:   apiv1.TaintEffectNoSchedule,
-						},
-					},
-				},
-			},
-		},
-	}
-}
-
-// EnsureImageCached creates or updates a cache DaemonSet for the given image.
-// If a DaemonSet already exists with the correct image annotation, this is a
-// no-op.
-func (m *ImageCacheManager) EnsureImageCached(ctx context.Context, image string) error {
-	if err := validateImageRef(image); err != nil {
-		return err
-	}
-
-	slug := slugifyImage(image)
-	dsName := dsNamePrefix + slug
-	client := m.clientset.AppsV1().DaemonSets(m.namespace)
-
-	existing, err := client.Get(ctx, dsName, metav1.GetOptions{})
-	if apierrors.IsNotFound(err) {
-		log.Infof("creating image cache DaemonSet %s for %s", dsName, image)
-		ds := m.buildCacheDaemonSet(image, slug)
-		_, err = client.Create(ctx, ds, metav1.CreateOptions{})
-		if err != nil {
-			return fmt.Errorf("creating image cache DaemonSet %s: %w", dsName, err)
-		}
-		return nil
-	}
-	if err != nil {
-		return fmt.Errorf("checking for existing image cache DaemonSet %s: %w", dsName, err)
-	}
-
-	// DaemonSet exists — check if the image annotation matches.
-	if existing.Annotations[annotationImage] == image {
-		log.Debugf("image cache DaemonSet %s already has correct image", dsName)
-		return nil
-	}
-
-	log.Infof("updating image cache DaemonSet %s from %q to %q", dsName, existing.Annotations[annotationImage], image)
-	ds := m.buildCacheDaemonSet(image, slug)
-	ds.ResourceVersion = existing.ResourceVersion
-	_, err = client.Update(ctx, ds, metav1.UpdateOptions{})
-	if err != nil {
-		return fmt.Errorf("updating image cache DaemonSet %s: %w", dsName, err)
-	}
-	return nil
-}
-
-// RefreshCachedImage forces the cache DaemonSet for the given image to re-pull
-// by updating a restart annotation on the pod template, which triggers a rolling
-// update. The init container's PullAlways policy causes containerd to fetch the
-// latest manifest. This is needed when a new image is pushed under the same tag.
-func (m *ImageCacheManager) RefreshCachedImage(ctx context.Context, image string) error {
-	if err := validateImageRef(image); err != nil {
-		return err
-	}
-
-	slug := slugifyImage(image)
-	dsName := dsNamePrefix + slug
-	client := m.clientset.AppsV1().DaemonSets(m.namespace)
-
-	ds, err := client.Get(ctx, dsName, metav1.GetOptions{})
-	if apierrors.IsNotFound(err) {
-		return fmt.Errorf("no cache DaemonSet found for image %q", image)
-	}
-	if err != nil {
-		return fmt.Errorf("getting cache DaemonSet %s: %w", dsName, err)
-	}
-
-	// Restart the DaemonSet by adding/updating a restart annotation on the
-	// pod template. This triggers a rolling update of all pods, which forces
-	// containerd to re-pull the image due to PullAlways on the init container.
-	if ds.Spec.Template.Annotations == nil {
-		ds.Spec.Template.Annotations = make(map[string]string)
-	}
-	ds.Spec.Template.Annotations["de.cyverse.org/restartedAt"] = metav1.Now().UTC().Format(time.RFC3339)
-
-	if _, err := client.Update(ctx, ds, metav1.UpdateOptions{}); err != nil {
-		return fmt.Errorf("restarting cache DaemonSet %s: %w", dsName, err)
-	}
-
-	log.Infof("refreshed image cache DaemonSet %s for %s", dsName, image)
-	return nil
-}
-
-// RemoveCachedImage deletes the cache DaemonSet for the given image.
-// Returns nil if the DaemonSet doesn't exist (idempotent).
-func (m *ImageCacheManager) RemoveCachedImage(ctx context.Context, image string) error {
-	if err := validateImageRef(image); err != nil {
-		return err
-	}
-	return m.RemoveCachedImageByID(ctx, slugifyImage(image))
-}
-
-// RemoveCachedImageByID deletes the cache DaemonSet with the given slug ID.
-// Returns nil if the DaemonSet doesn't exist (idempotent).
-func (m *ImageCacheManager) RemoveCachedImageByID(ctx context.Context, id string) error {
-	dsName := dsNamePrefix + id
-	err := m.clientset.AppsV1().DaemonSets(m.namespace).Delete(ctx, dsName, metav1.DeleteOptions{})
-	if apierrors.IsNotFound(err) {
-		return nil
-	}
-	if err != nil {
-		return fmt.Errorf("deleting image cache DaemonSet %s: %w", dsName, err)
-	}
-	log.Infof("deleted image cache DaemonSet %s", dsName)
-	return nil
-}
-
-// deriveCacheStatus computes the cache status string from DaemonSet status
-// fields. Evaluated in order: error, ready, cached-with-errors, pulling.
-//
-// Note: "cached-with-errors" is returned when ready==0 and desired>0. This
-// covers both distroless images where the init container CrashLoopBackOff
-// (image is still cached) and newly created DaemonSets where pods haven't
-// started yet. We cannot distinguish these cases from aggregate counts alone;
-// pod-level inspection would be needed. In practice, the transient "initial
-// pull" state resolves quickly, while CrashLoopBackOff is persistent.
+// "cached-with-errors" is returned when ready==0 and desired>0. For
+// DaemonSets this covers distroless images where the init container
+// CrashLoopBackOffs (image still cached) and newly created DaemonSets where
+// pods haven't started yet. For CronJobs it covers a failed last run.
 func deriveCacheStatus(desired, ready int32) string {
 	if desired == 0 {
 		return "error"
@@ -372,47 +154,4 @@ func deriveCacheStatus(desired, ready int32) string {
 		return "cached-with-errors"
 	}
 	return "pulling"
-}
-
-// cacheStatusFromDS builds an ImageCacheStatus from a DaemonSet.
-func cacheStatusFromDS(ds *appsv1.DaemonSet) ImageCacheStatus {
-	return ImageCacheStatus{
-		Image:   ds.Annotations[annotationImage],
-		ID:      ds.Labels[labelImageCacheID],
-		Ready:   ds.Status.NumberReady,
-		Desired: ds.Status.DesiredNumberScheduled,
-		Status:  deriveCacheStatus(ds.Status.DesiredNumberScheduled, ds.Status.NumberReady),
-	}
-}
-
-// ListCachedImages returns the status of all image cache DaemonSets in the
-// namespace.
-func (m *ImageCacheManager) ListCachedImages(ctx context.Context) ([]ImageCacheStatus, error) {
-	sel := labels.SelectorFromSet(labels.Set{
-		labelManagedBy: valueManagedBy,
-		labelPurpose:   valuePurpose,
-	})
-
-	list, err := m.clientset.AppsV1().DaemonSets(m.namespace).List(ctx, metav1.ListOptions{LabelSelector: sel.String()})
-	if err != nil {
-		return nil, fmt.Errorf("listing image cache DaemonSets: %w", err)
-	}
-
-	result := make([]ImageCacheStatus, 0, len(list.Items))
-	for i := range list.Items {
-		result = append(result, cacheStatusFromDS(&list.Items[i]))
-	}
-	return result, nil
-}
-
-// GetCachedImageStatus returns the status of a single cached image by its slug
-// ID. Returns an error if the DaemonSet is not found.
-func (m *ImageCacheManager) GetCachedImageStatus(ctx context.Context, id string) (*ImageCacheStatus, error) {
-	dsName := dsNamePrefix + id
-	ds, err := m.clientset.AppsV1().DaemonSets(m.namespace).Get(ctx, dsName, metav1.GetOptions{})
-	if err != nil {
-		return nil, fmt.Errorf("getting image cache DaemonSet %s: %w", dsName, err)
-	}
-	status := cacheStatusFromDS(ds)
-	return &status, nil
 }

--- a/operator/imagecache.go
+++ b/operator/imagecache.go
@@ -7,6 +7,9 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
 )
 
 const (
@@ -28,16 +31,27 @@ const (
 	// appended to slugs for uniqueness (12 hex chars = 48 bits).
 	slugHashLen = 12
 
+	// k8sMaxNameLen is the maximum length of a Kubernetes object name.
+	k8sMaxNameLen = 253
+
 	// pauseImage is the minimal container that runs as the main container
 	// in cache DaemonSets. Cron mode uses a Job and does not need it.
 	pauseImage = "registry.k8s.io/pause:3.10"
 )
 
-// imageRefPattern is a basic validation pattern for container image references.
-// It requires the reference to start with an alphanumeric character and contain
-// only alphanumeric characters, dots, underscores, slashes, colons, at-signs,
-// and hyphens.
+// imageRefPattern accepts well-formed image references and rejects strings
+// containing whitespace or shell-unsafe characters.
 var imageRefPattern = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._/:@-]*$`)
+
+// imageCacheIDPattern matches the slug IDs produced by slugifyImage so
+// the path-parameter handlers can reject obvious garbage before forwarding
+// it to the K8s API server. Bound is k8sMaxNameLen minus cacheNamePrefix.
+var imageCacheIDPattern = regexp.MustCompile(`^[a-z0-9][a-z0-9-]{0,240}$`)
+
+// maxImageRefLen caps the image reference length so a caller can't park a
+// huge string in CronJob/DaemonSet annotations (each annotation value can
+// be up to 256KiB; a real OCI ref tops out near 700 chars).
+const maxImageRefLen = 1024
 
 // ImageCacheRequest is the request body for bulk cache operations.
 type ImageCacheRequest struct {
@@ -83,13 +97,76 @@ type ImageCacheManager interface {
 	GetCachedImageStatus(ctx context.Context, id string) (*ImageCacheStatus, error)
 }
 
+// imagePullSecretsFor returns a pull-secret list for the given secret name, or
+// nil when the name is empty (omits the field from the pod spec for public images).
+func imagePullSecretsFor(name string) []apiv1.LocalObjectReference {
+	if name == "" {
+		return nil
+	}
+	return []apiv1.LocalObjectReference{{Name: name}}
+}
+
+// cachePodTolerations returns the standard tolerations applied to every cache
+// pod (DaemonSet init-container or CronJob pod). Tolerates the analysis taint
+// so pods land on analysis nodes, and the GPU taint so image pulls still reach
+// GPU-only nodes.
+func cachePodTolerations() []apiv1.Toleration {
+	return []apiv1.Toleration{
+		{
+			Key:      "analysis",
+			Operator: apiv1.TolerationOpExists,
+		},
+		{
+			Key:      "gpu",
+			Operator: apiv1.TolerationOpEqual,
+			Value:    "true",
+			Effect:   apiv1.TaintEffectNoSchedule,
+		},
+	}
+}
+
+// cacheResourceLabels returns the standard label set for a cache resource
+// identified by slug.
+func cacheResourceLabels(slug string) map[string]string {
+	return map[string]string{
+		labelManagedBy:    valueManagedBy,
+		labelPurpose:      valuePurpose,
+		labelImageCacheID: slug,
+	}
+}
+
+// cacheManagedBySelector returns a label selector that matches all resources
+// managed by this operator's image cache.
+func cacheManagedBySelector() labels.Selector {
+	return labels.SelectorFromSet(labels.Set{
+		labelManagedBy: valueManagedBy,
+		labelPurpose:   valuePurpose,
+	})
+}
+
 // validateImageRef checks that an image reference is minimally valid.
 func validateImageRef(image string) error {
 	if image == "" {
 		return errors.New("image reference must not be empty")
 	}
+	if len(image) > maxImageRefLen {
+		return fmt.Errorf("image reference too long: %d chars (max %d)", len(image), maxImageRefLen)
+	}
 	if !imageRefPattern.MatchString(image) {
 		return fmt.Errorf("invalid image reference: %q", image)
+	}
+	return nil
+}
+
+// validateImageCacheID rejects slug IDs that don't match the format
+// slugifyImage produces, so handlers can return 404 immediately instead of
+// forwarding malformed input to the K8s API.
+func validateImageCacheID(id string) error {
+	if id == "" {
+		return errors.New("image cache id must not be empty")
+	}
+	if !imageCacheIDPattern.MatchString(id) {
+		return fmt.Errorf("invalid image cache id: %q", id)
 	}
 	return nil
 }
@@ -109,8 +186,8 @@ func slugifyImage(image string) string {
 	slug = collapseRuns(slug, '-')
 	slug = strings.Trim(slug, "-")
 
-	// Truncate so cacheNamePrefix + slug + "-" + hash fits in 253 chars.
-	maxSlugLen := 253 - len(cacheNamePrefix) - 1 - slugHashLen
+	// Truncate so cacheNamePrefix + slug + "-" + hash fits within k8sMaxNameLen.
+	maxSlugLen := k8sMaxNameLen - len(cacheNamePrefix) - 1 - slugHashLen
 	if len(slug) > maxSlugLen {
 		slug = slug[:maxSlugLen]
 		slug = strings.TrimRight(slug, "-")
@@ -134,15 +211,11 @@ func collapseRuns(s string, c byte) string {
 	return b.String()
 }
 
-// deriveCacheStatus computes the cache status string from "ready" and
-// "desired" counts. Both backends populate these fields; in cron mode they
-// take values 0 or 1 derived from CronJob success state. Evaluated in order:
-// error, ready, cached-with-errors, pulling.
-//
-// "cached-with-errors" is returned when ready==0 and desired>0. For
-// DaemonSets this covers distroless images where the init container
-// CrashLoopBackOffs (image still cached) and newly created DaemonSets where
-// pods haven't started yet. For CronJobs it covers a failed last run.
+// deriveCacheStatus maps (desired, ready) counts to a status string shared by
+// both backends. In cron mode desired and ready are 0 or 1 derived from
+// CronJob success state. "cached-with-errors" covers distroless images
+// (CrashLoopBackOff after pull) and failed CronJob runs — the image is
+// present even though the container exited non-zero.
 func deriveCacheStatus(desired, ready int32) string {
 	if desired == 0 {
 		return "error"

--- a/operator/imagecache.go
+++ b/operator/imagecache.go
@@ -84,10 +84,11 @@ type ImageCacheListResponse struct {
 	Images []ImageCacheStatus `json:"images"`
 }
 
-// ImageCacheManager is the interface implemented by both backends: the
-// DaemonSet-per-image cache (node-local containerd warming) and the
+// ImageCacheManager is the interface implemented by the cache backends:
+// the DaemonSet-per-image cache (node-local containerd warming), the
 // CronJob-per-image cache (periodic pulls routed through an upstream
-// pull-through registry such as AWS ECR in EKS Auto Mode).
+// pull-through registry such as AWS ECR), and the manual-mirror manager
+// (read-only window onto a static mapping file maintained externally).
 type ImageCacheManager interface {
 	EnsureImageCached(ctx context.Context, image string) error
 	RefreshCachedImage(ctx context.Context, image string) error
@@ -95,7 +96,28 @@ type ImageCacheManager interface {
 	RemoveCachedImageByID(ctx context.Context, id string) error
 	ListCachedImages(ctx context.Context) ([]ImageCacheStatus, error)
 	GetCachedImageStatus(ctx context.Context, id string) (*ImageCacheStatus, error)
+	// ReadOnly reports whether the backing cache is externally managed,
+	// in which case mutating HTTP endpoints short-circuit to 400 rather
+	// than calling into the manager.
+	ReadOnly() bool
 }
+
+// ImageRewriter rewrites image references at launch time. Orthogonal to
+// ImageCacheManager: daemonset/cron modes contribute no rewriter (the
+// operator launches whatever images the bundle carries); manual-mirror
+// contributes one that swaps upstream refs for their mirrored counterparts
+// using a static JSON map.
+type ImageRewriter interface {
+	// RewriteImage returns the substitute ref when image has a mapping and
+	// ok=true; otherwise returns image unchanged and ok=false.
+	RewriteImage(image string) (rewritten string, ok bool)
+}
+
+// ErrCacheReadOnly is returned by manual-mirror's mutating cache methods.
+// Handlers detect ReadOnly() at the request level and don't normally call
+// into the manager when it's set, but this is the canonical error for any
+// path that does reach the methods.
+var ErrCacheReadOnly = errors.New("image cache is externally managed in this mode")
 
 // imagePullSecretsFor returns a pull-secret list for the given secret name, or
 // nil when the name is empty (omits the field from the pod spec for public images).

--- a/operator/imagecache_cronjob.go
+++ b/operator/imagecache_cronjob.go
@@ -44,6 +44,10 @@ func NewCronJobImageCacheManager(clientset kubernetes.Interface, namespace, imag
 	}
 }
 
+// ReadOnly is false: cron mode actively manages CronJob/Job resources via
+// the full mutating API.
+func (*CronJobImageCacheManager) ReadOnly() bool { return false }
+
 // buildCacheCronJob constructs a CronJob that pulls the given image on its
 // configured schedule. The Job runs a single container with the target
 // image and command ["true"]; K8s pulls the image before running the

--- a/operator/imagecache_cronjob.go
+++ b/operator/imagecache_cronjob.go
@@ -10,12 +10,8 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes"
 )
-
-// k8sMaxNameLen is the maximum length of a Kubernetes object name.
-const k8sMaxNameLen = 253
 
 // refreshJobTTLSeconds is the TTLSecondsAfterFinished applied to refresh
 // Jobs so they self-clean a few minutes after completing.
@@ -48,13 +44,6 @@ func NewCronJobImageCacheManager(clientset kubernetes.Interface, namespace, imag
 	}
 }
 
-func (m *CronJobImageCacheManager) imagePullSecrets() []apiv1.LocalObjectReference {
-	if m.imagePullSecretName == "" {
-		return nil
-	}
-	return []apiv1.LocalObjectReference{{Name: m.imagePullSecretName}}
-}
-
 // buildCacheCronJob constructs a CronJob that pulls the given image on its
 // configured schedule. The Job runs a single container with the target
 // image and command ["true"]; K8s pulls the image before running the
@@ -66,11 +55,7 @@ func (m *CronJobImageCacheManager) imagePullSecrets() []apiv1.LocalObjectReferen
 // before the entrypoint runs). The status API surfaces those as
 // "cached-with-errors".
 func (m *CronJobImageCacheManager) buildCacheCronJob(image, slug string) *batchv1.CronJob {
-	cjLabels := map[string]string{
-		labelManagedBy:    valueManagedBy,
-		labelPurpose:      valuePurpose,
-		labelImageCacheID: slug,
-	}
+	cjLabels := cacheResourceLabels(slug)
 
 	pullResources := apiv1.ResourceRequirements{
 		Requests: apiv1.ResourceList{
@@ -85,7 +70,7 @@ func (m *CronJobImageCacheManager) buildCacheCronJob(image, slug string) *batchv
 
 	podSpec := apiv1.PodSpec{
 		RestartPolicy:    apiv1.RestartPolicyNever,
-		ImagePullSecrets: m.imagePullSecrets(),
+		ImagePullSecrets: imagePullSecretsFor(m.imagePullSecretName),
 		Containers: []apiv1.Container{
 			{
 				Name:            "pull",
@@ -95,18 +80,7 @@ func (m *CronJobImageCacheManager) buildCacheCronJob(image, slug string) *batchv
 				Resources:       pullResources,
 			},
 		},
-		Tolerations: []apiv1.Toleration{
-			{
-				Key:      "analysis",
-				Operator: apiv1.TolerationOpExists,
-			},
-			{
-				Key:      "gpu",
-				Operator: apiv1.TolerationOpEqual,
-				Value:    "true",
-				Effect:   apiv1.TaintEffectNoSchedule,
-			},
-		},
+		Tolerations: cachePodTolerations(),
 	}
 
 	jobSpec := batchv1.JobSpec{
@@ -202,11 +176,7 @@ func (m *CronJobImageCacheManager) RefreshCachedImage(ctx context.Context, image
 	jobSpec := cj.Spec.JobTemplate.Spec.DeepCopy()
 	jobSpec.TTLSecondsAfterFinished = constants.Int32Ptr(refreshJobTTLSeconds)
 
-	jobLabels := map[string]string{
-		labelManagedBy:    valueManagedBy,
-		labelPurpose:      valuePurpose,
-		labelImageCacheID: slug,
-	}
+	jobLabels := cacheResourceLabels(slug)
 
 	// generateName lets the API server append a 5-char suffix so the name is
 	// unique even across rapid back-to-back refreshes. The prefix is
@@ -321,12 +291,7 @@ func deriveCronJobCacheStatus(cj *batchv1.CronJob) (desired, ready int32, status
 // ListCachedImages returns the status of all image cache CronJobs in the
 // namespace.
 func (m *CronJobImageCacheManager) ListCachedImages(ctx context.Context) ([]ImageCacheStatus, error) {
-	sel := labels.SelectorFromSet(labels.Set{
-		labelManagedBy: valueManagedBy,
-		labelPurpose:   valuePurpose,
-	})
-
-	list, err := m.clientset.BatchV1().CronJobs(m.namespace).List(ctx, metav1.ListOptions{LabelSelector: sel.String()})
+	list, err := m.clientset.BatchV1().CronJobs(m.namespace).List(ctx, metav1.ListOptions{LabelSelector: cacheManagedBySelector().String()})
 	if err != nil {
 		return nil, fmt.Errorf("listing image cache CronJobs: %w", err)
 	}
@@ -349,4 +314,3 @@ func (m *CronJobImageCacheManager) GetCachedImageStatus(ctx context.Context, id 
 	status := cacheStatusFromCronJob(cj)
 	return &status, nil
 }
-

--- a/operator/imagecache_cronjob.go
+++ b/operator/imagecache_cronjob.go
@@ -1,0 +1,352 @@
+package operator
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cyverse-de/app-exposer/constants"
+	batchv1 "k8s.io/api/batch/v1"
+	apiv1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/kubernetes"
+)
+
+// k8sMaxNameLen is the maximum length of a Kubernetes object name.
+const k8sMaxNameLen = 253
+
+// refreshJobTTLSeconds is the TTLSecondsAfterFinished applied to refresh
+// Jobs so they self-clean a few minutes after completing.
+const refreshJobTTLSeconds int32 = 300
+
+// CronJobImageCacheManager manages image cache CronJobs in a namespace. One
+// CronJob per cached image; each scheduled Job pulls the target image,
+// which on EKS Auto Mode nodes is transparently routed through an ECR
+// pull-through cache repository — populating ECR rather than node-local
+// containerd. Deletion removes only the CronJob; image eviction is handled
+// by ECR lifecycle policies, outside vice-operator.
+type CronJobImageCacheManager struct {
+	clientset           kubernetes.Interface
+	namespace           string
+	imagePullSecretName string
+	schedule            string
+}
+
+// NewCronJobImageCacheManager creates a manager that controls image cache
+// CronJobs within the given namespace. The schedule is a standard cron
+// expression applied to every cached image; the caller is responsible for
+// validating it before construction. imagePullSecretName behaves the same
+// as in the DaemonSet manager — empty means no secret is referenced.
+func NewCronJobImageCacheManager(clientset kubernetes.Interface, namespace, imagePullSecretName, schedule string) *CronJobImageCacheManager {
+	return &CronJobImageCacheManager{
+		clientset:           clientset,
+		namespace:           namespace,
+		imagePullSecretName: imagePullSecretName,
+		schedule:            schedule,
+	}
+}
+
+func (m *CronJobImageCacheManager) imagePullSecrets() []apiv1.LocalObjectReference {
+	if m.imagePullSecretName == "" {
+		return nil
+	}
+	return []apiv1.LocalObjectReference{{Name: m.imagePullSecretName}}
+}
+
+// buildCacheCronJob constructs a CronJob that pulls the given image on its
+// configured schedule. The Job runs a single container with the target
+// image and command ["true"]; K8s pulls the image before running the
+// command. On EKS Auto Mode nodes configured with an ECR pull-through
+// cache, this pull populates ECR transparently.
+//
+// Distroless or scratch-based images that lack "true" will produce failed
+// Jobs, but the image is still pulled and cached in ECR (the pull happens
+// before the entrypoint runs). The status API surfaces those as
+// "cached-with-errors".
+func (m *CronJobImageCacheManager) buildCacheCronJob(image, slug string) *batchv1.CronJob {
+	cjLabels := map[string]string{
+		labelManagedBy:    valueManagedBy,
+		labelPurpose:      valuePurpose,
+		labelImageCacheID: slug,
+	}
+
+	pullResources := apiv1.ResourceRequirements{
+		Requests: apiv1.ResourceList{
+			apiv1.ResourceCPU:    resource.MustParse("1m"),
+			apiv1.ResourceMemory: resource.MustParse("64Mi"),
+		},
+		Limits: apiv1.ResourceList{
+			apiv1.ResourceCPU:    resource.MustParse("10m"),
+			apiv1.ResourceMemory: resource.MustParse("64Mi"),
+		},
+	}
+
+	podSpec := apiv1.PodSpec{
+		RestartPolicy:    apiv1.RestartPolicyNever,
+		ImagePullSecrets: m.imagePullSecrets(),
+		Containers: []apiv1.Container{
+			{
+				Name:            "pull",
+				Image:           image,
+				Command:         []string{"true"},
+				ImagePullPolicy: apiv1.PullAlways,
+				Resources:       pullResources,
+			},
+		},
+		Tolerations: []apiv1.Toleration{
+			{
+				Key:      "analysis",
+				Operator: apiv1.TolerationOpExists,
+			},
+			{
+				Key:      "gpu",
+				Operator: apiv1.TolerationOpEqual,
+				Value:    "true",
+				Effect:   apiv1.TaintEffectNoSchedule,
+			},
+		},
+	}
+
+	jobSpec := batchv1.JobSpec{
+		BackoffLimit: constants.Int32Ptr(0),
+		Template: apiv1.PodTemplateSpec{
+			ObjectMeta: metav1.ObjectMeta{Labels: cjLabels},
+			Spec:       podSpec,
+		},
+	}
+
+	return &batchv1.CronJob{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cacheNamePrefix + slug,
+			Namespace: m.namespace,
+			Labels:    cjLabels,
+			Annotations: map[string]string{
+				annotationImage: image,
+			},
+		},
+		Spec: batchv1.CronJobSpec{
+			Schedule:                   m.schedule,
+			ConcurrencyPolicy:          batchv1.ForbidConcurrent,
+			SuccessfulJobsHistoryLimit: constants.Int32Ptr(1),
+			FailedJobsHistoryLimit:     constants.Int32Ptr(1),
+			JobTemplate: batchv1.JobTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: cjLabels},
+				Spec:       jobSpec,
+			},
+		},
+	}
+}
+
+// EnsureImageCached creates or updates a cache CronJob for the given image.
+// If a CronJob already exists with the correct image annotation, this is a
+// no-op.
+func (m *CronJobImageCacheManager) EnsureImageCached(ctx context.Context, image string) error {
+	if err := validateImageRef(image); err != nil {
+		return err
+	}
+
+	slug := slugifyImage(image)
+	cjName := cacheNamePrefix + slug
+	client := m.clientset.BatchV1().CronJobs(m.namespace)
+
+	existing, err := client.Get(ctx, cjName, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		log.Infof("creating image cache CronJob %s for %s", cjName, image)
+		cj := m.buildCacheCronJob(image, slug)
+		if _, err := client.Create(ctx, cj, metav1.CreateOptions{}); err != nil {
+			return fmt.Errorf("creating image cache CronJob %s: %w", cjName, err)
+		}
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("checking for existing image cache CronJob %s: %w", cjName, err)
+	}
+
+	if existing.Annotations[annotationImage] == image {
+		log.Debugf("image cache CronJob %s already has correct image", cjName)
+		return nil
+	}
+
+	log.Infof("updating image cache CronJob %s from %q to %q", cjName, existing.Annotations[annotationImage], image)
+	cj := m.buildCacheCronJob(image, slug)
+	cj.ResourceVersion = existing.ResourceVersion
+	if _, err := client.Update(ctx, cj, metav1.UpdateOptions{}); err != nil {
+		return fmt.Errorf("updating image cache CronJob %s: %w", cjName, err)
+	}
+	return nil
+}
+
+// RefreshCachedImage triggers an immediate pull by creating a one-off Job
+// from the CronJob's job template. The CronJob continues firing on its
+// normal schedule afterwards. Mirrors the DaemonSet manager's refresh
+// semantics ("re-pull now") so the bulk handler is mode-agnostic.
+func (m *CronJobImageCacheManager) RefreshCachedImage(ctx context.Context, image string) error {
+	if err := validateImageRef(image); err != nil {
+		return err
+	}
+
+	slug := slugifyImage(image)
+	cjName := cacheNamePrefix + slug
+	cjClient := m.clientset.BatchV1().CronJobs(m.namespace)
+
+	cj, err := cjClient.Get(ctx, cjName, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		return fmt.Errorf("no cache CronJob found for image %q", image)
+	}
+	if err != nil {
+		return fmt.Errorf("getting cache CronJob %s: %w", cjName, err)
+	}
+
+	jobSpec := cj.Spec.JobTemplate.Spec.DeepCopy()
+	jobSpec.TTLSecondsAfterFinished = constants.Int32Ptr(refreshJobTTLSeconds)
+
+	jobLabels := map[string]string{
+		labelManagedBy:    valueManagedBy,
+		labelPurpose:      valuePurpose,
+		labelImageCacheID: slug,
+	}
+
+	// generateName lets the API server append a 5-char suffix so the name is
+	// unique even across rapid back-to-back refreshes. The prefix is
+	// truncated if needed to stay under the K8s name length limit.
+	generatePrefix := refreshJobGeneratePrefix(slug)
+
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: generatePrefix,
+			Namespace:    m.namespace,
+			Labels:       jobLabels,
+			Annotations:  map[string]string{annotationImage: image},
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: "batch/v1",
+				Kind:       "CronJob",
+				Name:       cj.Name,
+				UID:        cj.UID,
+			}},
+		},
+		Spec: *jobSpec,
+	}
+
+	created, err := m.clientset.BatchV1().Jobs(m.namespace).Create(ctx, job, metav1.CreateOptions{})
+	if err != nil {
+		return fmt.Errorf("creating refresh Job for cache CronJob %s: %w", cjName, err)
+	}
+	log.Infof("refreshed image cache %s for %s via Job %s", cjName, image, created.Name)
+	return nil
+}
+
+// refreshJobGeneratePrefix returns a generateName prefix for a refresh Job,
+// truncated so the API server's 5-char random suffix fits within the K8s
+// name limit.
+func refreshJobGeneratePrefix(slug string) string {
+	prefix := cacheNamePrefix + slug + "-r-"
+	const maxPrefix = k8sMaxNameLen - 5
+	if len(prefix) > maxPrefix {
+		prefix = prefix[:maxPrefix]
+	}
+	return prefix
+}
+
+// RemoveCachedImage deletes the cache CronJob for the given image.
+// Returns nil if the CronJob doesn't exist (idempotent). Owned refresh
+// Jobs are cleaned up by the K8s garbage collector via OwnerReferences;
+// image eviction in ECR is handled by lifecycle policies, outside this
+// service.
+func (m *CronJobImageCacheManager) RemoveCachedImage(ctx context.Context, image string) error {
+	if err := validateImageRef(image); err != nil {
+		return err
+	}
+	return m.RemoveCachedImageByID(ctx, slugifyImage(image))
+}
+
+// RemoveCachedImageByID deletes the cache CronJob with the given slug ID.
+// Returns nil if the CronJob doesn't exist (idempotent).
+func (m *CronJobImageCacheManager) RemoveCachedImageByID(ctx context.Context, id string) error {
+	cjName := cacheNamePrefix + id
+	err := m.clientset.BatchV1().CronJobs(m.namespace).Delete(ctx, cjName, metav1.DeleteOptions{})
+	if apierrors.IsNotFound(err) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("deleting image cache CronJob %s: %w", cjName, err)
+	}
+	log.Infof("deleted image cache CronJob %s", cjName)
+	return nil
+}
+
+// cacheStatusFromCronJob builds an ImageCacheStatus from a CronJob, mapping
+// cron-specific state onto the DaemonSet-shaped (ready, desired, status)
+// triple so the API response is the same in both modes.
+//
+//	Suspended           → desired=0, ready=0, status=error
+//	Never scheduled yet → desired=1, ready=0, status=pulling
+//	Last run succeeded  → desired=1, ready=1, status=ready
+//	Last run failed     → desired=1, ready=0, status=cached-with-errors
+func cacheStatusFromCronJob(cj *batchv1.CronJob) ImageCacheStatus {
+	desired, ready, status := deriveCronJobCacheStatus(cj)
+	return ImageCacheStatus{
+		Image:   cj.Annotations[annotationImage],
+		ID:      cj.Labels[labelImageCacheID],
+		Ready:   ready,
+		Desired: desired,
+		Status:  status,
+	}
+}
+
+// deriveCronJobCacheStatus computes the (desired, ready, status) triple
+// from a CronJob's spec and status. Split out from cacheStatusFromCronJob
+// so it can be unit-tested without constructing a full CronJob.
+func deriveCronJobCacheStatus(cj *batchv1.CronJob) (desired, ready int32, status string) {
+	if cj.Spec.Suspend != nil && *cj.Spec.Suspend {
+		return 0, 0, "error"
+	}
+	desired = 1
+
+	scheduled := cj.Status.LastScheduleTime
+	success := cj.Status.LastSuccessfulTime
+
+	switch {
+	case scheduled == nil && success == nil:
+		// First run hasn't fired yet — schedule is in place, image not pulled.
+		return desired, 0, "pulling"
+	case success != nil && (scheduled == nil || !success.Time.Before(scheduled.Time)):
+		return desired, 1, "ready"
+	default:
+		return desired, 0, "cached-with-errors"
+	}
+}
+
+// ListCachedImages returns the status of all image cache CronJobs in the
+// namespace.
+func (m *CronJobImageCacheManager) ListCachedImages(ctx context.Context) ([]ImageCacheStatus, error) {
+	sel := labels.SelectorFromSet(labels.Set{
+		labelManagedBy: valueManagedBy,
+		labelPurpose:   valuePurpose,
+	})
+
+	list, err := m.clientset.BatchV1().CronJobs(m.namespace).List(ctx, metav1.ListOptions{LabelSelector: sel.String()})
+	if err != nil {
+		return nil, fmt.Errorf("listing image cache CronJobs: %w", err)
+	}
+
+	result := make([]ImageCacheStatus, 0, len(list.Items))
+	for i := range list.Items {
+		result = append(result, cacheStatusFromCronJob(&list.Items[i]))
+	}
+	return result, nil
+}
+
+// GetCachedImageStatus returns the status of a single cached image by its
+// slug ID. Returns an error if the CronJob is not found.
+func (m *CronJobImageCacheManager) GetCachedImageStatus(ctx context.Context, id string) (*ImageCacheStatus, error) {
+	cjName := cacheNamePrefix + id
+	cj, err := m.clientset.BatchV1().CronJobs(m.namespace).Get(ctx, cjName, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("getting image cache CronJob %s: %w", cjName, err)
+	}
+	status := cacheStatusFromCronJob(cj)
+	return &status, nil
+}
+

--- a/operator/imagecache_cronjob_test.go
+++ b/operator/imagecache_cronjob_test.go
@@ -1,0 +1,369 @@
+package operator
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	batchv1 "k8s.io/api/batch/v1"
+	apiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+const testCronSchedule = "0 2 * * *"
+
+func TestBuildCacheCronJob(t *testing.T) {
+	mgr := NewCronJobImageCacheManager(nil, "vice-apps", "vice-image-pull-secret", testCronSchedule)
+	image := "harbor.cyverse.org/de/vice-proxy:latest"
+	slug := slugifyImage(image)
+
+	cj := mgr.buildCacheCronJob(image, slug)
+
+	assert.Equal(t, cacheNamePrefix+slug, cj.Name)
+	assert.Equal(t, "vice-apps", cj.Namespace)
+	assert.Equal(t, valueManagedBy, cj.Labels[labelManagedBy])
+	assert.Equal(t, valuePurpose, cj.Labels[labelPurpose])
+	assert.Equal(t, slug, cj.Labels[labelImageCacheID])
+	assert.Equal(t, image, cj.Annotations[annotationImage])
+
+	assert.Equal(t, testCronSchedule, cj.Spec.Schedule)
+	assert.Equal(t, batchv1.ForbidConcurrent, cj.Spec.ConcurrencyPolicy)
+	require.NotNil(t, cj.Spec.SuccessfulJobsHistoryLimit)
+	assert.Equal(t, int32(1), *cj.Spec.SuccessfulJobsHistoryLimit)
+	require.NotNil(t, cj.Spec.FailedJobsHistoryLimit)
+	assert.Equal(t, int32(1), *cj.Spec.FailedJobsHistoryLimit)
+
+	jobSpec := cj.Spec.JobTemplate.Spec
+	require.NotNil(t, jobSpec.BackoffLimit)
+	assert.Equal(t, int32(0), *jobSpec.BackoffLimit)
+
+	require.Len(t, jobSpec.Template.Spec.Containers, 1)
+	pull := jobSpec.Template.Spec.Containers[0]
+	assert.Equal(t, image, pull.Image)
+	assert.Equal(t, []string{"true"}, pull.Command)
+	assert.Equal(t, apiv1.PullAlways, pull.ImagePullPolicy)
+	assert.Equal(t, apiv1.RestartPolicyNever, jobSpec.Template.Spec.RestartPolicy)
+
+	require.Len(t, jobSpec.Template.Spec.ImagePullSecrets, 1)
+	assert.Equal(t, "vice-image-pull-secret", jobSpec.Template.Spec.ImagePullSecrets[0].Name)
+
+	assert.Len(t, jobSpec.Template.Spec.Tolerations, 2)
+}
+
+func TestBuildCacheCronJobOmitsPullSecretWhenEmpty(t *testing.T) {
+	mgr := NewCronJobImageCacheManager(nil, "vice-apps", "", testCronSchedule)
+	cj := mgr.buildCacheCronJob("nginx:1.27", slugifyImage("nginx:1.27"))
+	assert.Empty(t, cj.Spec.JobTemplate.Spec.Template.Spec.ImagePullSecrets)
+}
+
+func TestCronEnsureImageCached(t *testing.T) {
+	const (
+		ns     = "vice-apps"
+		secret = "vice-image-pull-secret"
+		image  = "harbor.cyverse.org/de/vice-proxy:latest"
+	)
+	slug := slugifyImage(image)
+	cjName := cacheNamePrefix + slug
+
+	tests := []struct {
+		name     string
+		existing *batchv1.CronJob // nil = no pre-existing CronJob
+	}{
+		{
+			name:     "creates CronJob when missing",
+			existing: nil,
+		},
+		{
+			name:     "no-op when image matches",
+			existing: NewCronJobImageCacheManager(nil, ns, secret, testCronSchedule).buildCacheCronJob(image, slug),
+		},
+		{
+			name: "updates when annotation differs",
+			existing: func() *batchv1.CronJob {
+				cj := NewCronJobImageCacheManager(nil, ns, secret, testCronSchedule).buildCacheCronJob("old-image:v1", slug)
+				cj.Name = cjName
+				cj.Annotations[annotationImage] = "old-image:v1"
+				return cj
+			}(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var cs *fake.Clientset
+			if tt.existing != nil {
+				cs = fake.NewSimpleClientset(tt.existing)
+			} else {
+				cs = fake.NewSimpleClientset()
+			}
+
+			mgr := NewCronJobImageCacheManager(cs, ns, secret, testCronSchedule)
+			err := mgr.EnsureImageCached(context.Background(), image)
+			require.NoError(t, err)
+
+			cj, err := cs.BatchV1().CronJobs(ns).Get(context.Background(), cjName, metav1.GetOptions{})
+			require.NoError(t, err)
+			assert.Equal(t, image, cj.Annotations[annotationImage])
+		})
+	}
+}
+
+func TestCronEnsureImageCachedInvalidRef(t *testing.T) {
+	cs := fake.NewSimpleClientset()
+	mgr := NewCronJobImageCacheManager(cs, "vice-apps", "vice-image-pull-secret", testCronSchedule)
+
+	assert.Error(t, mgr.EnsureImageCached(context.Background(), ""))
+	assert.Error(t, mgr.EnsureImageCached(context.Background(), "bad image!"))
+}
+
+func TestCronRefreshCachedImageCreatesJob(t *testing.T) {
+	const (
+		ns     = "vice-apps"
+		secret = "vice-image-pull-secret"
+		image  = "harbor.cyverse.org/de/vice-proxy:latest"
+	)
+	slug := slugifyImage(image)
+	existing := NewCronJobImageCacheManager(nil, ns, secret, testCronSchedule).buildCacheCronJob(image, slug)
+	// Fake clientset doesn't set a UID; give one so we can assert the
+	// OwnerReference round-trips correctly.
+	existing.UID = "fake-uid-123"
+
+	cs := fake.NewSimpleClientset(existing)
+	mgr := NewCronJobImageCacheManager(cs, ns, secret, testCronSchedule)
+
+	err := mgr.RefreshCachedImage(context.Background(), image)
+	require.NoError(t, err)
+
+	jobs, err := cs.BatchV1().Jobs(ns).List(context.Background(), metav1.ListOptions{})
+	require.NoError(t, err)
+	require.Len(t, jobs.Items, 1)
+
+	job := jobs.Items[0]
+	assert.Equal(t, cacheNamePrefix+slug+"-r-", job.GenerateName)
+	assert.Equal(t, image, job.Annotations[annotationImage])
+	assert.Equal(t, slug, job.Labels[labelImageCacheID])
+	require.NotNil(t, job.Spec.TTLSecondsAfterFinished)
+	assert.Equal(t, int32(refreshJobTTLSeconds), *job.Spec.TTLSecondsAfterFinished)
+	require.Len(t, job.OwnerReferences, 1)
+	assert.Equal(t, "CronJob", job.OwnerReferences[0].Kind)
+	assert.Equal(t, existing.Name, job.OwnerReferences[0].Name)
+	assert.Equal(t, existing.UID, job.OwnerReferences[0].UID)
+}
+
+func TestCronRefreshCachedImageMissingSurfacesNotFound(t *testing.T) {
+	cs := fake.NewSimpleClientset()
+	mgr := NewCronJobImageCacheManager(cs, "vice-apps", "vice-image-pull-secret", testCronSchedule)
+
+	err := mgr.RefreshCachedImage(context.Background(), "harbor.cyverse.org/de/vice-proxy:latest")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no cache CronJob found")
+}
+
+func TestCronRefreshCachedImageInvalidRef(t *testing.T) {
+	cs := fake.NewSimpleClientset()
+	mgr := NewCronJobImageCacheManager(cs, "vice-apps", "vice-image-pull-secret", testCronSchedule)
+	assert.Error(t, mgr.RefreshCachedImage(context.Background(), "bad image!"))
+}
+
+func TestCronRemoveCachedImage(t *testing.T) {
+	const (
+		ns     = "vice-apps"
+		secret = "vice-image-pull-secret"
+		image  = "harbor.cyverse.org/de/vice-proxy:latest"
+	)
+
+	tests := []struct {
+		name     string
+		existing bool
+	}{
+		{name: "deletes existing CronJob", existing: true},
+		{name: "succeeds silently when missing", existing: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var cs *fake.Clientset
+			mgr := NewCronJobImageCacheManager(nil, ns, secret, testCronSchedule)
+			if tt.existing {
+				cj := mgr.buildCacheCronJob(image, slugifyImage(image))
+				cs = fake.NewSimpleClientset(cj)
+			} else {
+				cs = fake.NewSimpleClientset()
+			}
+			mgr = NewCronJobImageCacheManager(cs, ns, secret, testCronSchedule)
+
+			require.NoError(t, mgr.RemoveCachedImage(context.Background(), image))
+
+			list, err := cs.BatchV1().CronJobs(ns).List(context.Background(), metav1.ListOptions{})
+			require.NoError(t, err)
+			assert.Empty(t, list.Items)
+		})
+	}
+}
+
+func TestCronRemoveCachedImageByIDIdempotent(t *testing.T) {
+	cs := fake.NewSimpleClientset()
+	mgr := NewCronJobImageCacheManager(cs, "vice-apps", "vice-image-pull-secret", testCronSchedule)
+	require.NoError(t, mgr.RemoveCachedImageByID(context.Background(), "does-not-exist"))
+}
+
+func TestCronListCachedImages(t *testing.T) {
+	const (
+		ns     = "vice-apps"
+		secret = "vice-image-pull-secret"
+	)
+	mgr := NewCronJobImageCacheManager(nil, ns, secret, testCronSchedule)
+	image1 := "harbor.cyverse.org/de/vice-proxy:latest"
+	image2 := "harbor.cyverse.org/de/porklock:latest"
+	cj1 := mgr.buildCacheCronJob(image1, slugifyImage(image1))
+	cj2 := mgr.buildCacheCronJob(image2, slugifyImage(image2))
+
+	// Mark cj1 as successfully run; leave cj2 as never-run.
+	now := metav1.Now()
+	earlier := metav1.NewTime(now.Add(-time.Minute))
+	cj1.Status = batchv1.CronJobStatus{
+		LastScheduleTime:   &earlier,
+		LastSuccessfulTime: &now,
+	}
+
+	cs := fake.NewSimpleClientset(cj1, cj2)
+	mgr = NewCronJobImageCacheManager(cs, ns, secret, testCronSchedule)
+
+	images, err := mgr.ListCachedImages(context.Background())
+	require.NoError(t, err)
+	require.Len(t, images, 2)
+
+	byImage := map[string]ImageCacheStatus{}
+	for _, s := range images {
+		byImage[s.Image] = s
+	}
+
+	s1 := byImage[image1]
+	assert.Equal(t, "ready", s1.Status)
+	assert.Equal(t, int32(1), s1.Ready)
+	assert.Equal(t, int32(1), s1.Desired)
+
+	s2 := byImage[image2]
+	assert.Equal(t, "pulling", s2.Status)
+	assert.Equal(t, int32(0), s2.Ready)
+	assert.Equal(t, int32(1), s2.Desired)
+}
+
+func TestCronGetCachedImageStatus(t *testing.T) {
+	const (
+		ns     = "vice-apps"
+		secret = "vice-image-pull-secret"
+		image  = "harbor.cyverse.org/de/vice-proxy:latest"
+	)
+	mgr := NewCronJobImageCacheManager(nil, ns, secret, testCronSchedule)
+	slug := slugifyImage(image)
+	cj := mgr.buildCacheCronJob(image, slug)
+	now := metav1.Now()
+	cj.Status = batchv1.CronJobStatus{
+		LastScheduleTime:   &now,
+		LastSuccessfulTime: &now,
+	}
+
+	cs := fake.NewSimpleClientset(cj)
+	mgr = NewCronJobImageCacheManager(cs, ns, secret, testCronSchedule)
+
+	status, err := mgr.GetCachedImageStatus(context.Background(), slug)
+	require.NoError(t, err)
+	assert.Equal(t, image, status.Image)
+	assert.Equal(t, "ready", status.Status)
+
+	_, err = mgr.GetCachedImageStatus(context.Background(), "nonexistent")
+	assert.Error(t, err)
+}
+
+func TestDeriveCronJobCacheStatus(t *testing.T) {
+	now := metav1.Now()
+	earlier := metav1.NewTime(now.Add(-time.Minute))
+	later := metav1.NewTime(now.Add(time.Minute))
+
+	tests := []struct {
+		name        string
+		cj          *batchv1.CronJob
+		wantDesired int32
+		wantReady   int32
+		wantStatus  string
+	}{
+		{
+			name: "suspended → error",
+			cj: &batchv1.CronJob{
+				Spec: batchv1.CronJobSpec{Suspend: trueP()},
+			},
+			wantDesired: 0, wantReady: 0, wantStatus: "error",
+		},
+		{
+			name:        "never scheduled → pulling",
+			cj:          &batchv1.CronJob{},
+			wantDesired: 1, wantReady: 0, wantStatus: "pulling",
+		},
+		{
+			name: "last run succeeded → ready",
+			cj: &batchv1.CronJob{
+				Status: batchv1.CronJobStatus{
+					LastScheduleTime:   &earlier,
+					LastSuccessfulTime: &now,
+				},
+			},
+			wantDesired: 1, wantReady: 1, wantStatus: "ready",
+		},
+		{
+			name: "success at same time as schedule → ready",
+			cj: &batchv1.CronJob{
+				Status: batchv1.CronJobStatus{
+					LastScheduleTime:   &now,
+					LastSuccessfulTime: &now,
+				},
+			},
+			wantDesired: 1, wantReady: 1, wantStatus: "ready",
+		},
+		{
+			name: "scheduled after last success → cached-with-errors",
+			cj: &batchv1.CronJob{
+				Status: batchv1.CronJobStatus{
+					LastScheduleTime:   &later,
+					LastSuccessfulTime: &earlier,
+				},
+			},
+			wantDesired: 1, wantReady: 0, wantStatus: "cached-with-errors",
+		},
+		{
+			name: "scheduled but never succeeded → cached-with-errors",
+			cj: &batchv1.CronJob{
+				Status: batchv1.CronJobStatus{
+					LastScheduleTime: &earlier,
+				},
+			},
+			wantDesired: 1, wantReady: 0, wantStatus: "cached-with-errors",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d, r, s := deriveCronJobCacheStatus(tt.cj)
+			assert.Equal(t, tt.wantDesired, d)
+			assert.Equal(t, tt.wantReady, r)
+			assert.Equal(t, tt.wantStatus, s)
+		})
+	}
+}
+
+func TestRefreshJobGeneratePrefixTruncation(t *testing.T) {
+	// Construct a slug that, with cacheNamePrefix and "-r-", exceeds
+	// the K8s name limit minus 5. The truncated prefix must stay
+	// within bounds so the random suffix appended by the API server
+	// won't push the name over 253 chars.
+	long := strings.Repeat("a", 300)
+	prefix := refreshJobGeneratePrefix(long)
+	assert.LessOrEqual(t, len(prefix), k8sMaxNameLen-5)
+}
+
+// trueP returns a pointer to true, used for Suspend field tests.
+func trueP() *bool { v := true; return &v }

--- a/operator/imagecache_daemonset.go
+++ b/operator/imagecache_daemonset.go
@@ -1,0 +1,285 @@
+package operator
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	apiv1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/kubernetes"
+)
+
+// DaemonSetImageCacheManager manages image cache DaemonSets in a namespace.
+// One DaemonSet per cached image; the init-container pull populates the local
+// containerd store on every matching node.
+type DaemonSetImageCacheManager struct {
+	clientset           kubernetes.Interface
+	namespace           string
+	imagePullSecretName string
+}
+
+// NewDaemonSetImageCacheManager creates a manager that controls image cache
+// DaemonSets within the given namespace. If imagePullSecretName is empty,
+// cache DaemonSets will not reference an image pull secret (suitable for
+// public images only).
+func NewDaemonSetImageCacheManager(clientset kubernetes.Interface, namespace, imagePullSecretName string) *DaemonSetImageCacheManager {
+	return &DaemonSetImageCacheManager{
+		clientset:           clientset,
+		namespace:           namespace,
+		imagePullSecretName: imagePullSecretName,
+	}
+}
+
+// imagePullSecrets returns the image pull secrets list for cache DaemonSets.
+// Returns nil when no secret name is configured, which omits the field from
+// the pod spec entirely (allowing public images to be cached without credentials).
+func (m *DaemonSetImageCacheManager) imagePullSecrets() []apiv1.LocalObjectReference {
+	if m.imagePullSecretName == "" {
+		return nil
+	}
+	return []apiv1.LocalObjectReference{{Name: m.imagePullSecretName}}
+}
+
+// buildCacheDaemonSet constructs a DaemonSet that pre-pulls the given image
+// onto every node. The init container references the target image and runs
+// "true" to exit immediately; K8s pulls the image before running the command.
+//
+// For distroless or scratch-based images that lack "true", the init container
+// will fail with CrashLoopBackOff. This is expected — the image is still pulled
+// and cached on each node. The status API reports these as "cached-with-errors".
+func (m *DaemonSetImageCacheManager) buildCacheDaemonSet(image, slug string) *appsv1.DaemonSet {
+	// dsLabels is named to avoid shadowing the imported "k8s.io/apimachinery/pkg/labels" package.
+	dsLabels := map[string]string{
+		labelManagedBy:    valueManagedBy,
+		labelPurpose:      valuePurpose,
+		labelImageCacheID: slug,
+	}
+
+	// The init container needs enough memory to start the entrypoint process
+	// (even just "true") without being OOM-killed. The pause container is a
+	// tiny static binary and can run with minimal resources.
+	initResources := apiv1.ResourceRequirements{
+		Requests: apiv1.ResourceList{
+			apiv1.ResourceCPU:    resource.MustParse("1m"),
+			apiv1.ResourceMemory: resource.MustParse("64Mi"),
+		},
+		Limits: apiv1.ResourceList{
+			apiv1.ResourceCPU:    resource.MustParse("10m"),
+			apiv1.ResourceMemory: resource.MustParse("64Mi"),
+		},
+	}
+	pauseResources := apiv1.ResourceRequirements{
+		Requests: apiv1.ResourceList{
+			apiv1.ResourceCPU:    resource.MustParse("1m"),
+			apiv1.ResourceMemory: resource.MustParse("16Mi"),
+		},
+		Limits: apiv1.ResourceList{
+			apiv1.ResourceCPU:    resource.MustParse("1m"),
+			apiv1.ResourceMemory: resource.MustParse("16Mi"),
+		},
+	}
+
+	return &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cacheNamePrefix + slug,
+			Namespace: m.namespace,
+			Labels:    dsLabels,
+			Annotations: map[string]string{
+				annotationImage: image,
+			},
+		},
+		Spec: appsv1.DaemonSetSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: dsLabels,
+			},
+			Template: apiv1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: dsLabels,
+				},
+				Spec: apiv1.PodSpec{
+					ImagePullSecrets: m.imagePullSecrets(),
+					InitContainers: []apiv1.Container{
+						{
+							Name:            "pull",
+							Image:           image,
+							Command:         []string{"true"},
+							ImagePullPolicy: apiv1.PullAlways,
+							Resources:       initResources,
+						},
+					},
+					Containers: []apiv1.Container{
+						{
+							Name:            "pause",
+							Image:           pauseImage,
+							ImagePullPolicy: apiv1.PullIfNotPresent,
+							Resources:       pauseResources,
+						},
+					},
+					Tolerations: []apiv1.Toleration{
+						{
+							Key:      "analysis",
+							Operator: apiv1.TolerationOpExists,
+						},
+						{
+							Key:      "gpu",
+							Operator: apiv1.TolerationOpEqual,
+							Value:    "true",
+							Effect:   apiv1.TaintEffectNoSchedule,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// EnsureImageCached creates or updates a cache DaemonSet for the given image.
+// If a DaemonSet already exists with the correct image annotation, this is a
+// no-op.
+func (m *DaemonSetImageCacheManager) EnsureImageCached(ctx context.Context, image string) error {
+	if err := validateImageRef(image); err != nil {
+		return err
+	}
+
+	slug := slugifyImage(image)
+	dsName := cacheNamePrefix + slug
+	client := m.clientset.AppsV1().DaemonSets(m.namespace)
+
+	existing, err := client.Get(ctx, dsName, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		log.Infof("creating image cache DaemonSet %s for %s", dsName, image)
+		ds := m.buildCacheDaemonSet(image, slug)
+		_, err = client.Create(ctx, ds, metav1.CreateOptions{})
+		if err != nil {
+			return fmt.Errorf("creating image cache DaemonSet %s: %w", dsName, err)
+		}
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("checking for existing image cache DaemonSet %s: %w", dsName, err)
+	}
+
+	// DaemonSet exists — check if the image annotation matches.
+	if existing.Annotations[annotationImage] == image {
+		log.Debugf("image cache DaemonSet %s already has correct image", dsName)
+		return nil
+	}
+
+	log.Infof("updating image cache DaemonSet %s from %q to %q", dsName, existing.Annotations[annotationImage], image)
+	ds := m.buildCacheDaemonSet(image, slug)
+	ds.ResourceVersion = existing.ResourceVersion
+	_, err = client.Update(ctx, ds, metav1.UpdateOptions{})
+	if err != nil {
+		return fmt.Errorf("updating image cache DaemonSet %s: %w", dsName, err)
+	}
+	return nil
+}
+
+// RefreshCachedImage forces the cache DaemonSet for the given image to re-pull
+// by updating a restart annotation on the pod template, which triggers a rolling
+// update. The init container's PullAlways policy causes containerd to fetch the
+// latest manifest. This is needed when a new image is pushed under the same tag.
+func (m *DaemonSetImageCacheManager) RefreshCachedImage(ctx context.Context, image string) error {
+	if err := validateImageRef(image); err != nil {
+		return err
+	}
+
+	slug := slugifyImage(image)
+	dsName := cacheNamePrefix + slug
+	client := m.clientset.AppsV1().DaemonSets(m.namespace)
+
+	ds, err := client.Get(ctx, dsName, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		return fmt.Errorf("no cache DaemonSet found for image %q", image)
+	}
+	if err != nil {
+		return fmt.Errorf("getting cache DaemonSet %s: %w", dsName, err)
+	}
+
+	// Restart the DaemonSet by adding/updating a restart annotation on the
+	// pod template. This triggers a rolling update of all pods, which forces
+	// containerd to re-pull the image due to PullAlways on the init container.
+	if ds.Spec.Template.Annotations == nil {
+		ds.Spec.Template.Annotations = make(map[string]string)
+	}
+	ds.Spec.Template.Annotations["de.cyverse.org/restartedAt"] = metav1.Now().UTC().Format(time.RFC3339)
+
+	if _, err := client.Update(ctx, ds, metav1.UpdateOptions{}); err != nil {
+		return fmt.Errorf("restarting cache DaemonSet %s: %w", dsName, err)
+	}
+
+	log.Infof("refreshed image cache DaemonSet %s for %s", dsName, image)
+	return nil
+}
+
+// RemoveCachedImage deletes the cache DaemonSet for the given image.
+// Returns nil if the DaemonSet doesn't exist (idempotent).
+func (m *DaemonSetImageCacheManager) RemoveCachedImage(ctx context.Context, image string) error {
+	if err := validateImageRef(image); err != nil {
+		return err
+	}
+	return m.RemoveCachedImageByID(ctx, slugifyImage(image))
+}
+
+// RemoveCachedImageByID deletes the cache DaemonSet with the given slug ID.
+// Returns nil if the DaemonSet doesn't exist (idempotent).
+func (m *DaemonSetImageCacheManager) RemoveCachedImageByID(ctx context.Context, id string) error {
+	dsName := cacheNamePrefix + id
+	err := m.clientset.AppsV1().DaemonSets(m.namespace).Delete(ctx, dsName, metav1.DeleteOptions{})
+	if apierrors.IsNotFound(err) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("deleting image cache DaemonSet %s: %w", dsName, err)
+	}
+	log.Infof("deleted image cache DaemonSet %s", dsName)
+	return nil
+}
+
+// cacheStatusFromDS builds an ImageCacheStatus from a DaemonSet.
+func cacheStatusFromDS(ds *appsv1.DaemonSet) ImageCacheStatus {
+	return ImageCacheStatus{
+		Image:   ds.Annotations[annotationImage],
+		ID:      ds.Labels[labelImageCacheID],
+		Ready:   ds.Status.NumberReady,
+		Desired: ds.Status.DesiredNumberScheduled,
+		Status:  deriveCacheStatus(ds.Status.DesiredNumberScheduled, ds.Status.NumberReady),
+	}
+}
+
+// ListCachedImages returns the status of all image cache DaemonSets in the
+// namespace.
+func (m *DaemonSetImageCacheManager) ListCachedImages(ctx context.Context) ([]ImageCacheStatus, error) {
+	sel := labels.SelectorFromSet(labels.Set{
+		labelManagedBy: valueManagedBy,
+		labelPurpose:   valuePurpose,
+	})
+
+	list, err := m.clientset.AppsV1().DaemonSets(m.namespace).List(ctx, metav1.ListOptions{LabelSelector: sel.String()})
+	if err != nil {
+		return nil, fmt.Errorf("listing image cache DaemonSets: %w", err)
+	}
+
+	result := make([]ImageCacheStatus, 0, len(list.Items))
+	for i := range list.Items {
+		result = append(result, cacheStatusFromDS(&list.Items[i]))
+	}
+	return result, nil
+}
+
+// GetCachedImageStatus returns the status of a single cached image by its slug
+// ID. Returns an error if the DaemonSet is not found.
+func (m *DaemonSetImageCacheManager) GetCachedImageStatus(ctx context.Context, id string) (*ImageCacheStatus, error) {
+	dsName := cacheNamePrefix + id
+	ds, err := m.clientset.AppsV1().DaemonSets(m.namespace).Get(ctx, dsName, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("getting image cache DaemonSet %s: %w", dsName, err)
+	}
+	status := cacheStatusFromDS(ds)
+	return &status, nil
+}

--- a/operator/imagecache_daemonset.go
+++ b/operator/imagecache_daemonset.go
@@ -10,7 +10,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes"
 )
 
@@ -35,16 +34,6 @@ func NewDaemonSetImageCacheManager(clientset kubernetes.Interface, namespace, im
 	}
 }
 
-// imagePullSecrets returns the image pull secrets list for cache DaemonSets.
-// Returns nil when no secret name is configured, which omits the field from
-// the pod spec entirely (allowing public images to be cached without credentials).
-func (m *DaemonSetImageCacheManager) imagePullSecrets() []apiv1.LocalObjectReference {
-	if m.imagePullSecretName == "" {
-		return nil
-	}
-	return []apiv1.LocalObjectReference{{Name: m.imagePullSecretName}}
-}
-
 // buildCacheDaemonSet constructs a DaemonSet that pre-pulls the given image
 // onto every node. The init container references the target image and runs
 // "true" to exit immediately; K8s pulls the image before running the command.
@@ -53,12 +42,7 @@ func (m *DaemonSetImageCacheManager) imagePullSecrets() []apiv1.LocalObjectRefer
 // will fail with CrashLoopBackOff. This is expected — the image is still pulled
 // and cached on each node. The status API reports these as "cached-with-errors".
 func (m *DaemonSetImageCacheManager) buildCacheDaemonSet(image, slug string) *appsv1.DaemonSet {
-	// dsLabels is named to avoid shadowing the imported "k8s.io/apimachinery/pkg/labels" package.
-	dsLabels := map[string]string{
-		labelManagedBy:    valueManagedBy,
-		labelPurpose:      valuePurpose,
-		labelImageCacheID: slug,
-	}
+	dsLabels := cacheResourceLabels(slug)
 
 	// The init container needs enough memory to start the entrypoint process
 	// (even just "true") without being OOM-killed. The pause container is a
@@ -102,7 +86,7 @@ func (m *DaemonSetImageCacheManager) buildCacheDaemonSet(image, slug string) *ap
 					Labels: dsLabels,
 				},
 				Spec: apiv1.PodSpec{
-					ImagePullSecrets: m.imagePullSecrets(),
+					ImagePullSecrets: imagePullSecretsFor(m.imagePullSecretName),
 					InitContainers: []apiv1.Container{
 						{
 							Name:            "pull",
@@ -120,18 +104,7 @@ func (m *DaemonSetImageCacheManager) buildCacheDaemonSet(image, slug string) *ap
 							Resources:       pauseResources,
 						},
 					},
-					Tolerations: []apiv1.Toleration{
-						{
-							Key:      "analysis",
-							Operator: apiv1.TolerationOpExists,
-						},
-						{
-							Key:      "gpu",
-							Operator: apiv1.TolerationOpEqual,
-							Value:    "true",
-							Effect:   apiv1.TaintEffectNoSchedule,
-						},
-					},
+					Tolerations: cachePodTolerations(),
 				},
 			},
 		},
@@ -164,7 +137,6 @@ func (m *DaemonSetImageCacheManager) EnsureImageCached(ctx context.Context, imag
 		return fmt.Errorf("checking for existing image cache DaemonSet %s: %w", dsName, err)
 	}
 
-	// DaemonSet exists — check if the image annotation matches.
 	if existing.Annotations[annotationImage] == image {
 		log.Debugf("image cache DaemonSet %s already has correct image", dsName)
 		return nil
@@ -201,9 +173,6 @@ func (m *DaemonSetImageCacheManager) RefreshCachedImage(ctx context.Context, ima
 		return fmt.Errorf("getting cache DaemonSet %s: %w", dsName, err)
 	}
 
-	// Restart the DaemonSet by adding/updating a restart annotation on the
-	// pod template. This triggers a rolling update of all pods, which forces
-	// containerd to re-pull the image due to PullAlways on the init container.
 	if ds.Spec.Template.Annotations == nil {
 		ds.Spec.Template.Annotations = make(map[string]string)
 	}
@@ -255,12 +224,7 @@ func cacheStatusFromDS(ds *appsv1.DaemonSet) ImageCacheStatus {
 // ListCachedImages returns the status of all image cache DaemonSets in the
 // namespace.
 func (m *DaemonSetImageCacheManager) ListCachedImages(ctx context.Context) ([]ImageCacheStatus, error) {
-	sel := labels.SelectorFromSet(labels.Set{
-		labelManagedBy: valueManagedBy,
-		labelPurpose:   valuePurpose,
-	})
-
-	list, err := m.clientset.AppsV1().DaemonSets(m.namespace).List(ctx, metav1.ListOptions{LabelSelector: sel.String()})
+	list, err := m.clientset.AppsV1().DaemonSets(m.namespace).List(ctx, metav1.ListOptions{LabelSelector: cacheManagedBySelector().String()})
 	if err != nil {
 		return nil, fmt.Errorf("listing image cache DaemonSets: %w", err)
 	}

--- a/operator/imagecache_daemonset.go
+++ b/operator/imagecache_daemonset.go
@@ -34,6 +34,10 @@ func NewDaemonSetImageCacheManager(clientset kubernetes.Interface, namespace, im
 	}
 }
 
+// ReadOnly is false: the daemonset backend manages cache state via real
+// K8s resources and supports the full mutating API.
+func (*DaemonSetImageCacheManager) ReadOnly() bool { return false }
+
 // buildCacheDaemonSet constructs a DaemonSet that pre-pulls the given image
 // onto every node. The init container references the target image and runs
 // "true" to exit immediately; K8s pulls the image before running the command.

--- a/operator/imagecache_daemonset_test.go
+++ b/operator/imagecache_daemonset_test.go
@@ -1,0 +1,317 @@
+package operator
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	apiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	clienttesting "k8s.io/client-go/testing"
+)
+
+func TestBuildCacheDaemonSet(t *testing.T) {
+	mgr := NewDaemonSetImageCacheManager(nil, "vice-apps", "vice-image-pull-secret")
+	image := "harbor.cyverse.org/de/vice-proxy:latest"
+	slug := slugifyImage(image)
+
+	ds := mgr.buildCacheDaemonSet(image, slug)
+
+	// Metadata.
+	assert.Equal(t, cacheNamePrefix+slug, ds.Name)
+	assert.Equal(t, "vice-apps", ds.Namespace)
+	assert.Equal(t, valueManagedBy, ds.Labels[labelManagedBy])
+	assert.Equal(t, valuePurpose, ds.Labels[labelPurpose])
+	assert.Equal(t, slug, ds.Labels[labelImageCacheID])
+	assert.Equal(t, image, ds.Annotations[annotationImage])
+
+	// Selector must match pod template labels.
+	assert.Equal(t, ds.Spec.Selector.MatchLabels, ds.Spec.Template.Labels)
+
+	// Init container pulls the target image.
+	require.Len(t, ds.Spec.Template.Spec.InitContainers, 1)
+	pullContainer := ds.Spec.Template.Spec.InitContainers[0]
+	assert.Equal(t, image, pullContainer.Image)
+	assert.Equal(t, []string{"true"}, pullContainer.Command)
+	assert.Equal(t, apiv1.PullAlways, pullContainer.ImagePullPolicy)
+
+	// Main container is pause.
+	require.Len(t, ds.Spec.Template.Spec.Containers, 1)
+	pauseContainer := ds.Spec.Template.Spec.Containers[0]
+	assert.Equal(t, pauseImage, pauseContainer.Image)
+	assert.Equal(t, apiv1.PullIfNotPresent, pauseContainer.ImagePullPolicy)
+
+	// Image pull secret.
+	require.Len(t, ds.Spec.Template.Spec.ImagePullSecrets, 1)
+	assert.Equal(t, "vice-image-pull-secret", ds.Spec.Template.Spec.ImagePullSecrets[0].Name)
+
+	// Tolerations.
+	assert.Len(t, ds.Spec.Template.Spec.Tolerations, 2)
+}
+
+func TestEnsureImageCached(t *testing.T) {
+	const (
+		ns     = "vice-apps"
+		secret = "vice-image-pull-secret"
+		image  = "harbor.cyverse.org/de/vice-proxy:latest"
+	)
+	slug := slugifyImage(image)
+	dsName := cacheNamePrefix + slug
+
+	tests := []struct {
+		name     string
+		existing *appsv1.DaemonSet // nil = no pre-existing DS
+	}{
+		{
+			name:     "creates DaemonSet when missing",
+			existing: nil,
+		},
+		{
+			name:     "no-op when image matches",
+			existing: NewDaemonSetImageCacheManager(nil, ns, secret).buildCacheDaemonSet(image, slug),
+		},
+		{
+			name: "updates when annotation differs",
+			existing: func() *appsv1.DaemonSet {
+				ds := NewDaemonSetImageCacheManager(nil, ns, secret).buildCacheDaemonSet("old-image:v1", slug)
+				ds.Name = dsName
+				ds.Annotations[annotationImage] = "old-image:v1"
+				return ds
+			}(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var cs *fake.Clientset
+			if tt.existing != nil {
+				cs = fake.NewSimpleClientset(tt.existing)
+			} else {
+				cs = fake.NewSimpleClientset()
+			}
+
+			mgr := NewDaemonSetImageCacheManager(cs, ns, secret)
+			err := mgr.EnsureImageCached(context.Background(), image)
+			require.NoError(t, err)
+
+			// Verify DaemonSet exists with correct annotation.
+			ds, err := cs.AppsV1().DaemonSets(ns).Get(context.Background(), dsName, metav1.GetOptions{})
+			require.NoError(t, err)
+			assert.Equal(t, image, ds.Annotations[annotationImage])
+		})
+	}
+}
+
+func TestEnsureImageCachedInvalidRef(t *testing.T) {
+	cs := fake.NewSimpleClientset()
+	mgr := NewDaemonSetImageCacheManager(cs, "vice-apps", "vice-image-pull-secret")
+
+	err := mgr.EnsureImageCached(context.Background(), "")
+	assert.Error(t, err, "empty image should be rejected")
+
+	err = mgr.EnsureImageCached(context.Background(), "bad image!")
+	assert.Error(t, err, "invalid image should be rejected")
+}
+
+func TestRemoveCachedImageByID(t *testing.T) {
+	const (
+		ns     = "vice-apps"
+		secret = "vice-image-pull-secret"
+		image  = "harbor.cyverse.org/de/vice-proxy:latest"
+	)
+
+	// Create a DaemonSet, then remove by ID.
+	mgr := NewDaemonSetImageCacheManager(nil, ns, secret)
+	slug := slugifyImage(image)
+	ds := mgr.buildCacheDaemonSet(image, slug)
+	cs := fake.NewSimpleClientset(ds)
+	mgr = NewDaemonSetImageCacheManager(cs, ns, secret)
+
+	err := mgr.RemoveCachedImageByID(context.Background(), slug)
+	require.NoError(t, err)
+
+	list, err := cs.AppsV1().DaemonSets(ns).List(context.Background(), metav1.ListOptions{})
+	require.NoError(t, err)
+	assert.Empty(t, list.Items)
+
+	// Removing again should succeed (idempotent).
+	err = mgr.RemoveCachedImageByID(context.Background(), slug)
+	require.NoError(t, err)
+}
+
+func TestRemoveCachedImage(t *testing.T) {
+	const (
+		ns     = "vice-apps"
+		secret = "vice-image-pull-secret"
+		image  = "harbor.cyverse.org/de/vice-proxy:latest"
+	)
+
+	tests := []struct {
+		name     string
+		existing bool
+	}{
+		{name: "deletes existing DaemonSet", existing: true},
+		{name: "succeeds silently when missing", existing: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var cs *fake.Clientset
+			mgr := NewDaemonSetImageCacheManager(nil, ns, secret)
+			if tt.existing {
+				slug := slugifyImage(image)
+				ds := mgr.buildCacheDaemonSet(image, slug)
+				cs = fake.NewSimpleClientset(ds)
+			} else {
+				cs = fake.NewSimpleClientset()
+			}
+			mgr = NewDaemonSetImageCacheManager(cs, ns, secret)
+
+			err := mgr.RemoveCachedImage(context.Background(), image)
+			require.NoError(t, err)
+
+			// Verify DaemonSet is gone.
+			list, err := cs.AppsV1().DaemonSets(ns).List(context.Background(), metav1.ListOptions{})
+			require.NoError(t, err)
+			assert.Empty(t, list.Items)
+		})
+	}
+}
+
+// TestRefreshCachedImage exercises all four paths:
+//  1. Invalid image ref → validation error, no API calls.
+//  2. Missing DaemonSet → wrapped NotFound error.
+//  3. Update failure → wrapped error from client.Update.
+//  4. Happy path → the pod template carries a fresh restartedAt annotation.
+func TestRefreshCachedImage(t *testing.T) {
+	const (
+		ns     = "vice-apps"
+		secret = "vice-image-pull-secret"
+		image  = "harbor.cyverse.org/de/vice-proxy:latest"
+	)
+	slug := slugifyImage(image)
+	dsName := cacheNamePrefix + slug
+
+	t.Run("invalid image ref rejected", func(t *testing.T) {
+		cs := fake.NewSimpleClientset()
+		mgr := NewDaemonSetImageCacheManager(cs, ns, secret)
+
+		err := mgr.RefreshCachedImage(context.Background(), "bad image!")
+		require.Error(t, err)
+	})
+
+	t.Run("missing DaemonSet surfaces not-found", func(t *testing.T) {
+		cs := fake.NewSimpleClientset()
+		mgr := NewDaemonSetImageCacheManager(cs, ns, secret)
+
+		err := mgr.RefreshCachedImage(context.Background(), image)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no cache DaemonSet found")
+	})
+
+	t.Run("update failure is wrapped with DS name", func(t *testing.T) {
+		mgr := NewDaemonSetImageCacheManager(nil, ns, secret)
+		existing := mgr.buildCacheDaemonSet(image, slug)
+		cs := fake.NewSimpleClientset(existing)
+		mgr = NewDaemonSetImageCacheManager(cs, ns, secret)
+
+		// Inject an Update failure via the fake clientset's reactor chain.
+		cs.PrependReactor("update", "daemonsets", func(action clienttesting.Action) (bool, runtime.Object, error) {
+			return true, nil, errors.New("injected update failure")
+		})
+
+		err := mgr.RefreshCachedImage(context.Background(), image)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "restarting cache DaemonSet")
+		assert.Contains(t, err.Error(), dsName)
+	})
+
+	t.Run("happy path stamps restartedAt annotation", func(t *testing.T) {
+		mgr := NewDaemonSetImageCacheManager(nil, ns, secret)
+		existing := mgr.buildCacheDaemonSet(image, slug)
+		// Clear any pre-existing template annotations so we can assert
+		// the restartedAt key is created fresh rather than overwritten.
+		existing.Spec.Template.Annotations = nil
+
+		cs := fake.NewSimpleClientset(existing)
+		mgr = NewDaemonSetImageCacheManager(cs, ns, secret)
+
+		err := mgr.RefreshCachedImage(context.Background(), image)
+		require.NoError(t, err)
+
+		updated, err := cs.AppsV1().DaemonSets(ns).Get(context.Background(), dsName, metav1.GetOptions{})
+		require.NoError(t, err)
+		require.NotNil(t, updated.Spec.Template.Annotations)
+		assert.NotEmpty(t, updated.Spec.Template.Annotations["de.cyverse.org/restartedAt"])
+	})
+}
+
+func TestListCachedImages(t *testing.T) {
+	const (
+		ns     = "vice-apps"
+		secret = "vice-image-pull-secret"
+	)
+
+	mgr := NewDaemonSetImageCacheManager(nil, ns, secret)
+	image1 := "harbor.cyverse.org/de/vice-proxy:latest"
+	image2 := "harbor.cyverse.org/de/porklock:latest"
+	slug1 := slugifyImage(image1)
+	slug2 := slugifyImage(image2)
+	ds1 := mgr.buildCacheDaemonSet(image1, slug1)
+	ds2 := mgr.buildCacheDaemonSet(image2, slug2)
+
+	// Simulate status fields.
+	ds1.Status = appsv1.DaemonSetStatus{DesiredNumberScheduled: 3, NumberReady: 3}
+	ds2.Status = appsv1.DaemonSetStatus{DesiredNumberScheduled: 3, NumberReady: 1, NumberUnavailable: 2}
+
+	cs := fake.NewSimpleClientset(ds1, ds2)
+	mgr = NewDaemonSetImageCacheManager(cs, ns, secret)
+
+	images, err := mgr.ListCachedImages(context.Background())
+	require.NoError(t, err)
+	assert.Len(t, images, 2)
+
+	// Find each image in the results.
+	statusByImage := make(map[string]ImageCacheStatus)
+	for _, s := range images {
+		statusByImage[s.Image] = s
+	}
+
+	s1 := statusByImage[image1]
+	assert.Equal(t, "ready", s1.Status)
+	assert.Equal(t, int32(3), s1.Ready)
+
+	s2 := statusByImage[image2]
+	assert.Equal(t, "pulling", s2.Status)
+	assert.Equal(t, int32(1), s2.Ready)
+}
+
+func TestGetCachedImageStatus(t *testing.T) {
+	const (
+		ns     = "vice-apps"
+		secret = "vice-image-pull-secret"
+		image  = "harbor.cyverse.org/de/vice-proxy:latest"
+	)
+
+	mgr := NewDaemonSetImageCacheManager(nil, ns, secret)
+	slug := slugifyImage(image)
+	ds := mgr.buildCacheDaemonSet(image, slug)
+	ds.Status = appsv1.DaemonSetStatus{DesiredNumberScheduled: 3, NumberReady: 3}
+
+	cs := fake.NewSimpleClientset(ds)
+	mgr = NewDaemonSetImageCacheManager(cs, ns, secret)
+
+	status, err := mgr.GetCachedImageStatus(context.Background(), slug)
+	require.NoError(t, err)
+	assert.Equal(t, image, status.Image)
+	assert.Equal(t, "ready", status.Status)
+
+	// Non-existent slug returns error.
+	_, err = mgr.GetCachedImageStatus(context.Background(), "nonexistent")
+	assert.Error(t, err)
+}

--- a/operator/imagecache_daemonset_test.go
+++ b/operator/imagecache_daemonset_test.go
@@ -54,6 +54,12 @@ func TestBuildCacheDaemonSet(t *testing.T) {
 	assert.Len(t, ds.Spec.Template.Spec.Tolerations, 2)
 }
 
+func TestBuildCacheDaemonSetOmitsPullSecretWhenEmpty(t *testing.T) {
+	mgr := NewDaemonSetImageCacheManager(nil, "vice-apps", "")
+	ds := mgr.buildCacheDaemonSet("nginx:1.27", slugifyImage("nginx:1.27"))
+	assert.Empty(t, ds.Spec.Template.Spec.ImagePullSecrets)
+}
+
 func TestEnsureImageCached(t *testing.T) {
 	const (
 		ns     = "vice-apps"

--- a/operator/imagecache_handlers.go
+++ b/operator/imagecache_handlers.go
@@ -23,6 +23,11 @@ import (
 // because it forces every caller to parse the body just to know whether
 // anything went wrong.
 func (o *Operator) bulkImageOp(c echo.Context, fn func(ctx context.Context, image string) error) error {
+	if o.imageCache.ReadOnly() {
+		return c.JSON(http.StatusBadRequest, common.ErrorResponse{
+			Message: "image cache is externally managed in this mode; update the --repos-file and restart instead",
+		})
+	}
 	ctx := c.Request().Context()
 
 	var req ImageCacheRequest
@@ -156,11 +161,14 @@ func (o *Operator) HandleGetCachedImage(c echo.Context) error {
 
 	status, err := o.imageCache.GetCachedImageStatus(ctx, id)
 	if err != nil {
-		// GetCachedImageStatus wraps the K8s error with fmt.Errorf(%w), so
-		// unwrap explicitly with errors.As before comparing the reason. This
-		// matches the pattern used in gateway.go for CORS middleware lookups.
+		// Two paths to a not-found: a wrapped K8s StatusError from the
+		// daemonset/cron backends, or the manual-mirror sentinel for a
+		// slug that doesn't match any mapping entry.
 		var statusErr *apierrors.StatusError
 		if errors.As(err, &statusErr) && statusErr.ErrStatus.Reason == metav1.StatusReasonNotFound {
+			return c.JSON(http.StatusNotFound, common.ErrorResponse{Message: fmt.Sprintf("no cached image with id %q", id)})
+		}
+		if errors.Is(err, errImageCacheEntryNotFound) {
 			return c.JSON(http.StatusNotFound, common.ErrorResponse{Message: fmt.Sprintf("no cached image with id %q", id)})
 		}
 		return c.JSON(http.StatusInternalServerError, common.ErrorResponse{Message: err.Error()})
@@ -181,6 +189,11 @@ func (o *Operator) HandleGetCachedImage(c echo.Context) error {
 //	@Failure		500	{object}	common.ErrorResponse
 //	@Router			/image-cache/{id} [delete]
 func (o *Operator) HandleDeleteCachedImage(c echo.Context) error {
+	if o.imageCache.ReadOnly() {
+		return c.JSON(http.StatusBadRequest, common.ErrorResponse{
+			Message: "image cache is externally managed in this mode; update the --repos-file and restart instead",
+		})
+	}
 	ctx := c.Request().Context()
 	id := c.Param("id")
 	if err := validateImageCacheID(id); err != nil {

--- a/operator/imagecache_handlers.go
+++ b/operator/imagecache_handlers.go
@@ -12,6 +12,17 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// readOnlyResponse writes and returns a 400 when the cache is read-only;
+// returns nil otherwise so callers can use "if err := o.readOnlyResponse(c); err != nil { return err }".
+func (o *Operator) readOnlyResponse(c echo.Context) error {
+	if !o.imageCache.ReadOnly() {
+		return nil
+	}
+	return c.JSON(http.StatusBadRequest, common.ErrorResponse{
+		Message: "image cache is externally managed in this mode; update the --repos-file and restart instead",
+	})
+}
+
 // bulkImageOp binds the request, validates it, applies fn to each image,
 // and returns a 200 (all ok) or 207 Multi-Status (partial failure).
 //
@@ -23,10 +34,8 @@ import (
 // because it forces every caller to parse the body just to know whether
 // anything went wrong.
 func (o *Operator) bulkImageOp(c echo.Context, fn func(ctx context.Context, image string) error) error {
-	if o.imageCache.ReadOnly() {
-		return c.JSON(http.StatusBadRequest, common.ErrorResponse{
-			Message: "image cache is externally managed in this mode; update the --repos-file and restart instead",
-		})
+	if err := o.readOnlyResponse(c); err != nil {
+		return err
 	}
 	ctx := c.Request().Context()
 
@@ -137,6 +146,17 @@ func (o *Operator) HandleListCachedImages(c echo.Context) error {
 	return c.JSON(http.StatusOK, ImageCacheListResponse{Images: images})
 }
 
+// isCacheEntryNotFound reports whether err represents a "not found" outcome
+// from any cache backend: a K8s StatusError with reason NotFound (daemonset /
+// cron backends) or the manual-mirror sentinel errImageCacheEntryNotFound.
+func isCacheEntryNotFound(err error) bool {
+	var statusErr *apierrors.StatusError
+	if errors.As(err, &statusErr) && statusErr.ErrStatus.Reason == metav1.StatusReasonNotFound {
+		return true
+	}
+	return errors.Is(err, errImageCacheEntryNotFound)
+}
+
 // HandleGetCachedImage returns the status of a single cached image.
 //
 //	@Summary		Get cached image status
@@ -161,14 +181,9 @@ func (o *Operator) HandleGetCachedImage(c echo.Context) error {
 
 	status, err := o.imageCache.GetCachedImageStatus(ctx, id)
 	if err != nil {
-		// Two paths to a not-found: a wrapped K8s StatusError from the
-		// daemonset/cron backends, or the manual-mirror sentinel for a
-		// slug that doesn't match any mapping entry.
-		var statusErr *apierrors.StatusError
-		if errors.As(err, &statusErr) && statusErr.ErrStatus.Reason == metav1.StatusReasonNotFound {
-			return c.JSON(http.StatusNotFound, common.ErrorResponse{Message: fmt.Sprintf("no cached image with id %q", id)})
-		}
-		if errors.Is(err, errImageCacheEntryNotFound) {
+		if isCacheEntryNotFound(err) {
+			// Two paths to a not-found: a wrapped K8s StatusError from the
+			// daemonset/cron backends, or the manual-mirror sentinel.
 			return c.JSON(http.StatusNotFound, common.ErrorResponse{Message: fmt.Sprintf("no cached image with id %q", id)})
 		}
 		return c.JSON(http.StatusInternalServerError, common.ErrorResponse{Message: err.Error()})
@@ -189,10 +204,8 @@ func (o *Operator) HandleGetCachedImage(c echo.Context) error {
 //	@Failure		500	{object}	common.ErrorResponse
 //	@Router			/image-cache/{id} [delete]
 func (o *Operator) HandleDeleteCachedImage(c echo.Context) error {
-	if o.imageCache.ReadOnly() {
-		return c.JSON(http.StatusBadRequest, common.ErrorResponse{
-			Message: "image cache is externally managed in this mode; update the --repos-file and restart instead",
-		})
+	if err := o.readOnlyResponse(c); err != nil {
+		return err
 	}
 	ctx := c.Request().Context()
 	id := c.Param("id")

--- a/operator/imagecache_handlers.go
+++ b/operator/imagecache_handlers.go
@@ -148,8 +148,10 @@ func (o *Operator) HandleListCachedImages(c echo.Context) error {
 func (o *Operator) HandleGetCachedImage(c echo.Context) error {
 	ctx := c.Request().Context()
 	id := c.Param("id")
-	if id == "" {
-		return c.JSON(http.StatusBadRequest, common.ErrorResponse{Message: "image cache id is required"})
+	if err := validateImageCacheID(id); err != nil {
+		// Treat malformed IDs as not-found so we don't echo K8s API errors
+		// back through the response body.
+		return c.JSON(http.StatusNotFound, common.ErrorResponse{Message: fmt.Sprintf("no cached image with id %q", id)})
 	}
 
 	status, err := o.imageCache.GetCachedImageStatus(ctx, id)
@@ -181,8 +183,10 @@ func (o *Operator) HandleGetCachedImage(c echo.Context) error {
 func (o *Operator) HandleDeleteCachedImage(c echo.Context) error {
 	ctx := c.Request().Context()
 	id := c.Param("id")
-	if id == "" {
-		return c.JSON(http.StatusBadRequest, common.ErrorResponse{Message: "image cache id is required"})
+	if err := validateImageCacheID(id); err != nil {
+		// DELETE is idempotent: a malformed ID is treated the same as a
+		// missing one, returning success without contacting the API server.
+		return c.NoContent(http.StatusOK)
 	}
 
 	if err := o.imageCache.RemoveCachedImageByID(ctx, id); err != nil {

--- a/operator/imagecache_manual_mirror.go
+++ b/operator/imagecache_manual_mirror.go
@@ -39,8 +39,7 @@ func NewManualMirrorImageCacheManager(mappings map[string]string) *ManualMirrorI
 	}
 }
 
-// ReadOnly is true: the operator can't update the mapping at runtime; it
-// has to be edited in the JSON file and the operator restarted.
+// ReadOnly returns true; the mapping is owned externally and requires a restart to update.
 func (*ManualMirrorImageCacheManager) ReadOnly() bool { return true }
 
 // RewriteImage looks up image in the mapping. If found, returns the
@@ -53,22 +52,22 @@ func (m *ManualMirrorImageCacheManager) RewriteImage(image string) (string, bool
 	return target, true
 }
 
-// EnsureImageCached, RefreshCachedImage, RemoveCachedImage, and
-// RemoveCachedImageByID all return ErrCacheReadOnly. Handlers normally
-// detect ReadOnly() before reaching these, but having the methods return
-// a typed error keeps direct callers honest.
+// EnsureImageCached always returns ErrCacheReadOnly; the mapping is externally managed.
 func (*ManualMirrorImageCacheManager) EnsureImageCached(context.Context, string) error {
 	return ErrCacheReadOnly
 }
 
+// RefreshCachedImage always returns ErrCacheReadOnly; the mapping is externally managed.
 func (*ManualMirrorImageCacheManager) RefreshCachedImage(context.Context, string) error {
 	return ErrCacheReadOnly
 }
 
+// RemoveCachedImage always returns ErrCacheReadOnly; the mapping is externally managed.
 func (*ManualMirrorImageCacheManager) RemoveCachedImage(context.Context, string) error {
 	return ErrCacheReadOnly
 }
 
+// RemoveCachedImageByID always returns ErrCacheReadOnly; the mapping is externally managed.
 func (*ManualMirrorImageCacheManager) RemoveCachedImageByID(context.Context, string) error {
 	return ErrCacheReadOnly
 }
@@ -116,9 +115,17 @@ func (m *ManualMirrorImageCacheManager) GetCachedImageStatus(_ context.Context, 
 // 404 outcome — see HandleGetCachedImage.
 var errImageCacheEntryNotFound = errors.New("manual-mirror entry not found")
 
+// maxRepoFileEntries caps the number of mapping entries accepted from a
+// single repos file. Production mappings are expected to be in the low
+// double digits; a much larger file likely indicates a misconfiguration
+// (e.g. an accidentally-concatenated file) and should fail at startup
+// rather than silently allocating O(N) memory.
+const maxRepoFileEntries = 10000
+
 // LoadImageMirrorMap reads and validates a JSON file mapping upstream
 // image refs to mirrored refs. Both keys and values must pass
-// validateImageRef; the map must be non-empty.
+// validateImageRef; the map must be non-empty and at most
+// maxRepoFileEntries entries long.
 func LoadImageMirrorMap(path string) (map[string]string, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -131,6 +138,9 @@ func LoadImageMirrorMap(path string) (map[string]string, error) {
 	}
 	if len(raw) == 0 {
 		return nil, fmt.Errorf("repos file %s is empty", path)
+	}
+	if len(raw) > maxRepoFileEntries {
+		return nil, fmt.Errorf("repos file %s has %d entries; maximum is %d", path, len(raw), maxRepoFileEntries)
 	}
 
 	for k, v := range raw {

--- a/operator/imagecache_manual_mirror.go
+++ b/operator/imagecache_manual_mirror.go
@@ -1,0 +1,146 @@
+package operator
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+)
+
+// ManualMirrorImageCacheManager satisfies both ImageCacheManager and
+// ImageRewriter. The cache surface is read-only — the mapping is owned by
+// an external mirror process (e.g. mirror-images-to-ecr.sh), not by the
+// operator — so mutating cache methods return ErrCacheReadOnly. At launch
+// time RewriteImage substitutes upstream image refs for their mirrored
+// counterparts using the same mapping.
+type ManualMirrorImageCacheManager struct {
+	// mappings is keyed by the upstream image ref (the string that appears
+	// in incoming analysis bundles) and valued by the fully-qualified
+	// mirrored ref to substitute in its place.
+	mappings map[string]string
+
+	// idIndex maps slugifyImage(key) -> key so GetCachedImageStatus can
+	// resolve a slug ID without re-iterating the mapping.
+	idIndex map[string]string
+}
+
+// NewManualMirrorImageCacheManager constructs a manager around an
+// already-loaded mapping. Callers should use LoadImageMirrorMap to obtain
+// and validate the map from a JSON file.
+func NewManualMirrorImageCacheManager(mappings map[string]string) *ManualMirrorImageCacheManager {
+	idIndex := make(map[string]string, len(mappings))
+	for k := range mappings {
+		idIndex[slugifyImage(k)] = k
+	}
+	return &ManualMirrorImageCacheManager{
+		mappings: mappings,
+		idIndex:  idIndex,
+	}
+}
+
+// ReadOnly is true: the operator can't update the mapping at runtime; it
+// has to be edited in the JSON file and the operator restarted.
+func (*ManualMirrorImageCacheManager) ReadOnly() bool { return true }
+
+// RewriteImage looks up image in the mapping. If found, returns the
+// mirrored ref and ok=true; otherwise returns image unchanged and ok=false.
+func (m *ManualMirrorImageCacheManager) RewriteImage(image string) (string, bool) {
+	target, ok := m.mappings[image]
+	if !ok {
+		return image, false
+	}
+	return target, true
+}
+
+// EnsureImageCached, RefreshCachedImage, RemoveCachedImage, and
+// RemoveCachedImageByID all return ErrCacheReadOnly. Handlers normally
+// detect ReadOnly() before reaching these, but having the methods return
+// a typed error keeps direct callers honest.
+func (*ManualMirrorImageCacheManager) EnsureImageCached(context.Context, string) error {
+	return ErrCacheReadOnly
+}
+
+func (*ManualMirrorImageCacheManager) RefreshCachedImage(context.Context, string) error {
+	return ErrCacheReadOnly
+}
+
+func (*ManualMirrorImageCacheManager) RemoveCachedImage(context.Context, string) error {
+	return ErrCacheReadOnly
+}
+
+func (*ManualMirrorImageCacheManager) RemoveCachedImageByID(context.Context, string) error {
+	return ErrCacheReadOnly
+}
+
+// ListCachedImages exposes the mapping read-only as ImageCacheStatus
+// entries. Each entry's Image is the upstream key (what bundles reference)
+// and ID is its slug; Ready=Desired=1 with status="ready" since the mirror
+// is treated as authoritative.
+func (m *ManualMirrorImageCacheManager) ListCachedImages(context.Context) ([]ImageCacheStatus, error) {
+	out := make([]ImageCacheStatus, 0, len(m.mappings))
+	for upstream := range m.mappings {
+		out = append(out, ImageCacheStatus{
+			Image:   upstream,
+			ID:      slugifyImage(upstream),
+			Ready:   1,
+			Desired: 1,
+			Status:  "ready",
+		})
+	}
+	return out, nil
+}
+
+// GetCachedImageStatus resolves a slug ID back to its mapping entry.
+// Returns a wrapped not-found error if the slug doesn't correspond to any
+// entry; the handler converts that into a 404 the same way it does for
+// the K8s-backed backends.
+func (m *ManualMirrorImageCacheManager) GetCachedImageStatus(_ context.Context, id string) (*ImageCacheStatus, error) {
+	upstream, ok := m.idIndex[id]
+	if !ok {
+		return nil, fmt.Errorf("no manual-mirror entry for id %q: %w", id, errImageCacheEntryNotFound)
+	}
+	return &ImageCacheStatus{
+		Image:   upstream,
+		ID:      id,
+		Ready:   1,
+		Desired: 1,
+		Status:  "ready",
+	}, nil
+}
+
+// errImageCacheEntryNotFound is the manual-mirror-side sentinel for a
+// missing slug lookup. The Get handler in imagecache_handlers.go uses
+// errors.As against a K8s StatusError to detect 404s from the daemonset
+// and cron backends; for manual-mirror we map this sentinel to the same
+// 404 outcome — see HandleGetCachedImage.
+var errImageCacheEntryNotFound = errors.New("manual-mirror entry not found")
+
+// LoadImageMirrorMap reads and validates a JSON file mapping upstream
+// image refs to mirrored refs. Both keys and values must pass
+// validateImageRef; the map must be non-empty.
+func LoadImageMirrorMap(path string) (map[string]string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading repos file %s: %w", path, err)
+	}
+
+	var raw map[string]string
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return nil, fmt.Errorf("parsing repos file %s as JSON object of upstream->mirrored: %w", path, err)
+	}
+	if len(raw) == 0 {
+		return nil, fmt.Errorf("repos file %s is empty", path)
+	}
+
+	for k, v := range raw {
+		if err := validateImageRef(k); err != nil {
+			return nil, fmt.Errorf("repos file %s: invalid upstream key %q: %w", path, k, err)
+		}
+		if err := validateImageRef(v); err != nil {
+			return nil, fmt.Errorf("repos file %s: invalid mirrored value %q for key %q: %w", path, v, k, err)
+		}
+	}
+
+	return raw, nil
+}

--- a/operator/imagecache_manual_mirror_test.go
+++ b/operator/imagecache_manual_mirror_test.go
@@ -1,0 +1,168 @@
+package operator
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestManualMirrorRewriteImage(t *testing.T) {
+	mappings := map[string]string{
+		"harbor.cyverse.org/de/vice-proxy:latest": "123456789012.dkr.ecr.us-east-1.amazonaws.com/de/vice-proxy:latest",
+		"harbor.cyverse.org/de/porklock:qa":       "123456789012.dkr.ecr.us-east-1.amazonaws.com/de/porklock:qa",
+	}
+	mgr := NewManualMirrorImageCacheManager(mappings)
+
+	tests := []struct {
+		name    string
+		in      string
+		want    string
+		wantHit bool
+	}{
+		{name: "hit", in: "harbor.cyverse.org/de/vice-proxy:latest", want: "123456789012.dkr.ecr.us-east-1.amazonaws.com/de/vice-proxy:latest", wantHit: true},
+		{name: "different hit", in: "harbor.cyverse.org/de/porklock:qa", want: "123456789012.dkr.ecr.us-east-1.amazonaws.com/de/porklock:qa", wantHit: true},
+		{name: "miss leaves ref untouched", in: "harbor.cyverse.org/de/never-mirrored:latest", want: "harbor.cyverse.org/de/never-mirrored:latest", wantHit: false},
+		{name: "tag-mismatch is a miss", in: "harbor.cyverse.org/de/vice-proxy:qa", want: "harbor.cyverse.org/de/vice-proxy:qa", wantHit: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := mgr.RewriteImage(tt.in)
+			assert.Equal(t, tt.want, got)
+			assert.Equal(t, tt.wantHit, ok)
+		})
+	}
+}
+
+func TestManualMirrorReadOnlyAndMutatingMethodsReturnSentinel(t *testing.T) {
+	mgr := NewManualMirrorImageCacheManager(map[string]string{"a:1": "b:1"})
+	assert.True(t, mgr.ReadOnly())
+
+	ctx := context.Background()
+	for _, op := range []struct {
+		name string
+		fn   func() error
+	}{
+		{"EnsureImageCached", func() error { return mgr.EnsureImageCached(ctx, "a:1") }},
+		{"RefreshCachedImage", func() error { return mgr.RefreshCachedImage(ctx, "a:1") }},
+		{"RemoveCachedImage", func() error { return mgr.RemoveCachedImage(ctx, "a:1") }},
+		{"RemoveCachedImageByID", func() error { return mgr.RemoveCachedImageByID(ctx, slugifyImage("a:1")) }},
+	} {
+		t.Run(op.name, func(t *testing.T) {
+			err := op.fn()
+			require.Error(t, err)
+			assert.ErrorIs(t, err, ErrCacheReadOnly)
+		})
+	}
+}
+
+func TestManualMirrorListCachedImages(t *testing.T) {
+	mappings := map[string]string{
+		"harbor.cyverse.org/de/vice-proxy:latest": "123456789012.dkr.ecr.us-east-1.amazonaws.com/de/vice-proxy:latest",
+		"harbor.cyverse.org/de/porklock:latest":   "123456789012.dkr.ecr.us-east-1.amazonaws.com/de/porklock:latest",
+	}
+	mgr := NewManualMirrorImageCacheManager(mappings)
+
+	got, err := mgr.ListCachedImages(context.Background())
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+
+	byImage := map[string]ImageCacheStatus{}
+	for _, s := range got {
+		byImage[s.Image] = s
+	}
+	for upstream := range mappings {
+		s, ok := byImage[upstream]
+		require.True(t, ok, "list response missing %s", upstream)
+		assert.Equal(t, slugifyImage(upstream), s.ID)
+		assert.Equal(t, int32(1), s.Ready)
+		assert.Equal(t, int32(1), s.Desired)
+		assert.Equal(t, "ready", s.Status)
+	}
+}
+
+func TestManualMirrorGetCachedImageStatus(t *testing.T) {
+	upstream := "harbor.cyverse.org/de/vice-proxy:latest"
+	mgr := NewManualMirrorImageCacheManager(map[string]string{
+		upstream: "123456789012.dkr.ecr.us-east-1.amazonaws.com/de/vice-proxy:latest",
+	})
+
+	t.Run("hit returns status with correct upstream image and slug", func(t *testing.T) {
+		s, err := mgr.GetCachedImageStatus(context.Background(), slugifyImage(upstream))
+		require.NoError(t, err)
+		assert.Equal(t, upstream, s.Image)
+		assert.Equal(t, "ready", s.Status)
+	})
+
+	t.Run("miss returns sentinel that handler maps to 404", func(t *testing.T) {
+		_, err := mgr.GetCachedImageStatus(context.Background(), "no-such-slug-0123456789ab")
+		require.Error(t, err)
+		assert.ErrorIs(t, err, errImageCacheEntryNotFound)
+	})
+}
+
+func TestLoadImageMirrorMap(t *testing.T) {
+	tmp := t.TempDir()
+
+	writeFile := func(t *testing.T, name, body string) string {
+		t.Helper()
+		p := filepath.Join(tmp, name)
+		require.NoError(t, os.WriteFile(p, []byte(body), 0o600))
+		return p
+	}
+
+	validMap := map[string]string{
+		"harbor.cyverse.org/de/vice-proxy:latest": "123456789012.dkr.ecr.us-east-1.amazonaws.com/de/vice-proxy:latest",
+		"harbor.cyverse.org/de/porklock:qa":       "123456789012.dkr.ecr.us-east-1.amazonaws.com/de/porklock:qa",
+	}
+	validBytes, err := json.Marshal(validMap)
+	require.NoError(t, err)
+	validPath := writeFile(t, "valid.json", string(validBytes))
+
+	tests := []struct {
+		name        string
+		path        string
+		wantErr     bool
+		wantErrPart string
+	}{
+		{name: "valid file parses and validates", path: validPath, wantErr: false},
+		{name: "missing file is a clear error", path: filepath.Join(tmp, "does-not-exist.json"), wantErr: true, wantErrPart: "reading repos file"},
+		{name: "malformed JSON surfaces parse error", path: writeFile(t, "malformed.json", "{not valid"), wantErr: true, wantErrPart: "parsing repos file"},
+		{name: "empty object is rejected", path: writeFile(t, "empty.json", "{}"), wantErr: true, wantErrPart: "is empty"},
+		{name: "empty key is rejected", path: writeFile(t, "empty-key.json", `{"":"x:1"}`), wantErr: true, wantErrPart: "invalid upstream key"},
+		{name: "key with spaces is rejected", path: writeFile(t, "bad-key.json", `{"bad image":"x:1"}`), wantErr: true, wantErrPart: "invalid upstream key"},
+		{name: "value with spaces is rejected", path: writeFile(t, "bad-value.json", `{"harbor.cyverse.org/x:1":"bad ref"}`), wantErr: true, wantErrPart: "invalid mirrored value"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := LoadImageMirrorMap(tt.path)
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.wantErrPart != "" {
+					assert.Contains(t, err.Error(), tt.wantErrPart)
+				}
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, validMap, got)
+		})
+	}
+}
+
+func TestManualMirrorSatisfiesInterfaces(t *testing.T) {
+	// Compile-time confirmation that the concrete type satisfies both
+	// interfaces. Test body intentionally trivial — the assertions live
+	// in the var declarations.
+	var (
+		_ ImageCacheManager = (*ManualMirrorImageCacheManager)(nil)
+		_ ImageRewriter     = (*ManualMirrorImageCacheManager)(nil)
+	)
+	require.True(t, errors.Is(ErrCacheReadOnly, ErrCacheReadOnly))
+}

--- a/operator/imagecache_manual_mirror_test.go
+++ b/operator/imagecache_manual_mirror_test.go
@@ -3,7 +3,7 @@ package operator
 import (
 	"context"
 	"encoding/json"
-	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -135,6 +135,23 @@ func TestLoadImageMirrorMap(t *testing.T) {
 		{name: "missing file is a clear error", path: filepath.Join(tmp, "does-not-exist.json"), wantErr: true, wantErrPart: "reading repos file"},
 		{name: "malformed JSON surfaces parse error", path: writeFile(t, "malformed.json", "{not valid"), wantErr: true, wantErrPart: "parsing repos file"},
 		{name: "empty object is rejected", path: writeFile(t, "empty.json", "{}"), wantErr: true, wantErrPart: "is empty"},
+		{
+			name: "entry-count cap is enforced",
+			path: func() string {
+				m := make(map[string]string, maxRepoFileEntries+1)
+				for i := 0; i <= maxRepoFileEntries; i++ {
+					// validateImageRef requires alnum-start refs.
+					k := fmt.Sprintf("upstream%d:tag", i)
+					v := fmt.Sprintf("mirror%d:tag", i)
+					m[k] = v
+				}
+				b, err := json.Marshal(m)
+				require.NoError(t, err)
+				return writeFile(t, "too-many.json", string(b))
+			}(),
+			wantErr:     true,
+			wantErrPart: "maximum is",
+		},
 		{name: "empty key is rejected", path: writeFile(t, "empty-key.json", `{"":"x:1"}`), wantErr: true, wantErrPart: "invalid upstream key"},
 		{name: "key with spaces is rejected", path: writeFile(t, "bad-key.json", `{"bad image":"x:1"}`), wantErr: true, wantErrPart: "invalid upstream key"},
 		{name: "value with spaces is rejected", path: writeFile(t, "bad-value.json", `{"harbor.cyverse.org/x:1":"bad ref"}`), wantErr: true, wantErrPart: "invalid mirrored value"},
@@ -156,13 +173,11 @@ func TestLoadImageMirrorMap(t *testing.T) {
 	}
 }
 
-func TestManualMirrorSatisfiesInterfaces(t *testing.T) {
-	// Compile-time confirmation that the concrete type satisfies both
-	// interfaces. Test body intentionally trivial — the assertions live
-	// in the var declarations.
+func TestManualMirrorSatisfiesInterfaces(_ *testing.T) {
+	// Compile-time check that ManualMirrorImageCacheManager implements both
+	// interfaces; runtime body is intentionally empty.
 	var (
 		_ ImageCacheManager = (*ManualMirrorImageCacheManager)(nil)
 		_ ImageRewriter     = (*ManualMirrorImageCacheManager)(nil)
 	)
-	require.True(t, errors.Is(ErrCacheReadOnly, ErrCacheReadOnly))
 }

--- a/operator/imagecache_test.go
+++ b/operator/imagecache_test.go
@@ -285,6 +285,75 @@ func TestImageCacheIDValidation(t *testing.T) {
 	}
 }
 
+// TestManualMirrorHandlers400 confirms that mutating cache endpoints
+// return 400 in manual-mirror mode without reaching into the manager.
+// HandleListCachedImages / HandleGetCachedImage are still expected to
+// work as a read-only window onto the mapping.
+func TestManualMirrorHandlers400(t *testing.T) {
+	upstream := "harbor.cyverse.org/de/vice-proxy:latest"
+	mappings := map[string]string{
+		upstream: "123456789012.dkr.ecr.us-east-1.amazonaws.com/de/vice-proxy:latest",
+	}
+	op := newManualMirrorTestOperator(t, mappings)
+
+	mutatingHandlers := []struct {
+		name    string
+		method  string
+		invoke  func(c echo.Context) error
+		body    string
+		hasBody bool
+	}{
+		{name: "PUT /image-cache", method: http.MethodPut, invoke: op.HandleCacheImages, body: `{"images":["nginx:latest"]}`, hasBody: true},
+		{name: "DELETE /image-cache", method: http.MethodDelete, invoke: op.HandleRemoveCachedImages, body: `{"images":["nginx:latest"]}`, hasBody: true},
+		{name: "POST /image-cache/refresh", method: http.MethodPost, invoke: op.HandleRefreshCachedImages, body: `{"images":["nginx:latest"]}`, hasBody: true},
+		{name: "DELETE /image-cache/:id", method: http.MethodDelete, invoke: op.HandleDeleteCachedImage, hasBody: false},
+	}
+
+	for _, tt := range mutatingHandlers {
+		t.Run(tt.name, func(t *testing.T) {
+			e := echo.New()
+			var req *http.Request
+			if tt.hasBody {
+				req = httptest.NewRequest(tt.method, "/", bytes.NewReader([]byte(tt.body)))
+				req.Header.Set("Content-Type", "application/json")
+			} else {
+				req = httptest.NewRequest(tt.method, "/", nil)
+			}
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+			if !tt.hasBody {
+				c.SetParamNames("id")
+				c.SetParamValues(slugifyImage(upstream))
+			}
+			require.NoError(t, tt.invoke(c))
+			assert.Equal(t, http.StatusBadRequest, rec.Code)
+			assert.Contains(t, rec.Body.String(), "externally managed")
+		})
+	}
+
+	// Read-only handlers still work.
+	t.Run("GET /image-cache returns the mapping", func(t *testing.T) {
+		e := echo.New()
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+		require.NoError(t, op.HandleListCachedImages(c))
+		assert.Equal(t, http.StatusOK, rec.Code)
+		assert.Contains(t, rec.Body.String(), upstream)
+	})
+
+	t.Run("GET /image-cache/:id returns one entry", func(t *testing.T) {
+		e := echo.New()
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+		c.SetParamNames("id")
+		c.SetParamValues(slugifyImage(upstream))
+		require.NoError(t, op.HandleGetCachedImage(c))
+		assert.Equal(t, http.StatusOK, rec.Code)
+	})
+}
+
 // TestValidateImageRefLength bounds the input so a caller can't park a
 // huge string in CronJob/DaemonSet annotations.
 func TestValidateImageRefLength(t *testing.T) {

--- a/operator/imagecache_test.go
+++ b/operator/imagecache_test.go
@@ -245,3 +245,54 @@ func TestHandleGetCachedImageNotFound(t *testing.T) {
 	require.NoError(t, err) // handler writes response directly
 	assert.Equal(t, http.StatusNotFound, rec.Code)
 }
+
+// TestImageCacheIDValidation covers the path-parameter validation on the
+// per-image endpoints. Malformed IDs must not be forwarded to the K8s API.
+func TestImageCacheIDValidation(t *testing.T) {
+	tests := []struct {
+		name     string
+		id       string
+		wantGet  int // expected status from HandleGetCachedImage
+		wantDel  int // expected status from HandleDeleteCachedImage
+	}{
+		{name: "empty id", id: "", wantGet: http.StatusNotFound, wantDel: http.StatusOK},
+		{name: "uppercase rejected", id: "Bad-Slug", wantGet: http.StatusNotFound, wantDel: http.StatusOK},
+		{name: "shell-unsafe chars rejected", id: "a;b", wantGet: http.StatusNotFound, wantDel: http.StatusOK},
+		{name: "slash rejected", id: "a/b", wantGet: http.StatusNotFound, wantDel: http.StatusOK},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			op, _, _ := newTestOperator(t, 10)
+			e := echo.New()
+
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+			c.SetParamNames("id")
+			c.SetParamValues(tt.id)
+			require.NoError(t, op.HandleGetCachedImage(c))
+			assert.Equal(t, tt.wantGet, rec.Code, "GET")
+
+			req = httptest.NewRequest(http.MethodDelete, "/", nil)
+			rec = httptest.NewRecorder()
+			c = e.NewContext(req, rec)
+			c.SetParamNames("id")
+			c.SetParamValues(tt.id)
+			require.NoError(t, op.HandleDeleteCachedImage(c))
+			assert.Equal(t, tt.wantDel, rec.Code, "DELETE")
+		})
+	}
+}
+
+// TestValidateImageRefLength bounds the input so a caller can't park a
+// huge string in CronJob/DaemonSet annotations.
+func TestValidateImageRefLength(t *testing.T) {
+	long := make([]byte, maxImageRefLen+1)
+	for i := range long {
+		long[i] = 'a'
+	}
+	err := validateImageRef(string(long))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "too long")
+}

--- a/operator/imagecache_test.go
+++ b/operator/imagecache_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -12,12 +11,6 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	appsv1 "k8s.io/api/apps/v1"
-	apiv1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/kubernetes/fake"
-	clienttesting "k8s.io/client-go/testing"
 )
 
 func TestSlugifyImage(t *testing.T) {
@@ -38,9 +31,9 @@ func TestSlugifyImage(t *testing.T) {
 			// Must be a valid K8s name component (lowercase, no special chars except -).
 			assert.Regexp(t, `^[a-z0-9][a-z0-9-]*[a-z0-9]$`, slug, "slug must be a valid K8s name")
 
-			// Total DaemonSet name must fit K8s 253-char limit.
-			fullName := "image-cache-" + slug
-			assert.LessOrEqual(t, len(fullName), 253, "full DaemonSet name must fit K8s limit")
+			// Total cache resource name must fit K8s 253-char limit.
+			fullName := cacheNamePrefix + slug
+			assert.LessOrEqual(t, len(fullName), 253, "full cache resource name must fit K8s limit")
 		})
 	}
 }
@@ -77,6 +70,7 @@ func TestValidateImageRef(t *testing.T) {
 		{name: "valid full ref", image: "harbor.cyverse.org/de/vice-proxy:latest", wantErr: false},
 		{name: "valid simple", image: "nginx:1.25", wantErr: false},
 		{name: "valid no tag", image: "harbor.cyverse.org/de/vice-proxy", wantErr: false},
+		{name: "valid ECR pull-through ref", image: "123456789012.dkr.ecr.us-east-1.amazonaws.com/cache/harbor.cyverse.org/de/vice-proxy:latest", wantErr: false},
 		{name: "empty string", image: "", wantErr: true},
 		{name: "spaces", image: "bad image", wantErr: true},
 		{name: "only special chars", image: "!!!", wantErr: true},
@@ -92,242 +86,6 @@ func TestValidateImageRef(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestBuildCacheDaemonSet(t *testing.T) {
-	mgr := NewImageCacheManager(nil, "vice-apps", "vice-image-pull-secret")
-	image := "harbor.cyverse.org/de/vice-proxy:latest"
-	slug := slugifyImage(image)
-
-	ds := mgr.buildCacheDaemonSet(image, slug)
-
-	// Metadata.
-	assert.Equal(t, dsNamePrefix+slug, ds.Name)
-	assert.Equal(t, "vice-apps", ds.Namespace)
-	assert.Equal(t, valueManagedBy, ds.Labels[labelManagedBy])
-	assert.Equal(t, valuePurpose, ds.Labels[labelPurpose])
-	assert.Equal(t, slug, ds.Labels[labelImageCacheID])
-	assert.Equal(t, image, ds.Annotations[annotationImage])
-
-	// Selector must match pod template labels.
-	assert.Equal(t, ds.Spec.Selector.MatchLabels, ds.Spec.Template.Labels)
-
-	// Init container pulls the target image.
-	require.Len(t, ds.Spec.Template.Spec.InitContainers, 1)
-	pullContainer := ds.Spec.Template.Spec.InitContainers[0]
-	assert.Equal(t, image, pullContainer.Image)
-	assert.Equal(t, []string{"true"}, pullContainer.Command)
-	assert.Equal(t, apiv1.PullAlways, pullContainer.ImagePullPolicy)
-
-	// Main container is pause.
-	require.Len(t, ds.Spec.Template.Spec.Containers, 1)
-	pauseContainer := ds.Spec.Template.Spec.Containers[0]
-	assert.Equal(t, pauseImage, pauseContainer.Image)
-	assert.Equal(t, apiv1.PullIfNotPresent, pauseContainer.ImagePullPolicy)
-
-	// Image pull secret.
-	require.Len(t, ds.Spec.Template.Spec.ImagePullSecrets, 1)
-	assert.Equal(t, "vice-image-pull-secret", ds.Spec.Template.Spec.ImagePullSecrets[0].Name)
-
-	// Tolerations.
-	assert.Len(t, ds.Spec.Template.Spec.Tolerations, 2)
-}
-
-func TestEnsureImageCached(t *testing.T) {
-	const (
-		ns     = "vice-apps"
-		secret = "vice-image-pull-secret"
-		image  = "harbor.cyverse.org/de/vice-proxy:latest"
-	)
-	slug := slugifyImage(image)
-	dsName := dsNamePrefix + slug
-
-	tests := []struct {
-		name     string
-		existing *appsv1.DaemonSet // nil = no pre-existing DS
-	}{
-		{
-			name:     "creates DaemonSet when missing",
-			existing: nil,
-		},
-		{
-			name:     "no-op when image matches",
-			existing: NewImageCacheManager(nil, ns, secret).buildCacheDaemonSet(image, slug),
-		},
-		{
-			name: "updates when annotation differs",
-			existing: func() *appsv1.DaemonSet {
-				ds := NewImageCacheManager(nil, ns, secret).buildCacheDaemonSet("old-image:v1", slug)
-				ds.Name = dsName
-				ds.Annotations[annotationImage] = "old-image:v1"
-				return ds
-			}(),
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			var cs *fake.Clientset
-			if tt.existing != nil {
-				cs = fake.NewSimpleClientset(tt.existing)
-			} else {
-				cs = fake.NewSimpleClientset()
-			}
-
-			mgr := NewImageCacheManager(cs, ns, secret)
-			err := mgr.EnsureImageCached(context.Background(), image)
-			require.NoError(t, err)
-
-			// Verify DaemonSet exists with correct annotation.
-			ds, err := cs.AppsV1().DaemonSets(ns).Get(context.Background(), dsName, metav1.GetOptions{})
-			require.NoError(t, err)
-			assert.Equal(t, image, ds.Annotations[annotationImage])
-		})
-	}
-}
-
-func TestEnsureImageCachedInvalidRef(t *testing.T) {
-	cs := fake.NewSimpleClientset()
-	mgr := NewImageCacheManager(cs, "vice-apps", "vice-image-pull-secret")
-
-	err := mgr.EnsureImageCached(context.Background(), "")
-	assert.Error(t, err, "empty image should be rejected")
-
-	err = mgr.EnsureImageCached(context.Background(), "bad image!")
-	assert.Error(t, err, "invalid image should be rejected")
-}
-
-func TestRemoveCachedImageByID(t *testing.T) {
-	const (
-		ns     = "vice-apps"
-		secret = "vice-image-pull-secret"
-		image  = "harbor.cyverse.org/de/vice-proxy:latest"
-	)
-
-	// Create a DaemonSet, then remove by ID.
-	mgr := NewImageCacheManager(nil, ns, secret)
-	slug := slugifyImage(image)
-	ds := mgr.buildCacheDaemonSet(image, slug)
-	cs := fake.NewSimpleClientset(ds)
-	mgr = NewImageCacheManager(cs, ns, secret)
-
-	err := mgr.RemoveCachedImageByID(context.Background(), slug)
-	require.NoError(t, err)
-
-	list, err := cs.AppsV1().DaemonSets(ns).List(context.Background(), metav1.ListOptions{})
-	require.NoError(t, err)
-	assert.Empty(t, list.Items)
-
-	// Removing again should succeed (idempotent).
-	err = mgr.RemoveCachedImageByID(context.Background(), slug)
-	require.NoError(t, err)
-}
-
-func TestRemoveCachedImage(t *testing.T) {
-	const (
-		ns     = "vice-apps"
-		secret = "vice-image-pull-secret"
-		image  = "harbor.cyverse.org/de/vice-proxy:latest"
-	)
-
-	tests := []struct {
-		name     string
-		existing bool
-	}{
-		{name: "deletes existing DaemonSet", existing: true},
-		{name: "succeeds silently when missing", existing: false},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			var cs *fake.Clientset
-			mgr := NewImageCacheManager(nil, ns, secret)
-			if tt.existing {
-				slug := slugifyImage(image)
-				ds := mgr.buildCacheDaemonSet(image, slug)
-				cs = fake.NewSimpleClientset(ds)
-			} else {
-				cs = fake.NewSimpleClientset()
-			}
-			mgr = NewImageCacheManager(cs, ns, secret)
-
-			err := mgr.RemoveCachedImage(context.Background(), image)
-			require.NoError(t, err)
-
-			// Verify DaemonSet is gone.
-			list, err := cs.AppsV1().DaemonSets(ns).List(context.Background(), metav1.ListOptions{})
-			require.NoError(t, err)
-			assert.Empty(t, list.Items)
-		})
-	}
-}
-
-// TestRefreshCachedImage exercises all four paths:
-//  1. Invalid image ref → validation error, no API calls.
-//  2. Missing DaemonSet → wrapped NotFound error.
-//  3. Update failure → wrapped error from client.Update.
-//  4. Happy path → the pod template carries a fresh restartedAt annotation.
-func TestRefreshCachedImage(t *testing.T) {
-	const (
-		ns     = "vice-apps"
-		secret = "vice-image-pull-secret"
-		image  = "harbor.cyverse.org/de/vice-proxy:latest"
-	)
-	slug := slugifyImage(image)
-	dsName := dsNamePrefix + slug
-
-	t.Run("invalid image ref rejected", func(t *testing.T) {
-		cs := fake.NewSimpleClientset()
-		mgr := NewImageCacheManager(cs, ns, secret)
-
-		err := mgr.RefreshCachedImage(context.Background(), "bad image!")
-		require.Error(t, err)
-	})
-
-	t.Run("missing DaemonSet surfaces not-found", func(t *testing.T) {
-		cs := fake.NewSimpleClientset()
-		mgr := NewImageCacheManager(cs, ns, secret)
-
-		err := mgr.RefreshCachedImage(context.Background(), image)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "no cache DaemonSet found")
-	})
-
-	t.Run("update failure is wrapped with DS name", func(t *testing.T) {
-		mgr := NewImageCacheManager(nil, ns, secret)
-		existing := mgr.buildCacheDaemonSet(image, slug)
-		cs := fake.NewSimpleClientset(existing)
-		mgr = NewImageCacheManager(cs, ns, secret)
-
-		// Inject an Update failure via the fake clientset's reactor chain.
-		cs.PrependReactor("update", "daemonsets", func(action clienttesting.Action) (bool, runtime.Object, error) {
-			return true, nil, errors.New("injected update failure")
-		})
-
-		err := mgr.RefreshCachedImage(context.Background(), image)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "restarting cache DaemonSet")
-		assert.Contains(t, err.Error(), dsName)
-	})
-
-	t.Run("happy path stamps restartedAt annotation", func(t *testing.T) {
-		mgr := NewImageCacheManager(nil, ns, secret)
-		existing := mgr.buildCacheDaemonSet(image, slug)
-		// Clear any pre-existing template annotations so we can assert
-		// the restartedAt key is created fresh rather than overwritten.
-		existing.Spec.Template.Annotations = nil
-
-		cs := fake.NewSimpleClientset(existing)
-		mgr = NewImageCacheManager(cs, ns, secret)
-
-		err := mgr.RefreshCachedImage(context.Background(), image)
-		require.NoError(t, err)
-
-		updated, err := cs.AppsV1().DaemonSets(ns).Get(context.Background(), dsName, metav1.GetOptions{})
-		require.NoError(t, err)
-		require.NotNil(t, updated.Spec.Template.Annotations)
-		assert.NotEmpty(t, updated.Spec.Template.Annotations["de.cyverse.org/restartedAt"])
-	})
 }
 
 func TestDeriveStatus(t *testing.T) {
@@ -348,71 +106,6 @@ func TestDeriveStatus(t *testing.T) {
 			assert.Equal(t, tt.wantStatus, deriveCacheStatus(tt.desired, tt.ready))
 		})
 	}
-}
-
-func TestListCachedImages(t *testing.T) {
-	const (
-		ns     = "vice-apps"
-		secret = "vice-image-pull-secret"
-	)
-
-	mgr := NewImageCacheManager(nil, ns, secret)
-	image1 := "harbor.cyverse.org/de/vice-proxy:latest"
-	image2 := "harbor.cyverse.org/de/porklock:latest"
-	slug1 := slugifyImage(image1)
-	slug2 := slugifyImage(image2)
-	ds1 := mgr.buildCacheDaemonSet(image1, slug1)
-	ds2 := mgr.buildCacheDaemonSet(image2, slug2)
-
-	// Simulate status fields.
-	ds1.Status = appsv1.DaemonSetStatus{DesiredNumberScheduled: 3, NumberReady: 3}
-	ds2.Status = appsv1.DaemonSetStatus{DesiredNumberScheduled: 3, NumberReady: 1, NumberUnavailable: 2}
-
-	cs := fake.NewSimpleClientset(ds1, ds2)
-	mgr = NewImageCacheManager(cs, ns, secret)
-
-	images, err := mgr.ListCachedImages(context.Background())
-	require.NoError(t, err)
-	assert.Len(t, images, 2)
-
-	// Find each image in the results.
-	statusByImage := make(map[string]ImageCacheStatus)
-	for _, s := range images {
-		statusByImage[s.Image] = s
-	}
-
-	s1 := statusByImage[image1]
-	assert.Equal(t, "ready", s1.Status)
-	assert.Equal(t, int32(3), s1.Ready)
-
-	s2 := statusByImage[image2]
-	assert.Equal(t, "pulling", s2.Status)
-	assert.Equal(t, int32(1), s2.Ready)
-}
-
-func TestGetCachedImageStatus(t *testing.T) {
-	const (
-		ns     = "vice-apps"
-		secret = "vice-image-pull-secret"
-		image  = "harbor.cyverse.org/de/vice-proxy:latest"
-	)
-
-	mgr := NewImageCacheManager(nil, ns, secret)
-	slug := slugifyImage(image)
-	ds := mgr.buildCacheDaemonSet(image, slug)
-	ds.Status = appsv1.DaemonSetStatus{DesiredNumberScheduled: 3, NumberReady: 3}
-
-	cs := fake.NewSimpleClientset(ds)
-	mgr = NewImageCacheManager(cs, ns, secret)
-
-	status, err := mgr.GetCachedImageStatus(context.Background(), slug)
-	require.NoError(t, err)
-	assert.Equal(t, image, status.Image)
-	assert.Equal(t, "ready", status.Status)
-
-	// Non-existent slug returns error.
-	_, err = mgr.GetCachedImageStatus(context.Background(), "nonexistent")
-	assert.Error(t, err)
 }
 
 func TestHandleCacheImages(t *testing.T) {
@@ -458,9 +151,9 @@ func TestHandleCacheImages(t *testing.T) {
 
 // TestHandleRefreshCachedImages exercises the bulk refresh handler.
 // Cases mirror TestHandleCacheImages for parity:
-//  - all images refreshed → 200
-//  - empty list → 400
-//  - one image exists, one doesn't → 207 with the missing one's error in its result row
+//   - all images refreshed → 200
+//   - empty list → 400
+//   - one image exists, one doesn't → 207 with the missing one's error in its result row
 //
 // The refresh path requires a pre-existing DaemonSet per image, so the
 // "successful refresh" case seeds one first via a direct EnsureImageCached

--- a/operator/transform_images.go
+++ b/operator/transform_images.go
@@ -8,18 +8,22 @@ import (
 // TransformImageRefs walks the deployment's container and init-container
 // image fields and substitutes any that have a mapping in rewriter. Images
 // without a mapping pass through unchanged so non-VICE sidecars or
-// not-yet-mirrored images don't block a launch. Returns the number of
-// substitutions, so the caller can log when rewriting actually happened.
-func TransformImageRefs(deployment *appsv1.Deployment, rewriter ImageRewriter) int {
+// not-yet-mirrored images don't block a launch. Always emits an info log
+// summarizing the pass: an admin can grep for "image-ref rewrite" to see
+// whether manual-mirror engaged for a given launch, including the
+// drift-warning case where the rewriter is configured but matched
+// nothing.
+func TransformImageRefs(deployment *appsv1.Deployment, rewriter ImageRewriter) {
 	if deployment == nil || rewriter == nil {
-		return 0
+		return
 	}
-	return rewriteContainerImages(deployment.Spec.Template.Spec.InitContainers, rewriter) +
+	n := rewriteContainerImages(deployment.Spec.Template.Spec.InitContainers, rewriter) +
 		rewriteContainerImages(deployment.Spec.Template.Spec.Containers, rewriter)
+	log.Infof("image-ref rewrite: %d substitution(s) in deployment %s", n, deployment.Name)
 }
 
 func rewriteContainerImages(containers []apiv1.Container, rewriter ImageRewriter) int {
-	count := 0
+	var count int
 	for i := range containers {
 		if mirrored, ok := rewriter.RewriteImage(containers[i].Image); ok {
 			containers[i].Image = mirrored

--- a/operator/transform_images.go
+++ b/operator/transform_images.go
@@ -1,0 +1,30 @@
+package operator
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+	apiv1 "k8s.io/api/core/v1"
+)
+
+// TransformImageRefs walks the deployment's container and init-container
+// image fields and substitutes any that have a mapping in rewriter. Images
+// without a mapping pass through unchanged so non-VICE sidecars or
+// not-yet-mirrored images don't block a launch. Returns the number of
+// substitutions, so the caller can log when rewriting actually happened.
+func TransformImageRefs(deployment *appsv1.Deployment, rewriter ImageRewriter) int {
+	if deployment == nil || rewriter == nil {
+		return 0
+	}
+	return rewriteContainerImages(deployment.Spec.Template.Spec.InitContainers, rewriter) +
+		rewriteContainerImages(deployment.Spec.Template.Spec.Containers, rewriter)
+}
+
+func rewriteContainerImages(containers []apiv1.Container, rewriter ImageRewriter) int {
+	count := 0
+	for i := range containers {
+		if mirrored, ok := rewriter.RewriteImage(containers[i].Image); ok {
+			containers[i].Image = mirrored
+			count++
+		}
+	}
+	return count
+}

--- a/operator/transform_images_test.go
+++ b/operator/transform_images_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -54,7 +53,6 @@ func TestTransformImageRefs(t *testing.T) {
 		name           string
 		initIn, mainIn []string
 		wantInit, wantMain []string
-		wantCount      int
 	}{
 		{
 			name: "no images match: deployment unchanged",
@@ -62,7 +60,6 @@ func TestTransformImageRefs(t *testing.T) {
 			mainIn: []string{"harbor.cyverse.org/de/also-unrelated:2"},
 			wantInit: []string{"harbor.cyverse.org/de/unrelated:1"},
 			wantMain: []string{"harbor.cyverse.org/de/also-unrelated:2"},
-			wantCount: 0,
 		},
 		{
 			name: "init container is rewritten",
@@ -70,7 +67,6 @@ func TestTransformImageRefs(t *testing.T) {
 			mainIn: []string{"harbor.cyverse.org/de/vice-app:latest"},
 			wantInit: []string{"ecr/porklock:latest"},
 			wantMain: []string{"harbor.cyverse.org/de/vice-app:latest"},
-			wantCount: 1,
 		},
 		{
 			name: "main container is rewritten",
@@ -78,7 +74,6 @@ func TestTransformImageRefs(t *testing.T) {
 			mainIn: []string{"harbor.cyverse.org/de/vice-proxy:latest"},
 			wantInit: []string{},
 			wantMain: []string{"ecr/vice-proxy:latest"},
-			wantCount: 1,
 		},
 		{
 			name: "both kinds of containers rewritten in one pass",
@@ -86,15 +81,13 @@ func TestTransformImageRefs(t *testing.T) {
 			mainIn: []string{"harbor.cyverse.org/de/vice-proxy:latest", "harbor.cyverse.org/de/unrelated:3"},
 			wantInit: []string{"ecr/porklock:latest"},
 			wantMain: []string{"ecr/vice-proxy:latest", "harbor.cyverse.org/de/unrelated:3"},
-			wantCount: 2,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			dep := makeDeploymentWithImages(tt.initIn, tt.mainIn)
-			got := TransformImageRefs(dep, rewriter)
-			assert.Equal(t, tt.wantCount, got)
+			TransformImageRefs(dep, rewriter)
 
 			gotInit := make([]string, 0, len(dep.Spec.Template.Spec.InitContainers))
 			for _, c := range dep.Spec.Template.Spec.InitContainers {
@@ -112,8 +105,9 @@ func TestTransformImageRefs(t *testing.T) {
 
 func TestTransformImageRefsNilSafe(t *testing.T) {
 	rewriter := stubRewriter{m: map[string]string{"a": "b"}}
-	require.Equal(t, 0, TransformImageRefs(nil, rewriter), "nil deployment is a no-op")
+	// nil deployment and nil rewriter must both be no-ops; panic would fail the test.
+	TransformImageRefs(nil, rewriter)
 	dep := makeDeploymentWithImages(nil, []string{"a"})
-	require.Equal(t, 0, TransformImageRefs(dep, nil), "nil rewriter is a no-op")
-	assert.Equal(t, "a", dep.Spec.Template.Spec.Containers[0].Image)
+	TransformImageRefs(dep, nil)
+	assert.Equal(t, "a", dep.Spec.Template.Spec.Containers[0].Image, "nil rewriter must leave image unchanged")
 }

--- a/operator/transform_images_test.go
+++ b/operator/transform_images_test.go
@@ -1,0 +1,119 @@
+package operator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	apiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// stubRewriter satisfies ImageRewriter for tests without pulling in a full
+// ManualMirrorImageCacheManager.
+type stubRewriter struct{ m map[string]string }
+
+func (s stubRewriter) RewriteImage(image string) (string, bool) {
+	out, ok := s.m[image]
+	if !ok {
+		return image, false
+	}
+	return out, true
+}
+
+func makeDeploymentWithImages(init, main []string) *appsv1.Deployment {
+	initContainers := make([]apiv1.Container, len(init))
+	for i, img := range init {
+		initContainers[i] = apiv1.Container{Name: "init-" + img, Image: img}
+	}
+	containers := make([]apiv1.Container, len(main))
+	for i, img := range main {
+		containers[i] = apiv1.Container{Name: "main-" + img, Image: img}
+	}
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "test"},
+		Spec: appsv1.DeploymentSpec{
+			Template: apiv1.PodTemplateSpec{
+				Spec: apiv1.PodSpec{
+					InitContainers: initContainers,
+					Containers:     containers,
+				},
+			},
+		},
+	}
+}
+
+func TestTransformImageRefs(t *testing.T) {
+	rewriter := stubRewriter{m: map[string]string{
+		"harbor.cyverse.org/de/vice-proxy:latest": "ecr/vice-proxy:latest",
+		"harbor.cyverse.org/de/porklock:latest":   "ecr/porklock:latest",
+	}}
+
+	tests := []struct {
+		name           string
+		initIn, mainIn []string
+		wantInit, wantMain []string
+		wantCount      int
+	}{
+		{
+			name: "no images match: deployment unchanged",
+			initIn: []string{"harbor.cyverse.org/de/unrelated:1"},
+			mainIn: []string{"harbor.cyverse.org/de/also-unrelated:2"},
+			wantInit: []string{"harbor.cyverse.org/de/unrelated:1"},
+			wantMain: []string{"harbor.cyverse.org/de/also-unrelated:2"},
+			wantCount: 0,
+		},
+		{
+			name: "init container is rewritten",
+			initIn: []string{"harbor.cyverse.org/de/porklock:latest"},
+			mainIn: []string{"harbor.cyverse.org/de/vice-app:latest"},
+			wantInit: []string{"ecr/porklock:latest"},
+			wantMain: []string{"harbor.cyverse.org/de/vice-app:latest"},
+			wantCount: 1,
+		},
+		{
+			name: "main container is rewritten",
+			initIn: []string{},
+			mainIn: []string{"harbor.cyverse.org/de/vice-proxy:latest"},
+			wantInit: []string{},
+			wantMain: []string{"ecr/vice-proxy:latest"},
+			wantCount: 1,
+		},
+		{
+			name: "both kinds of containers rewritten in one pass",
+			initIn: []string{"harbor.cyverse.org/de/porklock:latest"},
+			mainIn: []string{"harbor.cyverse.org/de/vice-proxy:latest", "harbor.cyverse.org/de/unrelated:3"},
+			wantInit: []string{"ecr/porklock:latest"},
+			wantMain: []string{"ecr/vice-proxy:latest", "harbor.cyverse.org/de/unrelated:3"},
+			wantCount: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dep := makeDeploymentWithImages(tt.initIn, tt.mainIn)
+			got := TransformImageRefs(dep, rewriter)
+			assert.Equal(t, tt.wantCount, got)
+
+			gotInit := make([]string, 0, len(dep.Spec.Template.Spec.InitContainers))
+			for _, c := range dep.Spec.Template.Spec.InitContainers {
+				gotInit = append(gotInit, c.Image)
+			}
+			gotMain := make([]string, 0, len(dep.Spec.Template.Spec.Containers))
+			for _, c := range dep.Spec.Template.Spec.Containers {
+				gotMain = append(gotMain, c.Image)
+			}
+			assert.Equal(t, tt.wantInit, gotInit, "init container images")
+			assert.Equal(t, tt.wantMain, gotMain, "main container images")
+		})
+	}
+}
+
+func TestTransformImageRefsNilSafe(t *testing.T) {
+	rewriter := stubRewriter{m: map[string]string{"a": "b"}}
+	require.Equal(t, 0, TransformImageRefs(nil, rewriter), "nil deployment is a no-op")
+	dep := makeDeploymentWithImages(nil, []string{"a"})
+	require.Equal(t, 0, TransformImageRefs(dep, nil), "nil rewriter is a no-op")
+	assert.Equal(t, "a", dep.Spec.Template.Spec.Containers[0].Image)
+}


### PR DESCRIPTION
## Summary

- Adds a CronJob-per-image alternative to the existing DaemonSet image cache, selected by `--image-cache-mode` (`daemonset` default, or `cron`). Designed for EKS Auto Mode, where node churn defeats node-local caching; cron mode pulls images periodically so a pull-through ECR repo stays warm instead.
- vice-operator HTTP API is unchanged. `ImageCacheManager` is now an interface satisfied by `DaemonSetImageCacheManager` and the new `CronJobImageCacheManager`; handlers don't branch. CronJob state maps onto the existing `(ready, desired, status)` triple so the response shape is identical across modes.
- `POST /image-cache/refresh` in cron mode creates a one-off Job from the CronJob's job template (with TTL + OwnerReference back to the CronJob) so "re-pull now" semantics survive the mode switch.
- New `--image-cache-schedule` flag (default `0 2 * * *` UTC) validated at startup via `robfig/cron/v3` — bad expressions fail at boot, not at the first ensure call.
- Splits `operator/imagecache.go` (now >300 lines after adding cron) into three files by entity: `imagecache.go` (types/interface/shared helpers), `imagecache_daemonset.go`, `imagecache_cronjob.go`. Tests follow the same split.
- New design spec at `docs/superpowers/specs/2026-05-27-image-cache-cron-mode-ecr.md` covers the EKS Auto Mode + ECR pull-through rationale, CronJob structure, status mapping, refresh semantics, and what's deferred to IaC.

## Required deployment-side change (RBAC)

Cron mode needs the vice-operator ClusterRole to permit CronJob and Job operations. This repo doesn't carry the production RBAC manifest, so the cluster's vice-operator install must add the following before `--image-cache-mode=cron` is set anywhere:

\`\`\`yaml
- apiGroups: ["batch"]
  resources: ["cronjobs", "jobs"]
  verbs: ["get", "list", "create", "update", "delete"]
\`\`\`

(`watch` is intentionally omitted — the operator only reads on demand and never opens informers on these resources.)

The default-daemonset behavior is unchanged, so this PR is safe to merge before the RBAC update — only the flag flip requires the new permission.

## Test plan

- [x] \`just\` — all 11 binaries build clean
- [x] \`just test\` — full suite passes
- [x] \`golangci-lint run ./operator/... ./cmd/vice-operator/...\` — no issues
- [x] \`just operator-docs\` — no swagger diff (handler signatures unchanged)
- [ ] Manual: start vice-operator with default flags, exercise the `/image-cache` endpoints with curl, confirm DaemonSets appear/disappear (daemonset-mode regression check)
- [ ] Manual: restart with `--image-cache-mode=cron --image-cache-schedule="*/2 * * * *"`, repeat curls, confirm CronJob lifecycle and that `POST /image-cache/refresh` produces a one-off Job
- [ ] EKS smoke: deploy to a non-prod Auto Mode cluster with the RBAC update applied, PUT an image, wait for the cron tick, verify the image appears in the matching ECR pull-through repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)