### PR TITLE
Add operator deactivation and launch-draining

### DIFF
--- a/cmd/vice-operator-tool/client_test.go
+++ b/cmd/vice-operator-tool/client_test.go
@@ -259,6 +259,34 @@ func TestUpdateOperator(t *testing.T) {
 			respBody:   `{"id":"aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa","name":"renamed","url":"https://new.example.com","tls_skip_verify":true,"priority":7}`,
 		},
 		{
+			name: "drain — accepting_launches false only",
+			req:  &operatorclient.UpdateOperatorRequest{AcceptingLaunches: boolPtr(false)},
+			validate: func(t *testing.T, raw []byte, decoded operatorclient.UpdateOperatorRequest) {
+				t.Helper()
+				require.NotNil(t, decoded.AcceptingLaunches)
+				assert.False(t, *decoded.AcceptingLaunches)
+				assert.Nil(t, decoded.Deactivated)
+				assert.Contains(t, string(raw), "accepting_launches")
+				assert.NotContains(t, string(raw), "deactivated")
+			},
+			statusCode: http.StatusOK,
+			respBody:   `{"id":"aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa","name":"orig","url":"https://orig.example.com","tls_skip_verify":false,"priority":0,"accepting_launches":false,"deactivated":false}`,
+		},
+		{
+			name: "deactivate — deactivated true only",
+			req:  &operatorclient.UpdateOperatorRequest{Deactivated: boolPtr(true)},
+			validate: func(t *testing.T, raw []byte, decoded operatorclient.UpdateOperatorRequest) {
+				t.Helper()
+				require.NotNil(t, decoded.Deactivated)
+				assert.True(t, *decoded.Deactivated)
+				assert.Nil(t, decoded.AcceptingLaunches)
+				assert.Contains(t, string(raw), "deactivated")
+				assert.NotContains(t, string(raw), "accepting_launches")
+			},
+			statusCode: http.StatusOK,
+			respBody:   `{"id":"aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa","name":"orig","url":"https://orig.example.com","tls_skip_verify":false,"priority":0,"accepting_launches":true,"deactivated":true}`,
+		},
+		{
 			name:       "404 not found",
 			req:        &operatorclient.UpdateOperatorRequest{Priority: &newPriority},
 			statusCode: http.StatusNotFound,
@@ -327,6 +355,8 @@ func TestUpdateOperator(t *testing.T) {
 // strPtr returns a pointer to the given string. Used to build pointer-typed
 // fields concisely in test table entries.
 func strPtr(s string) *string { return &s }
+
+func boolPtr(b bool) *bool { return &b }
 
 // readAllAndRestore drains r.Body so the test can both inspect the raw
 // JSON and decode it. The body is replaced with a fresh reader so any

--- a/cmd/vice-operator-tool/main.go
+++ b/cmd/vice-operator-tool/main.go
@@ -16,10 +16,15 @@ import (
 const usage = `Usage: vice-operator-tool [--app-exposer-url URL] <command> [flags]
 
 Commands:
-  add      Add a new operator
-  list     List configured operators
-  update   Update an existing operator (partial update by name)
-  delete   Delete an operator by name
+  add         Add a new operator
+  list        List configured operators
+  update      Update an existing operator (partial update by name)
+  delete      Delete an operator by name
+  activate    Re-activate an operator (clear its deactivated flag)
+  deactivate  Deactivate an operator (remove it from the live pool)
+
+The "update" command can also set --accepting-launches (drain) and
+--deactivated alongside other fields.
 
 Use "vice-operator-tool <command> -h" for help on a command.
 `
@@ -53,6 +58,10 @@ func main() {
 		runUpdate(*appExposerURL, subcmdArgs)
 	case "delete":
 		runDelete(*appExposerURL, subcmdArgs)
+	case "activate":
+		runActivate(*appExposerURL, subcmdArgs)
+	case "deactivate":
+		runDeactivate(*appExposerURL, subcmdArgs)
 	default:
 		fmt.Fprintf(os.Stderr, "unknown command: %s\n", subcmd)
 		fmt.Fprint(os.Stderr, usage)
@@ -155,9 +164,9 @@ func runList(baseURLStr string, args []string) {
 	}
 
 	w := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
-	fmt.Fprintln(w, "ID\tNAME\tURL\tBASE_URL\tPRIORITY\tTLS_SKIP_VERIFY") //nolint:errcheck
+	fmt.Fprintln(w, "ID\tNAME\tURL\tBASE_URL\tPRIORITY\tTLS_SKIP_VERIFY\tACCEPTING_LAUNCHES\tDEACTIVATED") //nolint:errcheck
 	for _, op := range ops {
-		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%d\t%v\n", op.ID, op.Name, op.URL, derefOr(op.BaseURL, "-"), op.Priority, op.TLSSkipVerify) //nolint:errcheck
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%d\t%v\t%v\t%v\n", op.ID, op.Name, op.URL, derefOr(op.BaseURL, "-"), op.Priority, op.TLSSkipVerify, op.AcceptingLaunches, op.Deactivated) //nolint:errcheck
 	}
 	if err := w.Flush(); err != nil {
 		fmt.Fprintf(os.Stderr, "error: flushing tabwriter: %v\n", err)
@@ -174,6 +183,8 @@ func runUpdate(baseURLStr string, args []string) {
 	baseURL := fs.String("base-url", "", "New VICE landing-domain base URL")
 	tlsSkip := fs.Bool("tls-skip-verify", false, "Set TLS skip-verify flag")
 	priority := fs.Int("priority", 0, "Set scheduling priority")
+	acceptingLaunches := fs.Bool("accepting-launches", true, "Set whether the operator accepts new launches (false drains it)")
+	deactivated := fs.Bool("deactivated", false, "Set whether the operator is deactivated (true removes it from the live pool)")
 	// ExitOnError means Parse calls os.Exit on failure; it never returns a non-nil error.
 	_ = fs.Parse(args) //nolint:errcheck // see comment above
 
@@ -200,11 +211,16 @@ func runUpdate(baseURLStr string, args []string) {
 			req.TLSSkipVerify = tlsSkip
 		case "priority":
 			req.Priority = priority
+		case "accepting-launches":
+			req.AcceptingLaunches = acceptingLaunches
+		case "deactivated":
+			req.Deactivated = deactivated
 		}
 	})
 
-	if req.Name == nil && req.URL == nil && req.BaseURL == nil && req.TLSSkipVerify == nil && req.Priority == nil {
-		fmt.Fprintln(os.Stderr, "error: at least one of --new-name, --url, --base-url, --tls-skip-verify, --priority must be set")
+	if req.Name == nil && req.URL == nil && req.BaseURL == nil && req.TLSSkipVerify == nil &&
+		req.Priority == nil && req.AcceptingLaunches == nil && req.Deactivated == nil {
+		fmt.Fprintln(os.Stderr, "error: at least one of --new-name, --url, --base-url, --tls-skip-verify, --priority, --accepting-launches, --deactivated must be set")
 		os.Exit(1)
 	}
 
@@ -231,11 +247,11 @@ func runUpdate(baseURLStr string, args []string) {
 	// "old → new" only when they differ to keep the steady-state path
 	// terse.
 	if *name != summary.Name {
-		fmt.Printf("Operator %q → %q updated successfully (id=%s, url=%s, base_url=%s, priority=%d, tls_skip_verify=%v)\n",
-			*name, summary.Name, summary.ID, summary.URL, derefOr(summary.BaseURL, "-"), summary.Priority, summary.TLSSkipVerify)
+		fmt.Printf("Operator %q → %q updated successfully (id=%s, url=%s, base_url=%s, priority=%d, tls_skip_verify=%v, accepting_launches=%v, deactivated=%v)\n",
+			*name, summary.Name, summary.ID, summary.URL, derefOr(summary.BaseURL, "-"), summary.Priority, summary.TLSSkipVerify, summary.AcceptingLaunches, summary.Deactivated)
 	} else {
-		fmt.Printf("Operator %q updated successfully (id=%s, url=%s, base_url=%s, priority=%d, tls_skip_verify=%v)\n",
-			summary.Name, summary.ID, summary.URL, derefOr(summary.BaseURL, "-"), summary.Priority, summary.TLSSkipVerify)
+		fmt.Printf("Operator %q updated successfully (id=%s, url=%s, base_url=%s, priority=%d, tls_skip_verify=%v, accepting_launches=%v, deactivated=%v)\n",
+			summary.Name, summary.ID, summary.URL, derefOr(summary.BaseURL, "-"), summary.Priority, summary.TLSSkipVerify, summary.AcceptingLaunches, summary.Deactivated)
 	}
 }
 
@@ -270,4 +286,47 @@ func runDelete(baseURLStr string, args []string) {
 	}
 
 	fmt.Printf("Operator %q (id=%s) deleted.\n", name, id)
+}
+
+func runActivate(baseURLStr string, args []string) {
+	setDeactivated(baseURLStr, args, false, "activate")
+}
+
+func runDeactivate(baseURLStr string, args []string) {
+	setDeactivated(baseURLStr, args, true, "deactivate")
+}
+
+// setDeactivated toggles the operator's deactivated flag via the same
+// id-keyed PATCH endpoint as update, so a concurrent rename can't redirect
+// the change to a different row. deactivated is the target value; verb names
+// the command for usage/output text.
+func setDeactivated(baseURLStr string, args []string, deactivated bool, verb string) {
+	u := requireBaseURL(baseURLStr)
+
+	fs := flag.NewFlagSet(verb, flag.ExitOnError)
+	// ExitOnError means Parse calls os.Exit on failure; it never returns a non-nil error.
+	_ = fs.Parse(args) //nolint:errcheck // see comment above
+
+	if fs.NArg() != 1 {
+		fmt.Fprintf(os.Stderr, "usage: vice-operator-tool %s <operator-name>\n", verb)
+		os.Exit(1)
+	}
+	name := fs.Arg(0)
+
+	client := NewOperatorClient(u, http.DefaultClient)
+
+	id, err := resolveOperatorID(client, name)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+
+	summary, err := client.UpdateOperator(context.Background(), id, &operatorclient.UpdateOperatorRequest{Deactivated: &deactivated})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("Operator %q (id=%s) %sd (deactivated=%v, accepting_launches=%v).\n",
+		summary.Name, summary.ID, verb, summary.Deactivated, summary.AcceptingLaunches)
 }

--- a/cmd/vice-operator-tool/main.go
+++ b/cmd/vice-operator-tool/main.go
@@ -289,18 +289,18 @@ func runDelete(baseURLStr string, args []string) {
 }
 
 func runActivate(baseURLStr string, args []string) {
-	setDeactivated(baseURLStr, args, false, "activate")
+	setDeactivated(baseURLStr, args, false, "activate", "activated")
 }
 
 func runDeactivate(baseURLStr string, args []string) {
-	setDeactivated(baseURLStr, args, true, "deactivate")
+	setDeactivated(baseURLStr, args, true, "deactivate", "deactivated")
 }
 
 // setDeactivated toggles the operator's deactivated flag via the same
 // id-keyed PATCH endpoint as update, so a concurrent rename can't redirect
 // the change to a different row. deactivated is the target value; verb names
-// the command for usage/output text.
-func setDeactivated(baseURLStr string, args []string, deactivated bool, verb string) {
+// the command for usage text and pastTense labels the success message.
+func setDeactivated(baseURLStr string, args []string, deactivated bool, verb, pastTense string) {
 	u := requireBaseURL(baseURLStr)
 
 	fs := flag.NewFlagSet(verb, flag.ExitOnError)
@@ -327,6 +327,6 @@ func setDeactivated(baseURLStr string, args []string, deactivated bool, verb str
 		os.Exit(1)
 	}
 
-	fmt.Printf("Operator %q (id=%s) %sd (deactivated=%v, accepting_launches=%v).\n",
-		summary.Name, summary.ID, verb, summary.Deactivated, summary.AcceptingLaunches)
+	fmt.Printf("Operator %q (id=%s) %s (deactivated=%v, accepting_launches=%v).\n",
+		summary.Name, summary.ID, pastTense, summary.Deactivated, summary.AcceptingLaunches)
 }

--- a/db/operators.go
+++ b/db/operators.go
@@ -13,16 +13,18 @@ import (
 
 // Operator models the operators table.
 type Operator struct {
-	ID               uuid.UUID  `db:"id"`
-	Name             string     `db:"name"`
-	URL              string     `db:"url"`
-	TLSSkipVerify    bool       `db:"tls_skip_verify"`
-	Priority         int        `db:"priority"`
-	BaseURL          *string    `db:"base_url"`
-	LastReconciledAt *time.Time `db:"last_reconciled_at"`
-	ReconciledBy     *string    `db:"reconciled_by"`
-	CreatedAt        time.Time  `db:"created_at"`
-	UpdatedAt        time.Time  `db:"updated_at"`
+	ID                uuid.UUID  `db:"id"`
+	Name              string     `db:"name"`
+	URL               string     `db:"url"`
+	TLSSkipVerify     bool       `db:"tls_skip_verify"`
+	Priority          int        `db:"priority"`
+	BaseURL           *string    `db:"base_url"`
+	AcceptingLaunches bool       `db:"accepting_launches"`
+	Deactivated       bool       `db:"deactivated"`
+	LastReconciledAt  *time.Time `db:"last_reconciled_at"`
+	ReconciledBy      *string    `db:"reconciled_by"`
+	CreatedAt         time.Time  `db:"created_at"`
+	UpdatedAt         time.Time  `db:"updated_at"`
 }
 
 // JobStatusUpdate models a row in the job_status_updates table. The
@@ -62,19 +64,27 @@ func (o *Operator) ToOperatorConfig() operatorclient.OperatorConfig {
 // update, where the caller needs the row's id without an extra list call.
 func (o *Operator) ToOperatorAdminSummary() operatorclient.OperatorAdminSummary {
 	return operatorclient.OperatorAdminSummary{
-		ID:             o.ID,
-		OperatorConfig: o.ToOperatorConfig(),
+		ID:                o.ID,
+		OperatorConfig:    o.ToOperatorConfig(),
+		AcceptingLaunches: o.AcceptingLaunches,
+		Deactivated:       o.Deactivated,
 	}
 }
 
-// ListOperators returns all operators from the database, ordered by priority
-// (lower values first) with creation time as tiebreaker.
+// ListOperators returns the operators eligible for the live scheduler pool,
+// ordered by priority (lower values first) with creation time as tiebreaker.
+// Deactivated operators are excluded entirely: they take no launches, are not
+// reconciled, and drop out of every scheduler.Clients() fan-out (listing,
+// search, quota, capacity). Drained operators (accepting_launches=false) are
+// retained here — they stay in service and are skipped only at launch time.
 func (d *Database) ListOperators(ctx context.Context) ([]Operator, error) {
 	var ops []Operator
 	const query = `
 		SELECT id, name, url, tls_skip_verify, priority, base_url,
+		       accepting_launches, deactivated,
 		       last_reconciled_at, reconciled_by, created_at, updated_at
 		FROM operators
+		WHERE deactivated = false
 		ORDER BY priority ASC, created_at ASC
 	`
 	err := d.db.SelectContext(ctx, &ops, query)
@@ -88,6 +98,7 @@ func (d *Database) GetOperatorByID(ctx context.Context, id uuid.UUID) (*Operator
 	var op Operator
 	const query = `
 		SELECT id, name, url, tls_skip_verify, priority, base_url,
+		       accepting_launches, deactivated,
 		       last_reconciled_at, reconciled_by, created_at, updated_at
 		FROM operators
 		WHERE id = $1
@@ -106,7 +117,8 @@ func (d *Database) GetOperatorByID(ctx context.Context, id uuid.UUID) (*Operator
 func (d *Database) ListOperatorAdminSummaries(ctx context.Context) ([]operatorclient.OperatorAdminSummary, error) {
 	ops := make([]operatorclient.OperatorAdminSummary, 0)
 	const query = `
-		SELECT id, name, url, tls_skip_verify, priority, base_url
+		SELECT id, name, url, tls_skip_verify, priority, base_url,
+		       accepting_launches, deactivated
 		FROM operators
 		ORDER BY priority ASC, created_at ASC
 	`
@@ -121,6 +133,7 @@ func (d *Database) InsertOperator(ctx context.Context, op *Operator) (*Operator,
 		INSERT INTO operators (name, url, tls_skip_verify, priority, base_url)
 		VALUES ($1, $2, $3, $4, $5)
 		RETURNING id, name, url, tls_skip_verify, priority, base_url,
+		          accepting_launches, deactivated,
 		          last_reconciled_at, reconciled_by, created_at, updated_at
 	`
 	var created Operator
@@ -144,8 +157,9 @@ func (d *Database) DeleteOperatorByID(ctx context.Context, id uuid.UUID) error {
 
 // OperatorUpdate carries the optional fields for a partial-update of an
 // operator row. A nil pointer leaves the column unchanged. The name, url,
-// tls_skip_verify, and priority columns are covered by the AFTER UPDATE
-// NOTIFY trigger; base_url is not (it is consumed by the apps service, not
+// tls_skip_verify, priority, accepting_launches, and deactivated columns are
+// covered by the AFTER UPDATE NOTIFY trigger so scheduler-relevant changes
+// resync immediately; base_url is not (it is consumed by the apps service, not
 // app-exposer's scheduler). Reconciliation columns are intentionally
 // reconciler-only and not exposed here.
 //
@@ -154,11 +168,13 @@ func (d *Database) DeleteOperatorByID(ctx context.Context, id uuid.UUID) error {
 // once set. That is intentional: base_url is required from creation onward,
 // so the only NULL rows are legacy operators that predate the column.
 type OperatorUpdate struct {
-	Name          *string
-	URL           *string
-	TLSSkipVerify *bool
-	Priority      *int
-	BaseURL       *string
+	Name              *string
+	URL               *string
+	TLSSkipVerify     *bool
+	Priority          *int
+	BaseURL           *string
+	AcceptingLaunches *bool
+	Deactivated       *bool
 }
 
 // UpdateOperatorByID applies a partial update to the operator row identified
@@ -170,24 +186,28 @@ type OperatorUpdate struct {
 // the underlying *pq.Error (with Code 23505) on UNIQUE collisions for name
 // or url so the handler layer can map it to 409 Conflict.
 //
-// The AFTER UPDATE OF (name, url, tls_skip_verify, priority) trigger on
-// the operators table fires NOTIFY operator_changed automatically, which
-// the reconciler's pq.Listener picks up to drive an immediate scheduler
-// resync — no explicit pg_notify call is required here.
+// The AFTER UPDATE OF (name, url, tls_skip_verify, priority,
+// accepting_launches, deactivated) trigger on the operators table fires
+// NOTIFY operator_changed automatically, which the reconciler's pq.Listener
+// picks up to drive an immediate scheduler resync — no explicit pg_notify
+// call is required here.
 func (d *Database) UpdateOperatorByID(ctx context.Context, id uuid.UUID, upd OperatorUpdate) (*Operator, error) {
 	const query = `
 		UPDATE operators
-		SET name            = COALESCE($2, name),
-		    url             = COALESCE($3, url),
-		    tls_skip_verify = COALESCE($4, tls_skip_verify),
-		    priority        = COALESCE($5, priority),
-		    base_url        = COALESCE($6, base_url)
+		SET name               = COALESCE($2, name),
+		    url                = COALESCE($3, url),
+		    tls_skip_verify    = COALESCE($4, tls_skip_verify),
+		    priority           = COALESCE($5, priority),
+		    base_url           = COALESCE($6, base_url),
+		    accepting_launches = COALESCE($7, accepting_launches),
+		    deactivated        = COALESCE($8, deactivated)
 		WHERE id = $1
 		RETURNING id, name, url, tls_skip_verify, priority, base_url,
+		          accepting_launches, deactivated,
 		          last_reconciled_at, reconciled_by, created_at, updated_at
 	`
 	var updated Operator
-	err := d.db.QueryRowxContext(ctx, query, id, upd.Name, upd.URL, upd.TLSSkipVerify, upd.Priority, upd.BaseURL).StructScan(&updated)
+	err := d.db.QueryRowxContext(ctx, query, id, upd.Name, upd.URL, upd.TLSSkipVerify, upd.Priority, upd.BaseURL, upd.AcceptingLaunches, upd.Deactivated).StructScan(&updated)
 	if err != nil {
 		return nil, err
 	}
@@ -208,9 +228,11 @@ func (d *Database) ClaimAndReconcile(ctx context.Context, hostname string, recon
 
 	const claimQuery = `
 		SELECT id, name, url, tls_skip_verify, priority, base_url,
+		       accepting_launches, deactivated,
 		       last_reconciled_at, reconciled_by, created_at, updated_at
 		FROM operators
-		WHERE last_reconciled_at IS NULL OR last_reconciled_at < $1
+		WHERE deactivated = false
+		  AND (last_reconciled_at IS NULL OR last_reconciled_at < $1)
 		ORDER BY last_reconciled_at ASC NULLS FIRST
 		FOR UPDATE SKIP LOCKED
 		LIMIT 1

--- a/db/operators_test.go
+++ b/db/operators_test.go
@@ -85,12 +85,13 @@ func TestUpdateOperatorByID(t *testing.T) {
 	id := uuid.MustParse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
 	now := time.Now()
 
-	const expectedSQL = `UPDATE operators SET name = COALESCE($2, name), url = COALESCE($3, url), tls_skip_verify = COALESCE($4, tls_skip_verify), priority = COALESCE($5, priority), base_url = COALESCE($6, base_url) WHERE id = $1 RETURNING id, name, url, tls_skip_verify, priority, base_url, last_reconciled_at, reconciled_by, created_at, updated_at`
+	const expectedSQL = `UPDATE operators SET name = COALESCE($2, name), url = COALESCE($3, url), tls_skip_verify = COALESCE($4, tls_skip_verify), priority = COALESCE($5, priority), base_url = COALESCE($6, base_url), accepting_launches = COALESCE($7, accepting_launches), deactivated = COALESCE($8, deactivated) WHERE id = $1 RETURNING id, name, url, tls_skip_verify, priority, base_url, accepting_launches, deactivated, last_reconciled_at, reconciled_by, created_at, updated_at`
 
 	// returnedColumns matches the RETURNING list so StructScan can populate
 	// the *Operator struct on the success path.
 	returnedColumns := []string{
 		"id", "name", "url", "tls_skip_verify", "priority", "base_url",
+		"accepting_launches", "deactivated",
 		"last_reconciled_at", "reconciled_by", "created_at", "updated_at",
 	}
 
@@ -102,8 +103,9 @@ func TestUpdateOperatorByID(t *testing.T) {
 		name string
 		upd  OperatorUpdate
 		// wantArgs is the argument slice in the order the production query
-		// binds them: [id, name, url, tls_skip_verify, priority, base_url].
-		// Any driver.Value here is matched literally; nil represents SQL NULL.
+		// binds them: [id, name, url, tls_skip_verify, priority, base_url,
+		// accepting_launches, deactivated]. Any driver.Value here is matched
+		// literally; nil represents SQL NULL.
 		wantArgs []driver.Value
 		// dbErr is what sqlmock returns; nil means "succeed and return a row".
 		dbErr error
@@ -111,39 +113,51 @@ func TestUpdateOperatorByID(t *testing.T) {
 		{
 			name:     "single field — priority only",
 			upd:      OperatorUpdate{Priority: intPtr(7)},
-			wantArgs: []driver.Value{id.String(), nil, nil, nil, int64(7), nil},
+			wantArgs: []driver.Value{id.String(), nil, nil, nil, int64(7), nil, nil, nil},
 		},
 		{
 			name:     "rename only",
 			upd:      OperatorUpdate{Name: strPtr("renamed")},
-			wantArgs: []driver.Value{id.String(), "renamed", nil, nil, nil, nil},
+			wantArgs: []driver.Value{id.String(), "renamed", nil, nil, nil, nil, nil, nil},
 		},
 		{
 			name:     "base_url only",
 			upd:      OperatorUpdate{BaseURL: strPtr("https://a.cyverse.run")},
-			wantArgs: []driver.Value{id.String(), nil, nil, nil, nil, "https://a.cyverse.run"},
+			wantArgs: []driver.Value{id.String(), nil, nil, nil, nil, "https://a.cyverse.run", nil, nil},
+		},
+		{
+			name:     "drain — accepting_launches only",
+			upd:      OperatorUpdate{AcceptingLaunches: boolPtr(false)},
+			wantArgs: []driver.Value{id.String(), nil, nil, nil, nil, nil, false, nil},
+		},
+		{
+			name:     "deactivate — deactivated only",
+			upd:      OperatorUpdate{Deactivated: boolPtr(true)},
+			wantArgs: []driver.Value{id.String(), nil, nil, nil, nil, nil, nil, true},
 		},
 		{
 			name: "all fields",
 			upd: OperatorUpdate{
-				Name:          strPtr("a"),
-				URL:           strPtr("https://a.example.com"),
-				TLSSkipVerify: boolPtr(true),
-				Priority:      intPtr(2),
-				BaseURL:       strPtr("https://a.cyverse.run"),
+				Name:              strPtr("a"),
+				URL:               strPtr("https://a.example.com"),
+				TLSSkipVerify:     boolPtr(true),
+				Priority:          intPtr(2),
+				BaseURL:           strPtr("https://a.cyverse.run"),
+				AcceptingLaunches: boolPtr(false),
+				Deactivated:       boolPtr(true),
 			},
-			wantArgs: []driver.Value{id.String(), "a", "https://a.example.com", true, int64(2), "https://a.cyverse.run"},
+			wantArgs: []driver.Value{id.String(), "a", "https://a.example.com", true, int64(2), "https://a.cyverse.run", false, true},
 		},
 		{
 			name:     "no row matches — surfaces sql.ErrNoRows from RETURNING",
 			upd:      OperatorUpdate{Priority: intPtr(1)},
-			wantArgs: []driver.Value{id.String(), nil, nil, nil, int64(1), nil},
+			wantArgs: []driver.Value{id.String(), nil, nil, nil, int64(1), nil, nil, nil},
 			dbErr:    sql.ErrNoRows,
 		},
 		{
 			name:     "unique violation — surfaces *pq.Error 23505",
 			upd:      OperatorUpdate{Name: strPtr("dup")},
-			wantArgs: []driver.Value{id.String(), "dup", nil, nil, nil, nil},
+			wantArgs: []driver.Value{id.String(), "dup", nil, nil, nil, nil, nil, nil},
 			dbErr:    &pq.Error{Code: "23505", Message: "duplicate key value violates unique constraint"},
 		},
 	}
@@ -159,7 +173,7 @@ func TestUpdateOperatorByID(t *testing.T) {
 				expect.WillReturnError(tt.dbErr)
 			} else {
 				rows := sqlmock.NewRows(returnedColumns).
-					AddRow(id, "n", "https://u", false, 0, sql.NullString{}, sql.NullTime{}, sql.NullString{}, now, now)
+					AddRow(id, "n", "https://u", false, 0, sql.NullString{}, true, false, sql.NullTime{}, sql.NullString{}, now, now)
 				expect.WillReturnRows(rows)
 			}
 

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -3044,9 +3044,16 @@ const docTemplate = `{
         "operatorclient.OperatorAdminSummary": {
             "type": "object",
             "properties": {
+                "accepting_launches": {
+                    "description": "AcceptingLaunches and Deactivated are operational state, not part of the\ncreate-time OperatorConfig: new operators take the DB defaults\n(accepting_launches=true, deactivated=false). When false,\nAcceptingLaunches drains the operator (no new launches, otherwise in\nservice); Deactivated fully removes it from the live pool and takes\nprecedence over AcceptingLaunches.",
+                    "type": "boolean"
+                },
                 "base_url": {
                     "description": "required at create; nil only for legacy rows",
                     "type": "string"
+                },
+                "deactivated": {
+                    "type": "boolean"
                 },
                 "id": {
                     "type": "string"
@@ -3100,8 +3107,14 @@ const docTemplate = `{
         "operatorclient.UpdateOperatorRequest": {
             "type": "object",
             "properties": {
+                "accepting_launches": {
+                    "type": "boolean"
+                },
                 "base_url": {
                     "type": "string"
+                },
+                "deactivated": {
+                    "type": "boolean"
                 },
                 "name": {
                     "type": "string"

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -3038,9 +3038,16 @@
         "operatorclient.OperatorAdminSummary": {
             "type": "object",
             "properties": {
+                "accepting_launches": {
+                    "description": "AcceptingLaunches and Deactivated are operational state, not part of the\ncreate-time OperatorConfig: new operators take the DB defaults\n(accepting_launches=true, deactivated=false). When false,\nAcceptingLaunches drains the operator (no new launches, otherwise in\nservice); Deactivated fully removes it from the live pool and takes\nprecedence over AcceptingLaunches.",
+                    "type": "boolean"
+                },
                 "base_url": {
                     "description": "required at create; nil only for legacy rows",
                     "type": "string"
+                },
+                "deactivated": {
+                    "type": "boolean"
                 },
                 "id": {
                     "type": "string"
@@ -3094,8 +3101,14 @@
         "operatorclient.UpdateOperatorRequest": {
             "type": "object",
             "properties": {
+                "accepting_launches": {
+                    "type": "boolean"
+                },
                 "base_url": {
                     "type": "string"
+                },
+                "deactivated": {
+                    "type": "boolean"
                 },
                 "name": {
                     "type": "string"

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -938,9 +938,20 @@ definitions:
     type: object
   operatorclient.OperatorAdminSummary:
     properties:
+      accepting_launches:
+        description: |-
+          AcceptingLaunches and Deactivated are operational state, not part of the
+          create-time OperatorConfig: new operators take the DB defaults
+          (accepting_launches=true, deactivated=false). When false,
+          AcceptingLaunches drains the operator (no new launches, otherwise in
+          service); Deactivated fully removes it from the live pool and takes
+          precedence over AcceptingLaunches.
+        type: boolean
       base_url:
         description: required at create; nil only for legacy rows
         type: string
+      deactivated:
+        type: boolean
       id:
         type: string
       name:
@@ -975,8 +986,12 @@ definitions:
     type: object
   operatorclient.UpdateOperatorRequest:
     properties:
+      accepting_launches:
+        type: boolean
       base_url:
         type: string
+      deactivated:
+        type: boolean
       name:
         type: string
       priority:

--- a/httphandlers/canonical_url_test.go
+++ b/httphandlers/canonical_url_test.go
@@ -155,6 +155,7 @@ func (f *fakeOperator) summary(baseURL *string) operatorclient.OperatorAdminSumm
 			URL:     f.server.URL,
 			BaseURL: baseURL,
 		},
+		AcceptingLaunches: true,
 	}
 }
 

--- a/httphandlers/canonical_url_test.go
+++ b/httphandlers/canonical_url_test.go
@@ -27,13 +27,14 @@ import (
 // values even in fixtures.
 var operatorRowColumns = []string{
 	"id", "name", "url", "tls_skip_verify", "priority", "base_url",
+	"accepting_launches", "deactivated",
 	"last_reconciled_at", "reconciled_by", "created_at", "updated_at",
 }
 
 func operatorRow(id uuid.UUID, name, opURL string, baseURL any) *sqlmock.Rows {
 	now := time.Now()
 	return sqlmock.NewRows(operatorRowColumns).
-		AddRow(id, name, opURL, false, 0, baseURL,
+		AddRow(id, name, opURL, false, 0, baseURL, true, false,
 			sql.NullTime{}, sql.NullString{}, now, now)
 }
 
@@ -199,7 +200,7 @@ func TestAdminCanonicalURLHandler(t *testing.T) {
 			bystander.summary(nil),
 		})
 
-		mock.ExpectQuery(`SELECT id, name, url, tls_skip_verify, priority, base_url, last_reconciled_at, reconciled_by, created_at, updated_at FROM operators WHERE id = $1`).
+		mock.ExpectQuery(`SELECT id, name, url, tls_skip_verify, priority, base_url, accepting_launches, deactivated, last_reconciled_at, reconciled_by, created_at, updated_at FROM operators WHERE id = $1`).
 			WithArgs(owner.id).
 			WillReturnRows(operatorRow(owner.id, "aws", owner.server.URL, baseURL))
 
@@ -245,7 +246,7 @@ func TestAdminCanonicalURLHandler(t *testing.T) {
 			owner.summary(nil),
 		})
 
-		mock.ExpectQuery(`SELECT id, name, url, tls_skip_verify, priority, base_url, last_reconciled_at, reconciled_by, created_at, updated_at FROM operators WHERE id = $1`).
+		mock.ExpectQuery(`SELECT id, name, url, tls_skip_verify, priority, base_url, accepting_launches, deactivated, last_reconciled_at, reconciled_by, created_at, updated_at FROM operators WHERE id = $1`).
 			WithArgs(owner.id).
 			WillReturnRows(operatorRow(owner.id, "legacy", owner.server.URL, sql.NullString{}))
 
@@ -262,7 +263,7 @@ func TestAdminCanonicalURLHandler(t *testing.T) {
 			owner.summary(nil),
 		})
 
-		mock.ExpectQuery(`SELECT id, name, url, tls_skip_verify, priority, base_url, last_reconciled_at, reconciled_by, created_at, updated_at FROM operators WHERE id = $1`).
+		mock.ExpectQuery(`SELECT id, name, url, tls_skip_verify, priority, base_url, accepting_launches, deactivated, last_reconciled_at, reconciled_by, created_at, updated_at FROM operators WHERE id = $1`).
 			WithArgs(owner.id).
 			WillReturnError(sql.ErrNoRows)
 

--- a/httphandlers/handlers.go
+++ b/httphandlers/handlers.go
@@ -659,7 +659,8 @@ func (h *HTTPHandlers) UpdateOperatorHandler(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
 
-	if req.Name == nil && req.URL == nil && req.TLSSkipVerify == nil && req.Priority == nil && req.BaseURL == nil {
+	if req.Name == nil && req.URL == nil && req.TLSSkipVerify == nil && req.Priority == nil &&
+		req.BaseURL == nil && req.AcceptingLaunches == nil && req.Deactivated == nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "request body must update at least one field")
 	}
 
@@ -668,11 +669,13 @@ func (h *HTTPHandlers) UpdateOperatorHandler(c echo.Context) error {
 	}
 
 	updated, err := h.db.UpdateOperatorByID(ctx, id, db.OperatorUpdate{
-		Name:          req.Name,
-		URL:           req.URL,
-		TLSSkipVerify: req.TLSSkipVerify,
-		Priority:      req.Priority,
-		BaseURL:       req.BaseURL,
+		Name:              req.Name,
+		URL:               req.URL,
+		TLSSkipVerify:     req.TLSSkipVerify,
+		Priority:          req.Priority,
+		BaseURL:           req.BaseURL,
+		AcceptingLaunches: req.AcceptingLaunches,
+		Deactivated:       req.Deactivated,
 	})
 	if errors.Is(err, sql.ErrNoRows) {
 		return echo.NewHTTPError(http.StatusNotFound, "operator not found")

--- a/operatorclient/client.go
+++ b/operatorclient/client.go
@@ -49,10 +49,11 @@ func (e *HTTPStatusError) Transient() bool {
 
 // Client communicates with a single vice-operator instance via HTTP.
 type Client struct {
-	id      uuid.UUID
-	name    string
-	baseURL *url.URL
-	http    *http.Client
+	id                uuid.UUID
+	name              string
+	baseURL           *url.URL
+	http              *http.Client
+	acceptingLaunches bool
 }
 
 // NewClient creates a new operator Client from an OperatorAdminSummary
@@ -85,9 +86,10 @@ func NewClient(summary OperatorAdminSummary, ts oauth2.TokenSource) (*Client, er
 	}
 
 	return &Client{
-		id:      summary.ID,
-		name:    summary.Name,
-		baseURL: u,
+		id:                summary.ID,
+		name:              summary.Name,
+		baseURL:           u,
+		acceptingLaunches: summary.AcceptingLaunches,
 		http: &http.Client{
 			Transport: otelhttp.NewTransport(transport),
 			Timeout:   30 * time.Second,
@@ -129,6 +131,13 @@ func (c *Client) Name() string {
 // by id rather than name.
 func (c *Client) ID() uuid.UUID {
 	return c.id
+}
+
+// AcceptingLaunches reports whether this operator should receive new launches.
+// When false the operator is draining: the scheduler skips it for new work but
+// it remains in the pool so its running analyses stay listable and reconciled.
+func (c *Client) AcceptingLaunches() bool {
+	return c.acceptingLaunches
 }
 
 // Capacity queries the operator for its current cluster capacity.

--- a/operatorclient/client_test.go
+++ b/operatorclient/client_test.go
@@ -43,8 +43,17 @@ func TestNewClient(t *testing.T) {
 		{
 			name: "valid URL",
 			summary: OperatorAdminSummary{
-				ID:             uuid.New(),
-				OperatorConfig: OperatorConfig{Name: "op-a", URL: "http://op-a.example.invalid"},
+				ID:                uuid.New(),
+				OperatorConfig:    OperatorConfig{Name: "op-a", URL: "http://op-a.example.invalid"},
+				AcceptingLaunches: true,
+			},
+		},
+		{
+			name: "draining operator carries AcceptingLaunches=false",
+			summary: OperatorAdminSummary{
+				ID:                uuid.New(),
+				OperatorConfig:    OperatorConfig{Name: "op-drain", URL: "http://op-drain.example.invalid"},
+				AcceptingLaunches: false,
 			},
 		},
 		{
@@ -82,6 +91,7 @@ func TestNewClient(t *testing.T) {
 			require.NoError(t, err)
 			assert.Equal(t, tt.summary.Name, c.Name())
 			assert.Equal(t, tt.summary.ID, c.ID())
+			assert.Equal(t, tt.summary.AcceptingLaunches, c.AcceptingLaunches())
 			assert.NotNil(t, c.http, "http client must be initialized")
 			assert.Equal(t, 30*time.Second, c.http.Timeout)
 		})

--- a/operatorclient/scheduler.go
+++ b/operatorclient/scheduler.go
@@ -274,8 +274,10 @@ func (s *Scheduler) LaunchAnalysis(ctx context.Context, bundle *AnalysisBundle) 
 			len(clients), bundle.AnalysisID, ErrAllOperatorsDraining)
 	}
 
-	// Every operator's capacity check failed (all returned errors).
-	if capacityErrors == len(clients) {
+	// Every non-draining operator's capacity check failed. Draining operators
+	// are folded into the accounted-for total so this precise diagnostic still
+	// fires when the remaining operators all failed their capacity check.
+	if capacityErrors > 0 && capacityErrors+drainingSkips == len(clients) {
 		return uuid.Nil, "", fmt.Errorf("all %d operators failed capacity check: %w", len(clients), ErrAllOperatorsExhausted)
 	}
 
@@ -297,11 +299,15 @@ func (s *Scheduler) LaunchAnalysis(ctx context.Context, bundle *AnalysisBundle) 
 			wantModels, bundle.AnalysisID, ErrNoCompatibleModel)
 	}
 
-	// Every operator that passed capacity check then failed the launch for
-	// transient reasons. Surface the last underlying error so the caller
-	// can distinguish it from a real "all at capacity" situation.
+	// At least one operator passed capacity check then failed the launch for
+	// transient reasons, and every operator is now accounted for by some
+	// skip/failure bucket. Surface the last transient error so the caller can
+	// distinguish it from a real "all at capacity" situation. The message says
+	// "could not accept" rather than "unhealthy" because the accounted-for set
+	// may also include draining or at-capacity operators, which aren't unhealthy.
 	if transientErrors > 0 && capacityErrors+transientErrors+vendorMismatches+modelMismatches+drainingSkips == len(clients) {
-		return uuid.Nil, "", fmt.Errorf("all %d operators unhealthy; last error: %w", len(clients), lastTransient)
+		return uuid.Nil, "", fmt.Errorf("no operator could accept analysis %s (%d operators, last transient error): %w",
+			bundle.AnalysisID, len(clients), lastTransient)
 	}
 
 	return uuid.Nil, "", ErrAllOperatorsExhausted

--- a/operatorclient/scheduler.go
+++ b/operatorclient/scheduler.go
@@ -58,6 +58,12 @@ var (
 	// or returned a 409 Conflict during the launch attempt.
 	ErrAllOperatorsExhausted = errors.New("all operators at capacity")
 
+	// ErrAllOperatorsDraining means every operator in the pool is draining
+	// (accepting_launches=false), so none can take a new launch. Distinct
+	// from ErrAllOperatorsExhausted so callers can tell a deliberate drain
+	// apart from a genuine capacity shortfall.
+	ErrAllOperatorsDraining = errors.New("all operators draining (not accepting launches)")
+
 	// ErrNoCompatibleOperator means every operator with capacity reported
 	// a GPU vendor incompatible with the analysis's request. Distinct from
 	// ErrAllOperatorsExhausted so callers can tell a routing-policy failure
@@ -186,6 +192,7 @@ func (s *Scheduler) LaunchAnalysis(ctx context.Context, bundle *AnalysisBundle) 
 		transientErrors  int
 		vendorMismatches int
 		modelMismatches  int
+		drainingSkips    int
 		lastTransient    error
 	)
 
@@ -193,6 +200,14 @@ func (s *Scheduler) LaunchAnalysis(ctx context.Context, bundle *AnalysisBundle) 
 	wantModels := bundle.RequestedGPUModels()
 
 	for _, op := range clients {
+		// Skip operators that are draining: they stay in the pool to serve
+		// their existing analyses but must not receive new launches.
+		if !op.AcceptingLaunches() {
+			drainingSkips++
+			log.Infof("operator %s not accepting launches (draining); skipping", op.Name())
+			continue
+		}
+
 		// Check capacity first.
 		cap, err := op.Capacity(ctx)
 		if err != nil {
@@ -251,6 +266,14 @@ func (s *Scheduler) LaunchAnalysis(ctx context.Context, bundle *AnalysisBundle) 
 		return op.ID(), op.Name(), nil
 	}
 
+	// Every operator is draining: none could take the launch by policy, not
+	// because of capacity or health. Surface this distinctly so the caller
+	// isn't misled into reporting a capacity shortfall.
+	if drainingSkips == len(clients) {
+		return uuid.Nil, "", fmt.Errorf("all %d operators draining for analysis %s: %w",
+			len(clients), bundle.AnalysisID, ErrAllOperatorsDraining)
+	}
+
 	// Every operator's capacity check failed (all returned errors).
 	if capacityErrors == len(clients) {
 		return uuid.Nil, "", fmt.Errorf("all %d operators failed capacity check: %w", len(clients), ErrAllOperatorsExhausted)
@@ -258,8 +281,10 @@ func (s *Scheduler) LaunchAnalysis(ctx context.Context, bundle *AnalysisBundle) 
 
 	// No operator advertised a compatible GPU vendor. Distinct from the
 	// at-capacity / unhealthy buckets so callers can surface a routing-
-	// policy error rather than a misleading "at capacity" message.
-	if wantVendor != "" && vendorMismatches > 0 && capacityErrors+vendorMismatches == len(clients) {
+	// policy error rather than a misleading "at capacity" message. Draining
+	// operators are folded into the accounted-for total so the precise error
+	// still fires when the non-draining operators are all vendor mismatches.
+	if wantVendor != "" && vendorMismatches > 0 && capacityErrors+vendorMismatches+drainingSkips == len(clients) {
 		return uuid.Nil, "", fmt.Errorf("no operator with vendor %s for analysis %s: %w",
 			wantVendor, bundle.AnalysisID, ErrNoCompatibleOperator)
 	}
@@ -267,7 +292,7 @@ func (s *Scheduler) LaunchAnalysis(ctx context.Context, bundle *AnalysisBundle) 
 	// No operator advertised a compatible GPU model. Surface this distinctly
 	// so callers can tell "right vendor, wrong model" apart from
 	// ErrNoCompatibleOperator and ErrAllOperatorsExhausted.
-	if len(wantModels) > 0 && modelMismatches > 0 && capacityErrors+vendorMismatches+modelMismatches == len(clients) {
+	if len(wantModels) > 0 && modelMismatches > 0 && capacityErrors+vendorMismatches+modelMismatches+drainingSkips == len(clients) {
 		return uuid.Nil, "", fmt.Errorf("no operator with model %v for analysis %s: %w",
 			wantModels, bundle.AnalysisID, ErrNoCompatibleModel)
 	}
@@ -275,7 +300,7 @@ func (s *Scheduler) LaunchAnalysis(ctx context.Context, bundle *AnalysisBundle) 
 	// Every operator that passed capacity check then failed the launch for
 	// transient reasons. Surface the last underlying error so the caller
 	// can distinguish it from a real "all at capacity" situation.
-	if transientErrors > 0 && capacityErrors+transientErrors+vendorMismatches+modelMismatches == len(clients) {
+	if transientErrors > 0 && capacityErrors+transientErrors+vendorMismatches+modelMismatches+drainingSkips == len(clients) {
 		return uuid.Nil, "", fmt.Errorf("all %d operators unhealthy; last error: %w", len(clients), lastTransient)
 	}
 

--- a/operatorclient/scheduler_test.go
+++ b/operatorclient/scheduler_test.go
@@ -287,6 +287,29 @@ func TestSchedulerLaunchAllCapacityChecksFail(t *testing.T) {
 	assert.Contains(t, err.Error(), "failed capacity check", "message should distinguish capacity-failure from at-capacity")
 }
 
+// TestSchedulerLaunchDrainingPlusCapacityFail covers the mixed pool where one
+// operator is draining and every remaining operator fails its capacity check.
+// The draining operator is folded into the accounted-for total so the precise
+// "failed capacity check" diagnostic still fires rather than falling through to
+// the bare ErrAllOperatorsExhausted.
+func TestSchedulerLaunchDrainingPlusCapacityFail(t *testing.T) {
+	draining := mockOperatorServer(5, false) // healthy, but not accepting launches
+	defer draining.Close()
+	broken := mockOperatorServerWithStatuses(0, false, http.StatusInternalServerError, 0, "")
+	defer broken.Close()
+
+	scheduler := NewScheduler(nil)
+	require.NoError(t, scheduler.Sync([]OperatorAdminSummary{
+		{ID: uuid.New(), OperatorConfig: OperatorConfig{Name: "op-drain", URL: draining.URL}, AcceptingLaunches: false},
+		{ID: uuid.New(), OperatorConfig: OperatorConfig{Name: "op-broken", URL: broken.URL}, AcceptingLaunches: true},
+	}))
+
+	_, _, err := scheduler.LaunchAnalysis(context.Background(), &AnalysisBundle{AnalysisID: "test"})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrAllOperatorsExhausted)
+	assert.Contains(t, err.Error(), "failed capacity check", "draining operators must not suppress the capacity-failure diagnostic")
+}
+
 // TestSchedulerLaunchTransientErrorFalthrough covers the case added along
 // with isTransientLaunchError: the first operator accepts capacity but then
 // returns a 5xx on Launch. The scheduler should fall through to the next
@@ -345,7 +368,7 @@ func TestSchedulerLaunchAllTransient(t *testing.T) {
 
 	_, _, err := scheduler.LaunchAnalysis(context.Background(), &AnalysisBundle{AnalysisID: "test"})
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "unhealthy", "message should distinguish from at-capacity")
+	assert.Contains(t, err.Error(), "could accept", "message should distinguish from at-capacity")
 
 	var statusErr *HTTPStatusError
 	require.ErrorAs(t, err, &statusErr, "last transient error must be preserved in the chain")

--- a/operatorclient/scheduler_test.go
+++ b/operatorclient/scheduler_test.go
@@ -28,8 +28,9 @@ func schedulerWithConfigs(t *testing.T, configs []OperatorConfig) *Scheduler {
 	summaries := make([]OperatorAdminSummary, len(configs))
 	for i, cfg := range configs {
 		summaries[i] = OperatorAdminSummary{
-			ID:             uuid.New(),
-			OperatorConfig: cfg,
+			ID:                uuid.New(),
+			OperatorConfig:    cfg,
+			AcceptingLaunches: true,
 		}
 	}
 	s := NewScheduler(nil)
@@ -191,6 +192,68 @@ func TestSchedulerLaunchAnalysis(t *testing.T) {
 
 			bundle := &AnalysisBundle{AnalysisID: "test-123"}
 			_, operatorName, err := scheduler.LaunchAnalysis(context.Background(), bundle)
+
+			if tt.wantErr != nil {
+				assert.ErrorIs(t, err, tt.wantErr)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.wantOperator, operatorName)
+			}
+		})
+	}
+}
+
+// TestSchedulerLaunchSkipsDrainingOperators verifies that operators with
+// AcceptingLaunches=false are skipped for new launches: a following operator
+// that is accepting receives the analysis, and when every operator is draining
+// the scheduler reports ErrAllOperatorsDraining rather than a misleading
+// capacity error.
+func TestSchedulerLaunchSkipsDrainingOperators(t *testing.T) {
+	type op struct {
+		accepting bool
+		slots     int
+	}
+	tests := []struct {
+		name         string
+		operators    []op
+		wantOperator string
+		wantErr      error
+	}{
+		{
+			name:         "draining first operator is skipped for accepting second",
+			operators:    []op{{accepting: false, slots: 5}, {accepting: true, slots: 5}},
+			wantOperator: "op-1",
+		},
+		{
+			name:      "all draining returns ErrAllOperatorsDraining",
+			operators: []op{{accepting: false, slots: 5}, {accepting: false, slots: 5}},
+			wantErr:   ErrAllOperatorsDraining,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			summaries := make([]OperatorAdminSummary, 0, len(tt.operators))
+			var servers []*httptest.Server
+			for i, o := range tt.operators {
+				srv := mockOperatorServer(o.slots, false)
+				servers = append(servers, srv)
+				summaries = append(summaries, OperatorAdminSummary{
+					ID:                uuid.New(),
+					OperatorConfig:    OperatorConfig{Name: fmt.Sprintf("op-%d", i), URL: srv.URL},
+					AcceptingLaunches: o.accepting,
+				})
+			}
+			defer func() {
+				for _, srv := range servers {
+					srv.Close()
+				}
+			}()
+
+			scheduler := NewScheduler(nil)
+			require.NoError(t, scheduler.Sync(summaries))
+
+			_, operatorName, err := scheduler.LaunchAnalysis(context.Background(), &AnalysisBundle{AnalysisID: "drain-test"})
 
 			if tt.wantErr != nil {
 				assert.ErrorIs(t, err, tt.wantErr)
@@ -540,7 +603,7 @@ func TestSchedulerClientByID(t *testing.T) {
 	id := uuid.New()
 	scheduler := NewScheduler(nil)
 	require.NoError(t, scheduler.Sync([]OperatorAdminSummary{
-		{ID: id, OperatorConfig: OperatorConfig{Name: "test-op", URL: srv.URL}},
+		{ID: id, OperatorConfig: OperatorConfig{Name: "test-op", URL: srv.URL}, AcceptingLaunches: true},
 	}))
 
 	client := scheduler.ClientByID(id)
@@ -552,7 +615,7 @@ func TestSchedulerClientByID(t *testing.T) {
 
 	// Rename the operator (same id) and verify the lookup still works.
 	require.NoError(t, scheduler.Sync([]OperatorAdminSummary{
-		{ID: id, OperatorConfig: OperatorConfig{Name: "renamed", URL: srv.URL}},
+		{ID: id, OperatorConfig: OperatorConfig{Name: "renamed", URL: srv.URL}, AcceptingLaunches: true},
 	}))
 	client = scheduler.ClientByID(id)
 	require.NotNil(t, client, "id-keyed lookup must survive a rename")
@@ -606,7 +669,7 @@ func TestSchedulerSyncAndSetTokenSource(t *testing.T) {
 	defer srv0.Close()
 
 	origSummaries := []OperatorAdminSummary{
-		{ID: uuid.New(), OperatorConfig: OperatorConfig{Name: "original-op", URL: srv0.URL}},
+		{ID: uuid.New(), OperatorConfig: OperatorConfig{Name: "original-op", URL: srv0.URL}, AcceptingLaunches: true},
 	}
 	scheduler := NewScheduler(nil)
 	require.NoError(t, scheduler.Sync(origSummaries))
@@ -621,8 +684,8 @@ func TestSchedulerSyncAndSetTokenSource(t *testing.T) {
 	defer srv2.Close()
 
 	newSummaries := []OperatorAdminSummary{
-		{ID: uuid.New(), OperatorConfig: OperatorConfig{Name: "new-op-0", URL: srv1.URL}},
-		{ID: uuid.New(), OperatorConfig: OperatorConfig{Name: "new-op-1", URL: srv2.URL}},
+		{ID: uuid.New(), OperatorConfig: OperatorConfig{Name: "new-op-0", URL: srv1.URL}, AcceptingLaunches: true},
+		{ID: uuid.New(), OperatorConfig: OperatorConfig{Name: "new-op-1", URL: srv2.URL}, AcceptingLaunches: true},
 	}
 	require.NoError(t, scheduler.Sync(newSummaries))
 

--- a/operatorclient/types.go
+++ b/operatorclient/types.go
@@ -326,9 +326,10 @@ type OperatorConfig struct {
 // OperatorAdminSummary is the admin-facing listing shape for operators.
 // It extends OperatorConfig (via embedding) with the row's UUID so admin
 // clients can address an operator by id — which is stable across renames
-// — rather than by name. JSON marshalling and sqlx column scans both
-// flatten the embedded struct, so the wire format is the six fields
-// {id, name, url, base_url, tls_skip_verify, priority}.
+// — rather than by name, plus the operational-state flags below. JSON
+// marshalling and sqlx column scans both flatten the embedded struct, so the
+// wire format is the embedded OperatorConfig fields alongside id,
+// accepting_launches, and deactivated.
 type OperatorAdminSummary struct {
 	ID uuid.UUID `json:"id" db:"id"`
 	OperatorConfig

--- a/operatorclient/types.go
+++ b/operatorclient/types.go
@@ -332,6 +332,14 @@ type OperatorConfig struct {
 type OperatorAdminSummary struct {
 	ID uuid.UUID `json:"id" db:"id"`
 	OperatorConfig
+	// AcceptingLaunches and Deactivated are operational state, not part of the
+	// create-time OperatorConfig: new operators take the DB defaults
+	// (accepting_launches=true, deactivated=false). When false,
+	// AcceptingLaunches drains the operator (no new launches, otherwise in
+	// service); Deactivated fully removes it from the live pool and takes
+	// precedence over AcceptingLaunches.
+	AcceptingLaunches bool `json:"accepting_launches" db:"accepting_launches"`
+	Deactivated       bool `json:"deactivated" db:"deactivated"`
 }
 
 // UpdateOperatorRequest is the body for PATCH
@@ -341,9 +349,11 @@ type OperatorAdminSummary struct {
 // set it to the zero value" — a value-typed shape would silently force
 // priority=0 / tls_skip_verify=false on every PATCH that omitted them.
 type UpdateOperatorRequest struct {
-	Name          *string `json:"name,omitempty"`
-	URL           *string `json:"url,omitempty"`
-	TLSSkipVerify *bool   `json:"tls_skip_verify,omitempty"`
-	Priority      *int    `json:"priority,omitempty"`
-	BaseURL       *string `json:"base_url,omitempty"`
+	Name              *string `json:"name,omitempty"`
+	URL               *string `json:"url,omitempty"`
+	TLSSkipVerify     *bool   `json:"tls_skip_verify,omitempty"`
+	Priority          *int    `json:"priority,omitempty"`
+	BaseURL           *string `json:"base_url,omitempty"`
+	AcceptingLaunches *bool   `json:"accepting_launches,omitempty"`
+	Deactivated       *bool   `json:"deactivated,omitempty"`
 }

--- a/quota/enforcer_test.go
+++ b/quota/enforcer_test.go
@@ -85,8 +85,9 @@ func newTestScheduler(t *testing.T, operators ...operatorclient.OperatorConfig) 
 	summaries := make([]operatorclient.OperatorAdminSummary, len(operators))
 	for i, op := range operators {
 		summaries[i] = operatorclient.OperatorAdminSummary{
-			ID:             uuid.New(),
-			OperatorConfig: op,
+			ID:                uuid.New(),
+			OperatorConfig:    op,
+			AcceptingLaunches: true,
 		}
 	}
 	s := operatorclient.NewScheduler(nil)

--- a/reconciler/reconciler_test.go
+++ b/reconciler/reconciler_test.go
@@ -422,7 +422,7 @@ func TestReconcileNext(t *testing.T) {
 		// must match claimOp.ID because ReconcileNext looks up the
 		// scheduler client by id, not name.
 		require.NoError(t, r.scheduler.Sync([]operatorclient.OperatorAdminSummary{
-			{ID: opID, OperatorConfig: operatorclient.OperatorConfig{Name: "op-a", URL: srv.URL}},
+			{ID: opID, OperatorConfig: operatorclient.OperatorConfig{Name: "op-a", URL: srv.URL}, AcceptingLaunches: true},
 		}))
 
 		err := r.ReconcileNext(context.Background())
@@ -464,7 +464,7 @@ func TestReconcileNext(t *testing.T) {
 		}
 		r := newTestReconciler(t, fake)
 		require.NoError(t, r.scheduler.Sync([]operatorclient.OperatorAdminSummary{
-			{ID: opID, OperatorConfig: operatorclient.OperatorConfig{Name: "op-a", URL: srv.URL}},
+			{ID: opID, OperatorConfig: operatorclient.OperatorConfig{Name: "op-a", URL: srv.URL}, AcceptingLaunches: true},
 		}))
 
 		err := r.ReconcileNext(context.Background())
@@ -539,4 +539,3 @@ func TestNextBackoff(t *testing.T) {
 		})
 	}
 }
-


### PR DESCRIPTION
## Summary

Adds the ability to take a `vice-operator` out of service **without deleting** it, via two independent controls on the `operators` table:

- **`accepting_launches`** (default `true`) — graceful **drain** switch. When `false`, app-exposer routes no new launches to the operator, but it stays fully in service otherwise: still reconciled, and its running analyses remain listable, searchable, quota-counted, and subdomain-routable so they can finish.
- **`deactivated`** (default `false`) — full/emergency **kill** switch. When `true`, the operator drops out of the live scheduler pool entirely: no launches, reconciliation bypassed, and removed from listing/search/quota fan-out.

**Precedence:** a launch routes to an operator only when `accepting_launches = true AND deactivated = false`.

Typical flow: set `accepting_launches=false` to drain, wait for running analyses to finish, then set `deactivated=true` to fully remove it. In an emergency, set `deactivated=true` directly.

> **Note:** depends on the companion de-database migration `000051_operators_deactivation` (adds the two columns and extends the `operator_changed` update trigger).

## Changes

- **`db/operators.go`** — new `Operator`/`OperatorUpdate` fields; `WHERE deactivated = false` on `ListOperators` (scheduler source) and the `ClaimAndReconcile` claim query (reconciliation bypass). Admin `ListOperatorAdminSummaries`/`GetOperatorByID` stay unfiltered so admins always see every operator.
- **`operatorclient/`** — `OperatorAdminSummary`/`UpdateOperatorRequest` gain both fields; `Client` carries `acceptingLaunches`; `LaunchAnalysis` skips draining operators and returns a new `ErrAllOperatorsDraining` sentinel when all are draining.
- **`httphandlers/handlers.go`** — `UpdateOperatorHandler` threads the two flags through; create still uses DB defaults.
- **`vice-operator-tool`** — `activate`/`deactivate` subcommands, `--accepting-launches`/`--deactivated` flags on `update`, and new columns in `list`.
- Regenerated Swagger docs.

## Behavior tradeoff

Because `deactivated` removes the operator from the live pool entirely, analyses still running on a deactivated operator stop being listed/quota-counted/reconciled — the intended "emergency, stop touching it" behavior. The graceful path is `accepting_launches=false` first, which keeps those analyses fully visible and reconciled while draining.

## Testing

- `just test` — all packages pass.
- Added: scheduler draining table-test (drained operator skipped → next accepts; all-drained → `ErrAllOperatorsDraining`), CLI request-body cases for both flags, and updated sqlmock column/arg expectations.
- `go build ./...`, `go vet`, and `golangci-lint run` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
