### PR TITLE
Operator-side bundle construction: cluster-agnostic VICESpec (Phases 0-3)

### DIFF
--- a/cmd/vice-operator/app.go
+++ b/cmd/vice-operator/app.go
@@ -95,6 +95,10 @@ func NewApp(cfg AppConfig) *App {
 	}
 	api.GET("/capacity", op.HandleCapacity)
 	api.POST("/analyses", op.HandleLaunch)
+	// Spec launch path (operator-side construction). Static "/analyses/spec"
+	// takes priority over the "/analyses/:analysis-id" group below in Echo's
+	// router, so it does not collide with the param routes.
+	api.POST("/analyses/spec", op.HandleLaunchSpec)
 	api.GET("/analyses", op.HandleListing)
 
 	analyses := api.Group("/analyses/:analysis-id")

--- a/cmd/vice-operator/main.go
+++ b/cmd/vice-operator/main.go
@@ -114,6 +114,8 @@ func main() {
 		viceProxyStorageRequest      string
 		viceProxyStorageLimit        string
 		disableViceProxyStorageLimit bool
+
+		disableSpecLaunch bool
 	)
 
 	flag.StringVar(&kubeconfig, "kubeconfig", "", "Path to kubeconfig (empty for in-cluster)")
@@ -203,6 +205,8 @@ func main() {
 	flag.StringVar(&viceProxyStorageRequest, "vice-proxy-storage-resource-request", "16Gi", "Ephemeral storage request for the vice-proxy sidecar")
 	flag.StringVar(&viceProxyStorageLimit, "vice-proxy-storage-resource-limit", "100Gi", "Ephemeral storage limit for the vice-proxy sidecar")
 	flag.BoolVar(&disableViceProxyStorageLimit, "disable-vice-proxy-storage-resource-limit", true, "Disable the vice-proxy storage limit")
+
+	flag.BoolVar(&disableSpecLaunch, "disable-spec-launch", false, "Disable the operator-side VICESpec build path: advertise spec support off so app-exposer sends legacy bundles, and reject direct spec launches. Per-operator rollback lever during migration.")
 
 	flag.Parse()
 
@@ -490,6 +494,7 @@ func main() {
 		GatewayProvider:         gatewayProvider,
 		ImagePullSecretName:     imagePullSecret,
 		ResourceDefaults:        resourceDefaults,
+		DisableSpecLaunch:       disableSpecLaunch,
 	})
 	if err != nil {
 		log.Fatalf("failed to construct operator: %v", err)

--- a/cmd/vice-operator/main.go
+++ b/cmd/vice-operator/main.go
@@ -90,7 +90,6 @@ func main() {
 		porklockTag             string
 		viceProxyImage          string
 		useCSIDriver            bool
-		frontendBaseURL         string
 		irodsZone               string
 		inputPathListIdentifier string
 		gatewayProvider         string
@@ -183,7 +182,6 @@ func main() {
 	flag.StringVar(&porklockTag, "porklock-tag", "latest", "Tag for the porklock image")
 	flag.StringVar(&viceProxyImage, "vice-proxy-image", "harbor.cyverse.org/de/vice-proxy:latest", "Image (with tag) for the vice-proxy sidecar")
 	flag.BoolVar(&useCSIDriver, "use-csi-driver", false, "Use the iRODS CSI driver for data volumes instead of porklock file transfers")
-	flag.StringVar(&frontendBaseURL, "frontend-base-url", "https://cyverse.run", "Base URL used to build each analysis's REDIRECT_URL")
 	flag.StringVar(&irodsZone, "irods-zone", "cyverse", "iRODS zone name")
 	flag.StringVar(&inputPathListIdentifier, "input-path-list-identifier", "# application/vnd.de.multi-input-path-list+csv; version=1", "First line of the porklock input-path-list file")
 	flag.StringVar(&gatewayProvider, "gateway-provider", "traefik", "Gateway API provider for HTTPRoute construction (e.g. traefik)")
@@ -464,31 +462,35 @@ func main() {
 	}
 
 	op, err := operator.NewOperator(operator.OperatorOptions{
-		Clientset:               clientset,
-		GatewayClient:           gwClient,
-		Namespace:               namespace,
-		GatewayNamespace:        gatewayNamespace,
-		GatewayName:             gatewayName,
-		GPUVendor:               gpuVendor,
-		GPUModels:               gpuModels,
-		GPUModelAffinityKey:     gpuModelAffinityKey,
-		GPUModelMapping:         gpuModelMapping,
-		CapacityCalc:            capacityCalc,
-		ImageCache:              imageCache,
-		ImageRewriter:           imageRewriter,
-		LoadingServiceName:      loadingServiceName,
-		LoadingServicePort:      int32(loadingServicePort),
-		LoadingTimeoutMs:        loadingTimeoutMs,
-		BaseDomain:              baseDomain,
-		ClusterConfigSecret:     clusterConfigSecret,
-		EgressConfig:            egressConfig,
-		UserSuffix:              userSuffix,
-		LocalStorageClass:       localStorageClass,
-		PorklockImage:           porklockImage,
-		PorklockTag:             porklockTag,
-		ViceProxyImage:          viceProxyImage,
-		UseCSIDriver:            useCSIDriver,
-		FrontendBaseURL:         frontendBaseURL,
+		Clientset:           clientset,
+		GatewayClient:       gwClient,
+		Namespace:           namespace,
+		GatewayNamespace:    gatewayNamespace,
+		GatewayName:         gatewayName,
+		GPUVendor:           gpuVendor,
+		GPUModels:           gpuModels,
+		GPUModelAffinityKey: gpuModelAffinityKey,
+		GPUModelMapping:     gpuModelMapping,
+		CapacityCalc:        capacityCalc,
+		ImageCache:          imageCache,
+		ImageRewriter:       imageRewriter,
+		LoadingServiceName:  loadingServiceName,
+		LoadingServicePort:  int32(loadingServicePort),
+		LoadingTimeoutMs:    loadingTimeoutMs,
+		BaseDomain:          baseDomain,
+		ClusterConfigSecret: clusterConfigSecret,
+		EgressConfig:        egressConfig,
+		UserSuffix:          userSuffix,
+		LocalStorageClass:   localStorageClass,
+		PorklockImage:       porklockImage,
+		PorklockTag:         porklockTag,
+		ViceProxyImage:      viceProxyImage,
+		UseCSIDriver:        useCSIDriver,
+		// REDIRECT_URL for each analysis is built from the vice base URL — the
+		// same value whose hostname is the routing domain (baseDomain), since a
+		// redirect must land on the host its HTTPRoute serves. No separate
+		// frontend-base-url flag is needed.
+		FrontendBaseURL:         viceBaseURL,
 		IRODSZone:               irodsZone,
 		InputPathListIdentifier: inputPathListIdentifier,
 		GatewayProvider:         gatewayProvider,

--- a/cmd/vice-operator/main.go
+++ b/cmd/vice-operator/main.go
@@ -14,8 +14,10 @@ import (
 	"github.com/cyverse-de/app-exposer/common"
 	"github.com/cyverse-de/app-exposer/constants"
 	"github.com/cyverse-de/app-exposer/operator"
+	"github.com/cyverse-de/app-exposer/vicebuild"
 	"github.com/cyverse-de/go-mod/viceauth"
 	"github.com/sirupsen/logrus"
+	resourcev1 "k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/client-go/kubernetes"
 )
 
@@ -82,6 +84,36 @@ func main() {
 		imageCacheMode        string
 		imageCacheSchedule    string
 		reposFile             string
+
+		// VICESpec construction config (operator-side build path).
+		porklockImage           string
+		porklockTag             string
+		viceProxyImage          string
+		useCSIDriver            bool
+		frontendBaseURL         string
+		irodsZone               string
+		inputPathListIdentifier string
+		gatewayProvider         string
+
+		// Resource default/clamp policy ("what this cluster grants"). Flag
+		// names and defaults mirror app-exposer so a cluster behaves identically
+		// on the spec path and the legacy object path.
+		defaultCPURequest            string
+		defaultCPULimit              string
+		disableCPULimit              bool
+		defaultMemRequest            string
+		defaultMemLimit              string
+		disableMemLimit              bool
+		defaultStorageRequest        string
+		viceProxyCPURequest          string
+		viceProxyCPULimit            string
+		disableViceProxyCPULimit     bool
+		viceProxyMemRequest          string
+		viceProxyMemLimit            string
+		disableViceProxyMemLimit     bool
+		viceProxyStorageRequest      string
+		viceProxyStorageLimit        string
+		disableViceProxyStorageLimit bool
 	)
 
 	flag.StringVar(&kubeconfig, "kubeconfig", "", "Path to kubeconfig (empty for in-cluster)")
@@ -143,6 +175,35 @@ func main() {
 	flag.StringVar(&imageCacheMode, "image-cache-mode", "daemonset", "Image cache implementation: 'daemonset' for one DaemonSet per image (node-local containerd warming), 'cron' for one CronJob per image (periodic pulls), or 'manual-mirror' for read-only mapping driven by --repos-file (rewrites bundle image refs at launch time)")
 	flag.StringVar(&imageCacheSchedule, "image-cache-schedule", "0 2 * * *", "Cron schedule applied to every cached image when --image-cache-mode=cron (5-field standard cron expression in UTC)")
 	flag.StringVar(&reposFile, "repos-file", "", "Path to a JSON object mapping upstream image refs to mirrored refs (required when --image-cache-mode=manual-mirror; rejected otherwise)")
+
+	// VICESpec construction config (operator-side build path).
+	flag.StringVar(&porklockImage, "porklock-image", "discoenv/vice-file-transfers", "Image for the porklock file-transfer/init containers")
+	flag.StringVar(&porklockTag, "porklock-tag", "latest", "Tag for the porklock image")
+	flag.StringVar(&viceProxyImage, "vice-proxy-image", "harbor.cyverse.org/de/vice-proxy:latest", "Image (with tag) for the vice-proxy sidecar")
+	flag.BoolVar(&useCSIDriver, "use-csi-driver", false, "Use the iRODS CSI driver for data volumes instead of porklock file transfers")
+	flag.StringVar(&frontendBaseURL, "frontend-base-url", "https://cyverse.run", "Base URL used to build each analysis's REDIRECT_URL")
+	flag.StringVar(&irodsZone, "irods-zone", "cyverse", "iRODS zone name")
+	flag.StringVar(&inputPathListIdentifier, "input-path-list-identifier", "# application/vnd.de.multi-input-path-list+csv; version=1", "First line of the porklock input-path-list file")
+	flag.StringVar(&gatewayProvider, "gateway-provider", "traefik", "Gateway API provider for HTTPRoute construction (e.g. traefik)")
+
+	// Resource default/clamp policy. Defaults mirror app-exposer's flags.
+	flag.StringVar(&defaultCPURequest, "default-cpu-resource-request", "1000m", "Default CPU request for an analysis")
+	flag.StringVar(&defaultCPULimit, "default-cpu-resource-limit", "2000m", "Default CPU limit for an analysis")
+	flag.BoolVar(&disableCPULimit, "disable-cpu-resource-limit", false, "Disable the analysis CPU limit")
+	flag.StringVar(&defaultMemRequest, "default-memory-resource-request", "2Gi", "Default memory request for an analysis")
+	flag.StringVar(&defaultMemLimit, "default-memory-resource-limit", "8Gi", "Default memory limit for an analysis")
+	flag.BoolVar(&disableMemLimit, "disable-memory-resource-limit", false, "Disable the analysis memory limit")
+	flag.StringVar(&defaultStorageRequest, "default-storage-resource-request", "1Gi", "Default ephemeral storage request for an analysis")
+	flag.StringVar(&viceProxyCPURequest, "vice-proxy-cpu-resource-request", "100m", "CPU request for the vice-proxy sidecar")
+	flag.StringVar(&viceProxyCPULimit, "vice-proxy-cpu-resource-limit", "200m", "CPU limit for the vice-proxy sidecar")
+	flag.BoolVar(&disableViceProxyCPULimit, "disable-vice-proxy-cpu-resource-limit", false, "Disable the vice-proxy CPU limit")
+	flag.StringVar(&viceProxyMemRequest, "vice-proxy-memory-resource-request", "100Mi", "Memory request for the vice-proxy sidecar")
+	flag.StringVar(&viceProxyMemLimit, "vice-proxy-memory-resource-limit", "200Mi", "Memory limit for the vice-proxy sidecar")
+	flag.BoolVar(&disableViceProxyMemLimit, "disable-vice-proxy-memory-resource-limit", false, "Disable the vice-proxy memory limit")
+	flag.StringVar(&viceProxyStorageRequest, "vice-proxy-storage-resource-request", "16Gi", "Ephemeral storage request for the vice-proxy sidecar")
+	flag.StringVar(&viceProxyStorageLimit, "vice-proxy-storage-resource-limit", "100Gi", "Ephemeral storage limit for the vice-proxy sidecar")
+	flag.BoolVar(&disableViceProxyStorageLimit, "disable-vice-proxy-storage-resource-limit", true, "Disable the vice-proxy storage limit")
+
 	flag.Parse()
 
 	// Allow secrets to come from environment variables when not set on the
@@ -372,27 +433,63 @@ func main() {
 	if err != nil {
 		log.Fatalf("%v", err)
 	}
+	parseQty := func(name, s string) resourcev1.Quantity {
+		q, err := resourcev1.ParseQuantity(s)
+		if err != nil {
+			log.Fatalf("invalid quantity for %s (%q): %v", name, s, err)
+		}
+		return q
+	}
+	resourceDefaults := vicebuild.ResourceDefaults{
+		DefaultCPURequest:   parseQty("--default-cpu-resource-request", defaultCPURequest),
+		DefaultCPULimit:     parseQty("--default-cpu-resource-limit", defaultCPULimit),
+		DefaultMemRequest:   parseQty("--default-memory-resource-request", defaultMemRequest),
+		DefaultMemLimit:     parseQty("--default-memory-resource-limit", defaultMemLimit),
+		DefaultStorage:      parseQty("--default-storage-resource-request", defaultStorageRequest),
+		DoCPULimit:          !disableCPULimit,
+		DoMemLimit:          !disableMemLimit,
+		ViceProxyCPURequest: parseQty("--vice-proxy-cpu-resource-request", viceProxyCPURequest),
+		ViceProxyCPULimit:   parseQty("--vice-proxy-cpu-resource-limit", viceProxyCPULimit),
+		ViceProxyMemRequest: parseQty("--vice-proxy-memory-resource-request", viceProxyMemRequest),
+		ViceProxyMemLimit:   parseQty("--vice-proxy-memory-resource-limit", viceProxyMemLimit),
+		ViceProxyStorage:    parseQty("--vice-proxy-storage-resource-request", viceProxyStorageRequest),
+		ViceProxyStorageLim: parseQty("--vice-proxy-storage-resource-limit", viceProxyStorageLimit),
+		DoViceProxyCPULimit: !disableViceProxyCPULimit,
+		DoViceProxyMemLimit: !disableViceProxyMemLimit,
+		DoViceProxyStorage:  !disableViceProxyStorageLimit,
+	}
+
 	op, err := operator.NewOperator(operator.OperatorOptions{
-		Clientset:           clientset,
-		GatewayClient:       gwClient,
-		Namespace:           namespace,
-		GatewayNamespace:    gatewayNamespace,
-		GatewayName:         gatewayName,
-		GPUVendor:           gpuVendor,
-		GPUModels:           gpuModels,
-		GPUModelAffinityKey: gpuModelAffinityKey,
-		GPUModelMapping:     gpuModelMapping,
-		CapacityCalc:        capacityCalc,
-		ImageCache:          imageCache,
-		ImageRewriter:       imageRewriter,
-		LoadingServiceName:  loadingServiceName,
-		LoadingServicePort:  int32(loadingServicePort),
-		LoadingTimeoutMs:    loadingTimeoutMs,
-		BaseDomain:          baseDomain,
-		ClusterConfigSecret: clusterConfigSecret,
-		EgressConfig:        egressConfig,
-		UserSuffix:          userSuffix,
-		LocalStorageClass:   localStorageClass,
+		Clientset:               clientset,
+		GatewayClient:           gwClient,
+		Namespace:               namespace,
+		GatewayNamespace:        gatewayNamespace,
+		GatewayName:             gatewayName,
+		GPUVendor:               gpuVendor,
+		GPUModels:               gpuModels,
+		GPUModelAffinityKey:     gpuModelAffinityKey,
+		GPUModelMapping:         gpuModelMapping,
+		CapacityCalc:            capacityCalc,
+		ImageCache:              imageCache,
+		ImageRewriter:           imageRewriter,
+		LoadingServiceName:      loadingServiceName,
+		LoadingServicePort:      int32(loadingServicePort),
+		LoadingTimeoutMs:        loadingTimeoutMs,
+		BaseDomain:              baseDomain,
+		ClusterConfigSecret:     clusterConfigSecret,
+		EgressConfig:            egressConfig,
+		UserSuffix:              userSuffix,
+		LocalStorageClass:       localStorageClass,
+		PorklockImage:           porklockImage,
+		PorklockTag:             porklockTag,
+		ViceProxyImage:          viceProxyImage,
+		UseCSIDriver:            useCSIDriver,
+		FrontendBaseURL:         frontendBaseURL,
+		IRODSZone:               irodsZone,
+		InputPathListIdentifier: inputPathListIdentifier,
+		GatewayProvider:         gatewayProvider,
+		ImagePullSecretName:     imagePullSecret,
+		ResourceDefaults:        resourceDefaults,
 	})
 	if err != nil {
 		log.Fatalf("failed to construct operator: %v", err)

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -83,14 +83,16 @@ const (
 	// based matching against them. A typo at any one site silently
 	// breaks matching, so the keys live here rather than as raw
 	// string literals in each package.
-	AnalysisIDLabel = "analysis-id"
-	AppNameLabel    = "app-name"
-	AppTypeLabel    = "app-type"
-	AppIDLabel      = "app-id"
-	ExternalIDLabel = "external-id"
-	UsernameLabel   = "username"
-	UserIDLabel     = "user-id"
-	SubdomainLabel  = "subdomain"
+	AnalysisIDLabel   = "analysis-id"
+	AnalysisNameLabel = "analysis-name"
+	AppNameLabel      = "app-name"
+	AppTypeLabel      = "app-type"
+	AppIDLabel        = "app-id"
+	ExternalIDLabel   = "external-id"
+	UsernameLabel     = "username"
+	UserIDLabel       = "user-id"
+	SubdomainLabel    = "subdomain"
+	LoginIPLabel      = "login-ip"
 )
 
 // AnalysisID is the app-exposer/DE analysis identifier — the "id" column

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -3025,6 +3025,10 @@ const docTemplate = `{
                 "runningAnalyses": {
                     "type": "integer"
                 },
+                "specVersion": {
+                    "description": "SpecVersion is the maximum VICESpec wire-contract version this operator\ncan build. 0 (the zero value, also what pre-spec operators report) means\nthe operator does not support the spec path, so the scheduler must send\nit a legacy AnalysisBundle instead. See operatorclient.CurrentVICESpecVersion.",
+                    "type": "integer"
+                },
                 "supportedGPUModels": {
                     "type": "array",
                     "items": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -3019,6 +3019,10 @@
                 "runningAnalyses": {
                     "type": "integer"
                 },
+                "specVersion": {
+                    "description": "SpecVersion is the maximum VICESpec wire-contract version this operator\ncan build. 0 (the zero value, also what pre-spec operators report) means\nthe operator does not support the spec path, so the scheduler must send\nit a legacy AnalysisBundle instead. See operatorclient.CurrentVICESpecVersion.",
+                    "type": "integer"
+                },
                 "supportedGPUModels": {
                     "type": "array",
                     "items": {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -925,6 +925,13 @@ definitions:
         type: integer
       runningAnalyses:
         type: integer
+      specVersion:
+        description: |-
+          SpecVersion is the maximum VICESpec wire-contract version this operator
+          can build. 0 (the zero value, also what pre-spec operators report) means
+          the operator does not support the spec path, so the scheduler must send
+          it a legacy AnalysisBundle instead. See operatorclient.CurrentVICESpecVersion.
+        type: integer
       supportedGPUModels:
         items:
           type: string

--- a/httphandlers/launch.go
+++ b/httphandlers/launch.go
@@ -153,19 +153,26 @@ func (h *HTTPHandlers) launchAsync(job *model.Job) {
 		return
 	}
 
-	// Build a bundle and route to an operator. Uses job.ID directly because
-	// job_steps rows don't exist yet at launch time.
-	bundle, err := h.incluster.BuildAnalysisBundle(ctx, job, constants.AnalysisID(job.ID))
+	// Build the cluster-agnostic spec and route to an operator. Uses job.ID
+	// directly because job_steps rows don't exist yet at launch time. The
+	// scheduler sends the spec to spec-aware operators and falls back to a
+	// legacy AnalysisBundle for older ones; the bundle is built on demand only
+	// if a spec-unaware operator is actually selected.
+	analysisID := constants.AnalysisID(job.ID)
+	spec, err := h.incluster.BuildVICESpec(ctx, job, analysisID)
 	if err != nil {
-		log.Errorf("async launch %s: failed to build analysis bundle: %v", job.ID, err)
-		h.failLaunch(ctx, job, fmt.Sprintf("failed to build analysis bundle: %v", err))
+		log.Errorf("async launch %s: failed to build VICE spec: %v", job.ID, err)
+		h.failLaunch(ctx, job, fmt.Sprintf("failed to build VICE spec: %v", err))
 		return
 	}
 
-	// Route the bundle to an available operator. The scheduler returns
-	// both the id (used for the DB write below) and the name (used in
-	// human-readable log lines).
-	operatorID, operatorName, err := h.scheduler.LaunchAnalysis(ctx, bundle)
+	legacyBundle := func() (*operatorclient.AnalysisBundle, error) {
+		return h.incluster.BuildAnalysisBundle(ctx, job, analysisID)
+	}
+
+	// Route to an available operator. The scheduler returns both the id (used
+	// for the DB write below) and the name (used in human-readable log lines).
+	operatorID, operatorName, err := h.scheduler.LaunchAnalysisSpec(ctx, spec, legacyBundle)
 	if err != nil {
 		log.Errorf("async launch %s: failed to launch analysis: %v", job.ID, err)
 		h.failLaunch(ctx, job, fmt.Sprintf("failed to schedule analysis on operator: %v", err))

--- a/httphandlers/launch.go
+++ b/httphandlers/launch.go
@@ -132,7 +132,11 @@ func (h *HTTPHandlers) launchAsync(job *model.Job) {
 	defer cancel()
 
 	// Pre-build the deployment locally to calculate millicores reservation
-	// and validate resource requirements.
+	// and validate resource requirements. NOTE: this uses app-exposer's
+	// resourcing defaults, not the target operator's ResourceDefaults. For
+	// spec-path launches on an operator whose defaults differ, the reserved
+	// millicores may be slightly off; unifying this is Phase 4 follow-up work
+	// once every operator runs the spec path.
 	deployment, err := h.incluster.GetDeployment(ctx, job)
 	if err != nil {
 		log.Errorf("async launch %s: failed to get deployment: %v", job.ID, err)

--- a/incluster/golden_equivalence_test.go
+++ b/incluster/golden_equivalence_test.go
@@ -1,0 +1,324 @@
+package incluster
+
+import (
+	"context"
+	"maps"
+	"testing"
+
+	"github.com/cyverse-de/app-exposer/constants"
+	"github.com/cyverse-de/app-exposer/incluster/jobinfo"
+	"github.com/cyverse-de/app-exposer/operator"
+	"github.com/cyverse-de/app-exposer/operatorclient"
+	"github.com/cyverse-de/app-exposer/vicebuild"
+	"github.com/cyverse-de/model/v10"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+// fakeJobInfo returns a fixed label set so BuildAnalysisBundle can run without
+// the apps/DB dependency. It returns exactly what vicebuild.BuildLabels would
+// produce for the equivalent spec, so the golden comparison isolates the
+// structural/transform equivalence rather than re-checking label assembly
+// (already covered by vicebuild's TestBuildLabelsMatchesJobInfo).
+type fakeJobInfo struct{ labels map[string]string }
+
+func (f fakeJobInfo) JobLabels(_ context.Context, _ *model.Job) (map[string]string, error) {
+	// Return a fresh copy per call, matching the real JobLabels — some callers
+	// (the CSI data-volume labels) mutate the returned map.
+	return maps.Clone(f.labels), nil
+}
+
+var _ jobinfo.JobInfo = fakeJobInfo{}
+
+// resourcingDefaults mirrors the resourcing package's compile-time defaults
+// (no setters are called in tests), so vicebuild produces the same resource
+// requirements the legacy resourcing path does.
+func resourcingDefaults() vicebuild.ResourceDefaults {
+	return vicebuild.ResourceDefaults{
+		DefaultCPURequest:   resource.MustParse("1000m"),
+		DefaultCPULimit:     resource.MustParse("2000m"),
+		DefaultMemRequest:   resource.MustParse("2Gi"),
+		DefaultMemLimit:     resource.MustParse("8Gi"),
+		DefaultStorage:      resource.MustParse("1Gi"),
+		DoCPULimit:          true,
+		DoMemLimit:          true,
+		ViceProxyCPURequest: resource.MustParse("100m"),
+		ViceProxyCPULimit:   resource.MustParse("200m"),
+		ViceProxyMemRequest: resource.MustParse("100Mi"),
+		ViceProxyMemLimit:   resource.MustParse("200Mi"),
+		ViceProxyStorage:    resource.MustParse("100Mi"),
+		ViceProxyStorageLim: resource.MustParse("200Mi"),
+		DoViceProxyCPULimit: true,
+		DoViceProxyMemLimit: true,
+		DoViceProxyStorage:  true,
+	}
+}
+
+// goldenParams captures the cluster knobs varied across golden cases.
+type goldenParams struct {
+	useCSI       bool
+	vendor       string
+	modelKey     string
+	modelMapping map[string]string
+}
+
+// goldenConfig is the vicebuild.Config whose values correspond to goldenInit()
+// plus the operator transform parameters the golden test simulates.
+func goldenConfig(p goldenParams) *vicebuild.Config {
+	return &vicebuild.Config{
+		PorklockImage:           "harbor.cyverse.org/de/porklock",
+		PorklockTag:             "latest",
+		ViceProxyImage:          "harbor.cyverse.org/de/vice-proxy",
+		UseCSIDriver:            p.useCSI,
+		IRODSZone:               "example",
+		LocalStorageClass:       "", // matches legacy (PVC class left unset, operator default)
+		FrontendBaseURL:         "https://de.example.org",
+		BaseDomain:              "cyverse.run",
+		Namespace:               "vice-apps",
+		GatewayNamespace:        "prod",
+		GatewayName:             "vice",
+		GatewayProvider:         "traefik",
+		ImagePullSecretName:     "imanimagepullsecret",
+		ClusterConfigSecretName: "cluster-config-secret",
+		UserSuffix:              "@example.org",
+		InputPathListIdentifier: "imapathlist",
+		GPUVendor:               p.vendor,
+		GPUModelAffinityKey:     p.modelKey,
+		GPUModelMapping:         p.modelMapping,
+		LoadingServiceName:      "vice-operator-loading",
+		LoadingServicePort:      80,
+		Resources:               resourcingDefaults(),
+	}
+}
+
+// applyOperatorTransforms reproduces HandleLaunch's transform sequence on a
+// legacy bundle so it can be compared against the vicebuild output.
+func applyOperatorTransforms(b *operatorclient.AnalysisBundle, cfg *vicebuild.Config) {
+	if b.HTTPRoute != nil {
+		operator.TransformHostnames(b.HTTPRoute, cfg.BaseDomain)
+		operator.TransformGatewayNamespace(b.HTTPRoute, cfg.GatewayNamespace, cfg.GatewayName)
+		operator.TransformBackendToLoadingService(b.HTTPRoute, cfg.LoadingServiceName, cfg.LoadingServicePort)
+	}
+	operator.EnsurePermissionsConfigMap(b, cfg.UserSuffix)
+	operator.TransformViceProxyArgs(b.Deployment, string(b.AnalysisID), cfg.ClusterConfigSecretName)
+	operator.TransformGPUModels(b.Deployment, cfg.GPUModelAffinityKey, cfg.GPUModelMapping)
+	operator.TransformGPUVendor(b.Deployment, operator.GPUVendor(cfg.GPUVendor))
+}
+
+func goldenJob(withGPU bool) *model.Job {
+	c := model.Container{
+		Image:       model.ContainerImage{Name: "cyverse/jupyter", Tag: "latest"},
+		UID:         1000,
+		MinCPUCores: 1,
+		MaxCPUCores: 4,
+		Ports:       []model.Ports{{ContainerPort: 8888}},
+	}
+	if withGPU {
+		c.MinGPUs = 1
+		c.MaxGPUs = 2
+		c.GPUModels = []string{"NVIDIA-A10G"}
+	}
+	return &model.Job{
+		ID:           "analysis-1",
+		InvocationID: "external-1",
+		Name:         "My Analysis",
+		AppID:        "app-1",
+		AppName:      "JupyterLab",
+		UserID:       "user-1",
+		Submitter:    "someuser",
+		UserHome:     "/example/home/someuser",
+		Steps: []model.Step{{
+			Component:   model.StepComponent{Container: c},
+			Environment: map[string]string{"FOO": "bar"},
+		}},
+	}
+}
+
+// TestGoldenEquivalence is the migration safety net: for representative jobs,
+// the operator-side spec build (BuildVICESpec → vicebuild) produces objects
+// equivalent to the legacy app-exposer build (BuildAnalysisBundle) plus the
+// operator's transform pass. It compares the transform-sensitive surfaces — the
+// exact places the two paths could diverge.
+func TestGoldenEquivalence(t *testing.T) {
+	tests := []struct {
+		name    string
+		withGPU bool
+		params  goldenParams
+	}{
+		{name: "csi, no gpu", withGPU: false, params: goldenParams{useCSI: true, vendor: operatorclient.GPUVendorNvidia}},
+		{name: "non-csi, no gpu", withGPU: false, params: goldenParams{useCSI: false, vendor: operatorclient.GPUVendorNvidia}},
+		{name: "nvidia gpu with model", withGPU: true, params: goldenParams{useCSI: true, vendor: operatorclient.GPUVendorNvidia}},
+		{
+			name: "eks gpu model mapping", withGPU: true,
+			params: goldenParams{useCSI: true, vendor: operatorclient.GPUVendorNvidia,
+				modelKey: "eks.amazonaws.com/instance-gpu-name", modelMapping: map[string]string{"NVIDIA-A10G": "a10g"}},
+		},
+		{name: "amd gpu", withGPU: true, params: goldenParams{useCSI: true, vendor: operatorclient.GPUVendorAMD}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			job := goldenJob(tt.withGPU)
+			analysisID := constants.AnalysisID(job.ID)
+			cfg := goldenConfig(tt.params)
+
+			// Spec path.
+			spec, err := buildVICESpec(job, analysisID, "10.0.0.1")
+			require.NoError(t, err)
+			specBundle, err := cfg.BuildBundle(spec)
+			require.NoError(t, err)
+
+			// Legacy path: build with a struct-literal Incluster (fake jobInfo
+			// returns the same labels vicebuild produces), then transform.
+			i := &Incluster{Init: *goldenInit(tt.params), jobInfo: fakeJobInfo{labels: vicebuild.BuildLabels(spec)}}
+			legacy, err := i.BuildAnalysisBundle(context.Background(), job, analysisID)
+			require.NoError(t, err)
+			applyOperatorTransforms(legacy, cfg)
+
+			assertBundlesEquivalent(t, legacy, specBundle)
+		})
+	}
+}
+
+// goldenInit returns the legacy Init matching goldenConfig.
+func goldenInit(p goldenParams) *Init {
+	return &Init{
+		PorklockImage:           "harbor.cyverse.org/de/porklock",
+		PorklockTag:             "latest",
+		UseCSIDriver:            p.useCSI,
+		InputPathListIdentifier: "imapathlist",
+		ImagePullSecretName:     "imanimagepullsecret",
+		ViceProxyImage:          "harbor.cyverse.org/de/vice-proxy",
+		FrontendBaseURL:         "https://de.example.org",
+		ViceDomain:              "cyverse.run",
+		VICEBackendNamespace:    "prod",
+		ViceNamespace:           "vice-apps",
+		UserSuffix:              "@example.org",
+		IRODSZone:               "example",
+		GatewayProvider:         "traefik",
+		ClusterConfigSecretName: "cluster-config-secret",
+	}
+}
+
+func assertBundlesEquivalent(t *testing.T, legacy, spec *operatorclient.AnalysisBundle) {
+	t.Helper()
+
+	// Top-level identity.
+	assert.Equal(t, legacy.AnalysisID, spec.AnalysisID)
+
+	// Deployment: name, labels, pod hostname, image-pull secrets.
+	require.NotNil(t, spec.Deployment)
+	assert.Equal(t, legacy.Deployment.Name, spec.Deployment.Name, "deployment name")
+	assert.Equal(t, legacy.Deployment.Labels, spec.Deployment.Labels, "deployment labels")
+	lp, sp := legacy.Deployment.Spec.Template.Spec, spec.Deployment.Spec.Template.Spec
+	assert.Equal(t, lp.Hostname, sp.Hostname, "pod hostname")
+	assert.Equal(t, lp.ImagePullSecrets, sp.ImagePullSecrets, "image pull secrets")
+
+	// Containers and init containers compared by name + image + key fields.
+	assertContainersEquivalent(t, lp.Containers, sp.Containers)
+	assert.Equal(t, containerNames(lp.InitContainers), containerNames(sp.InitContainers), "init container names")
+	assert.Equal(t, volumeNames(lp.Volumes), volumeNames(sp.Volumes), "pod volume names")
+
+	// Node affinity (GPU model key/values) and tolerations.
+	assert.Equal(t, lp.Affinity, sp.Affinity, "affinity (incl. GPU node selectors)")
+	assert.Equal(t, lp.Tolerations, sp.Tolerations, "tolerations")
+
+	// Service.
+	require.NotNil(t, spec.Service)
+	assert.Equal(t, legacy.Service.Name, spec.Service.Name, "service name")
+	assert.Equal(t, legacy.Service.Spec.Ports, spec.Service.Spec.Ports, "service ports")
+	assert.Equal(t, legacy.Service.Spec.Selector, spec.Service.Spec.Selector, "service selector")
+
+	// HTTPRoute: hostname, parentRefs, backend, namespace.
+	require.NotNil(t, spec.HTTPRoute)
+	assert.Equal(t, legacy.HTTPRoute.Name, spec.HTTPRoute.Name, "route name")
+	assert.Equal(t, legacy.HTTPRoute.Namespace, spec.HTTPRoute.Namespace, "route namespace")
+	assert.Equal(t, legacy.HTTPRoute.Spec.Hostnames, spec.HTTPRoute.Spec.Hostnames, "route hostnames")
+	assert.Equal(t, legacy.HTTPRoute.Spec.ParentRefs, spec.HTTPRoute.Spec.ParentRefs, "route parentRefs")
+	assert.Equal(t, legacy.HTTPRoute.Spec.Rules, spec.HTTPRoute.Spec.Rules, "route rules (incl. backend)")
+
+	// ConfigMaps compared as name->data maps (order-independent).
+	assert.Equal(t, configMapData(legacy.ConfigMaps), configMapData(spec.ConfigMaps), "configmap data")
+
+	// PVCs: name -> storage class.
+	assert.Equal(t, pvcClasses(legacy.PersistentVolumeClaims), pvcClasses(spec.PersistentVolumeClaims), "pvc storage classes")
+
+	// PVs (CSI): name -> CSI volume attributes.
+	assert.Equal(t, len(legacy.PersistentVolumes), len(spec.PersistentVolumes), "pv count")
+	if len(legacy.PersistentVolumes) == 1 && len(spec.PersistentVolumes) == 1 {
+		assert.Equal(t, legacy.PersistentVolumes[0].Spec.CSI.VolumeAttributes,
+			spec.PersistentVolumes[0].Spec.CSI.VolumeAttributes, "CSI volume attributes")
+	}
+
+	// PDB.
+	require.NotNil(t, spec.PodDisruptionBudget)
+	assert.Equal(t, legacy.PodDisruptionBudget.Name, spec.PodDisruptionBudget.Name, "pdb name")
+}
+
+func assertContainersEquivalent(t *testing.T, legacy, spec []apiv1.Container) {
+	t.Helper()
+	require.Equal(t, containerNames(legacy), containerNames(spec), "container names/order")
+	byName := func(cs []apiv1.Container) map[string]apiv1.Container {
+		m := make(map[string]apiv1.Container, len(cs))
+		for _, c := range cs {
+			m[c.Name] = c
+		}
+		return m
+	}
+	lm, sm := byName(legacy), byName(spec)
+	for name, lc := range lm {
+		sc := sm[name]
+		assert.Equalf(t, lc.Image, sc.Image, "%s image", name)
+		assert.Equalf(t, lc.Command, sc.Command, "%s command", name)
+		assert.Equalf(t, lc.Args, sc.Args, "%s args", name)
+		assert.Equalf(t, lc.Resources, sc.Resources, "%s resources", name)
+		assert.Equalf(t, lc.EnvFrom, sc.EnvFrom, "%s envFrom", name)
+		assert.Equalf(t, volumeMountNames(lc.VolumeMounts), volumeMountNames(sc.VolumeMounts), "%s volume mounts", name)
+	}
+}
+
+func containerNames(cs []apiv1.Container) []string {
+	out := make([]string, 0, len(cs))
+	for _, c := range cs {
+		out = append(out, c.Name)
+	}
+	return out
+}
+
+func volumeNames(vs []apiv1.Volume) []string {
+	out := make([]string, 0, len(vs))
+	for _, v := range vs {
+		out = append(out, v.Name)
+	}
+	return out
+}
+
+func volumeMountNames(ms []apiv1.VolumeMount) []string {
+	out := make([]string, 0, len(ms))
+	for _, m := range ms {
+		out = append(out, m.Name)
+	}
+	return out
+}
+
+func configMapData(cms []*apiv1.ConfigMap) map[string]map[string]string {
+	out := make(map[string]map[string]string, len(cms))
+	for _, cm := range cms {
+		out[cm.Name] = cm.Data
+	}
+	return out
+}
+
+func pvcClasses(pvcs []*apiv1.PersistentVolumeClaim) map[string]string {
+	out := make(map[string]string, len(pvcs))
+	for _, pvc := range pvcs {
+		sc := ""
+		if pvc.Spec.StorageClassName != nil {
+			sc = *pvc.Spec.StorageClassName
+		}
+		out[pvc.Name] = sc
+	}
+	return out
+}

--- a/incluster/golden_equivalence_test.go
+++ b/incluster/golden_equivalence_test.go
@@ -129,6 +129,9 @@ func goldenJob(withGPU bool) *model.Job {
 		UserID:       "user-1",
 		Submitter:    "someuser",
 		UserHome:     "/example/home/someuser",
+		// Exercises the porklock file-transfer command's -m metadata args
+		// (non-CSI cases) and the FileMetadata mapping in the spec.
+		FileMetadata: []model.FileMetadata{{Attribute: "ipc-analysis-id", Value: "analysis-1", Unit: ""}},
 		Steps: []model.Step{{
 			Component:   model.StepComponent{Container: c},
 			Environment: map[string]string{"FOO": "bar"},
@@ -275,6 +278,14 @@ func assertContainersEquivalent(t *testing.T, legacy, spec []apiv1.Container) {
 		assert.Equalf(t, lc.Args, sc.Args, "%s args", name)
 		assert.Equalf(t, lc.Resources, sc.Resources, "%s resources", name)
 		assert.Equalf(t, lc.EnvFrom, sc.EnvFrom, "%s envFrom", name)
+		assert.Equalf(t, lc.Ports, sc.Ports, "%s ports", name)
+		assert.Equalf(t, lc.WorkingDir, sc.WorkingDir, "%s workingDir", name)
+		assert.Equalf(t, lc.SecurityContext, sc.SecurityContext, "%s securityContext", name)
+		assert.Equalf(t, lc.ReadinessProbe, sc.ReadinessProbe, "%s readinessProbe", name)
+		// Env is the most analysis-specific surface (REDIRECT_URL, IPLANT_*,
+		// plus the analysis's own vars); compare order-independently since the
+		// two builders may emit the map-derived vars in different orders.
+		assert.ElementsMatchf(t, lc.Env, sc.Env, "%s env", name)
 		assert.Equalf(t, volumeMountNames(lc.VolumeMounts), volumeMountNames(sc.VolumeMounts), "%s volume mounts", name)
 	}
 }

--- a/incluster/jobinfo/main.go
+++ b/incluster/jobinfo/main.go
@@ -36,16 +36,16 @@ func (j *DefaultJobInfo) JobLabels(ctx context.Context, job *model.Job) (map[str
 	}
 
 	return map[string]string{
-		constants.ExternalIDLabel: job.InvocationID,
-		constants.AnalysisIDLabel: job.ID,
-		constants.AppNameLabel:    common.LabelValueString(job.AppName),
-		constants.AppIDLabel:      job.AppID,
-		constants.UsernameLabel:   common.LabelValueString(job.Submitter),
-		constants.UserIDLabel:     job.UserID,
-		"analysis-name":           common.LabelValueString(string(name[:stringmax])),
-		constants.AppTypeLabel:    "interactive",
-		constants.SubdomainLabel:  common.Subdomain(job.UserID, job.InvocationID),
-		"login-ip":                ipAddr,
+		constants.ExternalIDLabel:   job.InvocationID,
+		constants.AnalysisIDLabel:   job.ID,
+		constants.AppNameLabel:      common.LabelValueString(job.AppName),
+		constants.AppIDLabel:        job.AppID,
+		constants.UsernameLabel:     common.LabelValueString(job.Submitter),
+		constants.UserIDLabel:       job.UserID,
+		constants.AnalysisNameLabel: common.LabelValueString(string(name[:stringmax])),
+		constants.AppTypeLabel:      string(constants.Interactive),
+		constants.SubdomainLabel:    common.Subdomain(job.UserID, job.InvocationID),
+		constants.LoginIPLabel:      ipAddr,
 	}, nil
 }
 

--- a/incluster/vicespec.go
+++ b/incluster/vicespec.go
@@ -1,0 +1,184 @@
+package incluster
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cyverse-de/app-exposer/constants"
+	"github.com/cyverse-de/app-exposer/operatorclient"
+	"github.com/cyverse-de/app-exposer/resourcing"
+	"github.com/cyverse-de/model/v10"
+)
+
+// BuildVICESpec maps a model.Job onto the cluster-agnostic VICESpec that
+// app-exposer sends to a spec-aware operator. It is the resolution half of the
+// old incluster builders: every model.Job method that encodes DE semantics
+// (OutputDirectory, ExcludeArguments, Step.Arguments, StepInput.IRODSPath, …) is
+// evaluated here so the operator receives resolved primitives and needs no
+// model dependency. The one DB-derived value — the user's login IP — is
+// resolved here too (the only network call), keeping the operator DB-free.
+func (i *Incluster) BuildVICESpec(ctx context.Context, job *model.Job, analysisID constants.AnalysisID) (*operatorclient.VICESpec, error) {
+	loginIP, err := i.apps.GetUserIP(ctx, job.UserID)
+	if err != nil {
+		return nil, fmt.Errorf("resolving login IP for analysis %s: %w", analysisID, err)
+	}
+	return buildVICESpec(job, analysisID, loginIP)
+}
+
+// buildVICESpec is the pure model.Job → VICESpec mapping, with the one
+// DB-derived value (loginIP) passed in. Kept separate from BuildVICESpec so the
+// mapping is testable without the apps/DB dependency.
+func buildVICESpec(job *model.Job, analysisID constants.AnalysisID, loginIP string) (*operatorclient.VICESpec, error) {
+	if len(job.Steps) == 0 {
+		return nil, fmt.Errorf("job %s has no steps", job.ID)
+	}
+	step := &job.Steps[0]
+	container := step.Component.Container
+
+	ports := make([]int, 0, len(container.Ports))
+	for _, p := range container.Ports {
+		ports = append(ports, p.ContainerPort)
+	}
+
+	spec := &operatorclient.VICESpec{
+		SpecVersion: operatorclient.CurrentVICESpecVersion,
+
+		AnalysisID:  analysisID,
+		ExternalID:  constants.ExternalID(job.InvocationID),
+		JobName:     job.Name,
+		AppID:       job.AppID,
+		AppName:     job.AppName,
+		UserID:      job.UserID,
+		Submitter:   job.Submitter,
+		UserLoginIP: loginIP,
+
+		Container: operatorclient.ContainerSpec{
+			Image:      container.Image.Name,
+			Tag:        container.Image.Tag,
+			UID:        container.UID,
+			Ports:      ports,
+			EntryPoint: container.EntryPoint,
+			WorkingDir: container.WorkingDir, // raw; vicebuild resolves the mount default
+			Arguments:  step.Arguments(),
+		},
+		Environment: step.Environment,
+
+		Resources: buildResourceSpec(job),
+		GPU:       buildGPUSpec(job),
+
+		UserHome:           job.UserHome,
+		OutputDirectory:    job.OutputDirectory(),
+		ExcludeArguments:   job.ExcludeArguments(),
+		Inputs:             buildInputSpecs(job),
+		InputPathListPaths: ticketlessInputPaths(job),
+		FileMetadata:       buildFileMetadata(job.FileMetadata),
+	}
+
+	return spec, nil
+}
+
+// buildResourceSpec extracts the raw resource asks. The cluster's
+// default/clamp policy is applied operator-side, so only the asks ride here.
+func buildResourceSpec(job *model.Job) operatorclient.ResourceSpec {
+	container := job.Steps[0].Component.Container
+	rs := operatorclient.ResourceSpec{
+		MinCPUCores:    container.MinCPUCores,
+		MaxCPUCores:    container.MaxCPUCores,
+		MinMemoryBytes: container.MinMemoryLimit,
+		MaxMemoryBytes: container.MemoryLimit,
+		MinDiskBytes:   maxDiskSpace(job),
+	}
+	if shm := resourcing.SharedMemoryAmount(job); shm != nil {
+		bytes := shm.Value()
+		rs.SharedMemoryBytes = &bytes
+	}
+	return rs
+}
+
+// maxDiskSpace returns the largest MinDiskSpace across the job's steps, matching
+// incluster.getPersistentVolumeCapacity. VICE is single-step, but the max keeps
+// parity with the legacy builder.
+func maxDiskSpace(job *model.Job) int64 {
+	var maxDisk int64
+	for _, step := range job.Steps {
+		if d := step.Component.Container.MinDiskSpace; d > maxDisk {
+			maxDisk = d
+		}
+	}
+	return maxDisk
+}
+
+// buildGPUSpec resolves the analysis's GPU request into a canonical, vendor-
+// neutral GPUSpec, or nil when no GPU is requested. The vendor is nvidia today
+// (model.Job carries no vendor); the count folds the legacy /dev/nvidia and
+// MinGPUs/MaxGPUs logic into the single effective count the operator emits with
+// requests == limits.
+func buildGPUSpec(job *model.Job) *operatorclient.GPUSpec {
+	if !resourcing.GPUEnabled(job) {
+		return nil
+	}
+	container := job.Steps[0].Component.Container
+	return &operatorclient.GPUSpec{
+		Vendor: operatorclient.GPUVendorNvidia,
+		Count:  effectiveGPUCount(container.MinGPUs, container.MaxGPUs),
+		Models: resourcing.GPUModelsRequested(job),
+	}
+}
+
+// effectiveGPUCount mirrors the count the operator's equalizeGPUResources would
+// settle on: the higher of the requested min/max, defaulting to 1 for a legacy
+// device-path GPU with neither field set.
+func effectiveGPUCount(minGPUs, maxGPUs int64) int64 {
+	if maxGPUs > 0 {
+		return maxGPUs
+	}
+	if minGPUs > 0 {
+		return minGPUs
+	}
+	return 1
+}
+
+// buildInputSpecs resolves every input across all steps into the CSI mount
+// view (full list, with resolved iRODS paths and types).
+func buildInputSpecs(job *model.Job) []operatorclient.InputSpec {
+	var inputs []operatorclient.InputSpec
+	for s := range job.Steps {
+		for in := range job.Steps[s].Config.Inputs {
+			input := &job.Steps[s].Config.Inputs[in]
+			inputs = append(inputs, operatorclient.InputSpec{
+				IRODSPath: input.IRODSPath(),
+				Type:      input.Type,
+			})
+		}
+	}
+	return inputs
+}
+
+// ticketlessInputPaths resolves the input-path-list view: the iRODS paths of
+// inputs without download tickets (the subset porklock stages).
+func ticketlessInputPaths(job *model.Job) []string {
+	withoutTickets := job.FilterInputsWithoutTickets()
+	if len(withoutTickets) == 0 {
+		return nil
+	}
+	paths := make([]string, 0, len(withoutTickets))
+	for i := range withoutTickets {
+		paths = append(paths, withoutTickets[i].IRODSPath())
+	}
+	return paths
+}
+
+func buildFileMetadata(metadata []model.FileMetadata) []operatorclient.MetadataAVU {
+	if len(metadata) == 0 {
+		return nil
+	}
+	out := make([]operatorclient.MetadataAVU, 0, len(metadata))
+	for _, m := range metadata {
+		out = append(out, operatorclient.MetadataAVU{
+			Attribute: m.Attribute,
+			Value:     m.Value,
+			Unit:      m.Unit,
+		})
+	}
+	return out
+}

--- a/incluster/vicespec_test.go
+++ b/incluster/vicespec_test.go
@@ -1,0 +1,71 @@
+package incluster
+
+import (
+	"testing"
+
+	"github.com/cyverse-de/app-exposer/constants"
+	"github.com/cyverse-de/app-exposer/operatorclient"
+	"github.com/cyverse-de/model/v10"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBuildVICESpecMapping checks the resolved field mapping that
+// buildVICESpec performs — the values the operator would otherwise have to
+// re-derive from model.Job.
+func TestBuildVICESpecMapping(t *testing.T) {
+	job := goldenJob(true) // nvidia GPU, min 1 / max 2, model NVIDIA-A10G
+	job.FileMetadata = []model.FileMetadata{{Attribute: "ipc-batch", Value: "true", Unit: ""}}
+
+	spec, err := buildVICESpec(job, constants.AnalysisID(job.ID), "10.0.0.1")
+	require.NoError(t, err)
+
+	assert.Equal(t, operatorclient.CurrentVICESpecVersion, spec.SpecVersion)
+	assert.Equal(t, constants.AnalysisID("analysis-1"), spec.AnalysisID)
+	assert.Equal(t, constants.ExternalID("external-1"), spec.ExternalID)
+	assert.Equal(t, "10.0.0.1", spec.UserLoginIP)
+	assert.Equal(t, "cyverse/jupyter", spec.Container.Image)
+	assert.Equal(t, []int{8888}, spec.Container.Ports)
+	assert.Equal(t, map[string]string{"FOO": "bar"}, spec.Environment)
+
+	// GPU resolves to a vendor-neutral spec; count folds min/max to the higher.
+	require.NotNil(t, spec.GPU)
+	assert.Equal(t, operatorclient.GPUVendorNvidia, spec.GPU.Vendor)
+	assert.Equal(t, int64(2), spec.GPU.Count)
+	assert.Equal(t, []string{"NVIDIA-A10G"}, spec.GPU.Models)
+
+	// Resource asks ride raw (no clamp applied here).
+	assert.Equal(t, float32(1), spec.Resources.MinCPUCores)
+	assert.Equal(t, float32(4), spec.Resources.MaxCPUCores)
+
+	// File metadata maps across without the model dependency.
+	require.Len(t, spec.FileMetadata, 1)
+	assert.Equal(t, "ipc-batch", spec.FileMetadata[0].Attribute)
+}
+
+func TestBuildVICESpecNoGPU(t *testing.T) {
+	spec, err := buildVICESpec(goldenJob(false), "analysis-1", "10.0.0.1")
+	require.NoError(t, err)
+	assert.Nil(t, spec.GPU, "no GPU requested → nil GPU spec")
+}
+
+func TestBuildVICESpecNoSteps(t *testing.T) {
+	_, err := buildVICESpec(&model.Job{ID: "j-1"}, "analysis-1", "10.0.0.1")
+	require.Error(t, err)
+}
+
+// TestEffectiveGPUCount documents the min/max → single-count folding that
+// matches the operator's request==limit equalization.
+func TestEffectiveGPUCount(t *testing.T) {
+	tests := []struct {
+		min, max, want int64
+	}{
+		{min: 1, max: 2, want: 2},
+		{min: 2, max: 0, want: 2},
+		{min: 0, max: 3, want: 3},
+		{min: 0, max: 0, want: 1}, // legacy device-path GPU
+	}
+	for _, tt := range tests {
+		assert.Equal(t, tt.want, effectiveGPUCount(tt.min, tt.max))
+	}
+}

--- a/operator/capacity_test.go
+++ b/operator/capacity_test.go
@@ -242,6 +242,26 @@ func TestHandleCapacityIncludesGPUVendor(t *testing.T) {
 	}
 }
 
+// TestHandleCapacityAdvertisesSpecVersion confirms HandleCapacity reports the
+// operator's max supported VICESpec version, which the scheduler reads to
+// decide whether to send a spec or fall back to the legacy bundle.
+func TestHandleCapacityAdvertisesSpecVersion(t *testing.T) {
+	op, _, _ := newTestOperator(t, 10)
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/capacity", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	require.NoError(t, op.HandleCapacity(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp operatorclient.CapacityResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, operatorclient.CurrentVICESpecVersion, resp.SpecVersion)
+	assert.True(t, resp.SupportsSpecVersion(operatorclient.CurrentVICESpecVersion))
+}
+
 // TestHandleCapacityIncludesGPUModels confirms that HandleCapacity copies
 // the operator's configured GPU model list into the response so the
 // scheduler can filter capability at routing time.

--- a/operator/capacity_test.go
+++ b/operator/capacity_test.go
@@ -262,6 +262,27 @@ func TestHandleCapacityAdvertisesSpecVersion(t *testing.T) {
 	assert.True(t, resp.SupportsSpecVersion(operatorclient.CurrentVICESpecVersion))
 }
 
+// TestHandleCapacitySpecLaunchDisabled confirms that with spec launch disabled
+// the operator advertises SpecVersion 0, which the scheduler reads as "send a
+// legacy bundle" — the per-operator rollback lever.
+func TestHandleCapacitySpecLaunchDisabled(t *testing.T) {
+	op, _, _ := newTestOperator(t, 10)
+	op.disableSpecLaunch = true
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/capacity", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	require.NoError(t, op.HandleCapacity(c))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp operatorclient.CapacityResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, 0, resp.SpecVersion)
+	assert.False(t, resp.SupportsSpecVersion(operatorclient.CurrentVICESpecVersion))
+}
+
 // TestHandleCapacityIncludesGPUModels confirms that HandleCapacity copies
 // the operator's configured GPU model list into the response so the
 // scheduler can filter capability at routing time.

--- a/operator/handlers.go
+++ b/operator/handlers.go
@@ -11,6 +11,7 @@ import (
 	"github.com/cyverse-de/app-exposer/constants"
 	"github.com/cyverse-de/app-exposer/operatorclient"
 	"github.com/cyverse-de/app-exposer/reporting"
+	"github.com/cyverse-de/app-exposer/vicebuild"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
 
@@ -68,6 +69,20 @@ type Operator struct {
 	httpClient          HTTPClient          // Client for contacting the vice-proxy sidecar.
 	userSuffix          string              // Domain suffix for usernames (e.g. "@iplantcollaborative.org").
 	localStorageClass   string              // StorageClass for the per-analysis working-dir PVC; empty means cluster default.
+
+	// Construction config for the operator-side VICESpec build path. These are
+	// the cluster values vicebuild needs that the legacy transform path didn't
+	// require app-exposer to know. Populated from cmd/vice-operator flags.
+	porklockImage           string
+	porklockTag             string
+	viceProxyImage          string
+	useCSIDriver            bool
+	frontendBaseURL         string
+	irodsZone               string
+	inputPathListIdentifier string
+	gatewayProvider         string
+	imagePullSecretName     string
+	resourceDefaults        vicebuild.ResourceDefaults
 }
 
 // OperatorOptions aggregates everything NewOperator needs. Held as a
@@ -95,6 +110,19 @@ type OperatorOptions struct {
 	EgressConfig        NetworkPolicyConfig // Egress policy config for per-analysis policies.
 	UserSuffix          string              // Domain suffix for usernames (e.g. "@iplantcollaborative.org").
 	LocalStorageClass   string              // StorageClass for the per-analysis working-dir PVC; empty means cluster default.
+
+	// VICESpec construction config (see Operator). These drive the
+	// operator-side build path; the legacy bundle path ignores them.
+	PorklockImage           string
+	PorklockTag             string
+	ViceProxyImage          string
+	UseCSIDriver            bool
+	FrontendBaseURL         string
+	IRODSZone               string
+	InputPathListIdentifier string
+	GatewayProvider         string
+	ImagePullSecretName     string
+	ResourceDefaults        vicebuild.ResourceDefaults
 }
 
 // Validate confirms the wiring-critical fields are present. The caller
@@ -153,7 +181,63 @@ func NewOperator(opts OperatorOptions) (*Operator, error) {
 		httpClient:          noRedirectHTTPClient,
 		userSuffix:          opts.UserSuffix,
 		localStorageClass:   opts.LocalStorageClass,
+
+		porklockImage:           opts.PorklockImage,
+		porklockTag:             opts.PorklockTag,
+		viceProxyImage:          opts.ViceProxyImage,
+		useCSIDriver:            opts.UseCSIDriver,
+		frontendBaseURL:         opts.FrontendBaseURL,
+		irodsZone:               opts.IRODSZone,
+		inputPathListIdentifier: opts.InputPathListIdentifier,
+		gatewayProvider:         opts.GatewayProvider,
+		imagePullSecretName:     opts.ImagePullSecretName,
+		resourceDefaults:        opts.ResourceDefaults,
 	}, nil
+}
+
+// viceBuildConfig assembles the vicebuild.Config from the operator's cluster
+// configuration. This is the single place the operator's scattered config
+// fields map onto the builder's input, so the spec launch path and any future
+// build callers stay consistent.
+func (o *Operator) viceBuildConfig() vicebuild.Config {
+	gwNamespace := o.gatewayNamespace
+	if gwNamespace == "" {
+		gwNamespace = o.namespace
+	}
+	var rewriter func(string) string
+	if o.imageRewriter != nil {
+		rewriter = func(ref string) string {
+			if mirrored, ok := o.imageRewriter.RewriteImage(ref); ok {
+				return mirrored
+			}
+			return ref
+		}
+	}
+	return vicebuild.Config{
+		PorklockImage:           o.porklockImage,
+		PorklockTag:             o.porklockTag,
+		ViceProxyImage:          o.viceProxyImage,
+		UseCSIDriver:            o.useCSIDriver,
+		IRODSZone:               o.irodsZone,
+		LocalStorageClass:       o.localStorageClass,
+		FrontendBaseURL:         o.frontendBaseURL,
+		BaseDomain:              o.baseDomain,
+		Namespace:               o.namespace,
+		GatewayNamespace:        gwNamespace,
+		GatewayName:             o.gatewayName,
+		GatewayProvider:         o.gatewayProvider,
+		ImagePullSecretName:     o.imagePullSecretName,
+		ClusterConfigSecretName: o.clusterConfigSecret,
+		UserSuffix:              o.userSuffix,
+		InputPathListIdentifier: o.inputPathListIdentifier,
+		GPUVendor:               string(o.gpuVendor),
+		GPUModelAffinityKey:     o.gpuModelAffinityKey,
+		GPUModelMapping:         o.gpuModelMapping,
+		LoadingServiceName:      o.loadingServiceName,
+		LoadingServicePort:      o.loadingServicePort,
+		ImageRewriter:           rewriter,
+		Resources:               o.resourceDefaults,
+	}
 }
 
 // getAccessURL contacts the vice-proxy sidecar through its in-cluster Service
@@ -210,6 +294,7 @@ func (o *Operator) HandleCapacity(c echo.Context) error {
 	}
 	cap.GPUVendor = string(o.gpuVendor)
 	cap.SupportedGPUModels = o.gpuModels
+	cap.SpecVersion = operatorclient.CurrentVICESpecVersion
 	return c.JSON(http.StatusOK, cap)
 }
 
@@ -291,31 +376,101 @@ func (o *Operator) HandleLaunch(c echo.Context) error {
 		TransformImageRefs(bundle.Deployment, o.imageRewriter)
 	}
 
-	// Apply all resources via upsert pattern.
-	if err := o.applyBundle(ctx, &bundle); err != nil {
+	if err := o.applyBundleAndEgress(ctx, &bundle); err != nil {
 		log.Errorf("launch failed for analysis %s: %v", bundle.AnalysisID, err)
-		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
-	}
-
-	// Create a per-analysis egress NetworkPolicy using the cluster's egress
-	// config. This is done by vice-operator (not app-exposer) because only
-	// the operator knows the cluster environment (blocked CIDRs, Keycloak
-	// IPs, internet access setting, etc.). Deployment metadata labels are
-	// used (not pod template labels) because they always include analysis-id,
-	// which deleteAnalysisResources uses for label-based cleanup.
-	bundleLabels := bundle.Deployment.Labels
-	np := buildAnalysisEgressPolicy(string(bundle.AnalysisID), o.namespace, bundleLabels, o.egressConfig)
-	if len(np.Spec.Egress) == 0 {
-		log.Warnf("analysis %s egress policy has no allow rules; pods will have DNS-only egress", bundle.AnalysisID)
-	}
-	npClient := o.clientset.NetworkingV1().NetworkPolicies(o.namespace)
-	if err := upsert(ctx, npClient, "NetworkPolicy", np.Name, np); err != nil {
-		log.Errorf("egress policy failed for analysis %s: %v", bundle.AnalysisID, err)
 		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
 
 	log.Infof("launch succeeded for analysis %s", bundle.AnalysisID)
 	return c.JSON(http.StatusCreated, map[string]string{"analysisID": string(bundle.AnalysisID)})
+}
+
+// applyBundleAndEgress applies every resource in the bundle and creates the
+// per-analysis egress NetworkPolicy. Shared by the legacy object launch path
+// and the VICESpec launch path, which differ only in how the bundle is
+// produced. The egress policy is built operator-side because only the operator
+// knows the cluster environment (blocked CIDRs, Keycloak IPs, internet-access
+// setting); it keys on the deployment's analysis-id label, which
+// deleteAnalysisResources also uses for cleanup.
+func (o *Operator) applyBundleAndEgress(ctx context.Context, bundle *operatorclient.AnalysisBundle) error {
+	if err := o.applyBundle(ctx, bundle); err != nil {
+		return err
+	}
+
+	np := buildAnalysisEgressPolicy(string(bundle.AnalysisID), o.namespace, bundle.Deployment.Labels, o.egressConfig)
+	if len(np.Spec.Egress) == 0 {
+		log.Warnf("analysis %s egress policy has no allow rules; pods will have DNS-only egress", bundle.AnalysisID)
+	}
+	npClient := o.clientset.NetworkingV1().NetworkPolicies(o.namespace)
+	if err := upsert(ctx, npClient, "NetworkPolicy", np.Name, np); err != nil {
+		return fmt.Errorf("egress policy failed for analysis %s: %w", bundle.AnalysisID, err)
+	}
+	return nil
+}
+
+// HandleLaunchSpec receives a cluster-agnostic VICESpec, builds the concrete
+// k8s objects for this cluster via vicebuild, and applies them. It is the
+// operator-side construction path that replaces the legacy "receive pre-built
+// objects + transform" flow; the two coexist during migration, selected by
+// app-exposer per the operator's advertised SpecVersion.
+//
+//	@Summary		Launch a VICE analysis from a spec
+//	@Description	Receives a cluster-agnostic VICESpec, builds the k8s objects for
+//	@Description	this cluster, and applies them. Returns 409 if at capacity.
+//	@Tags			analyses
+//	@Accept			json
+//	@Produce		json
+//	@Param			request	body		operatorclient.VICESpec	true	"The analysis spec to launch"
+//	@Success		201		{object}	map[string]string
+//	@Failure		400		{object}	common.ErrorResponse
+//	@Failure		409		{object}	common.ErrorResponse
+//	@Failure		500		{object}	common.ErrorResponse
+//	@Router			/analyses/spec [post]
+func (o *Operator) HandleLaunchSpec(c echo.Context) error {
+	ctx := c.Request().Context()
+
+	var spec operatorclient.VICESpec
+	if err := c.Bind(&spec); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
+	}
+	if err := spec.Validate(); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
+	}
+	// Reject specs newer than this operator can faithfully build. The scheduler
+	// should already have skipped us via the advertised SpecVersion; this is the
+	// defensive backstop, returning 400 so app-exposer fails fast rather than
+	// the operator silently mis-building.
+	if spec.SpecVersion > operatorclient.CurrentVICESpecVersion {
+		return echo.NewHTTPError(http.StatusBadRequest,
+			fmt.Sprintf("unsupported spec version %d; this operator supports up to %d (upgrade the operator to launch this analysis)",
+				spec.SpecVersion, operatorclient.CurrentVICESpecVersion))
+	}
+
+	cap, err := o.capacityCalc.Calculate(ctx)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+	if !cap.HasCapacity() {
+		log.Infof("spec launch rejected: at capacity (analysis %s)", spec.AnalysisID)
+		return echo.NewHTTPError(http.StatusConflict, "operator at capacity")
+	}
+
+	log.Infof("launching analysis %s from spec", spec.AnalysisID)
+
+	cfg := o.viceBuildConfig()
+	bundle, err := cfg.BuildBundle(&spec)
+	if err != nil {
+		log.Errorf("building objects for analysis %s failed: %v; this usually means a malformed spec (e.g. an unrecognized input type)", spec.AnalysisID, err)
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
+	}
+
+	if err := o.applyBundleAndEgress(ctx, bundle); err != nil {
+		log.Errorf("spec launch failed for analysis %s: %v", spec.AnalysisID, err)
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+
+	log.Infof("spec launch succeeded for analysis %s", spec.AnalysisID)
+	return c.JSON(http.StatusCreated, map[string]string{"analysisID": string(spec.AnalysisID)})
 }
 
 // HandleExit deletes all K8s resources associated with an analysis by its

--- a/operator/handlers.go
+++ b/operator/handlers.go
@@ -465,8 +465,10 @@ func (o *Operator) HandleLaunchSpec(c echo.Context) error {
 	}
 
 	if err := o.applyBundleAndEgress(ctx, bundle); err != nil {
+		// Log the full error (k8s resource/namespace detail) server-side; return
+		// a generic message so cluster internals don't leak in the response body.
 		log.Errorf("spec launch failed for analysis %s: %v", spec.AnalysisID, err)
-		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+		return echo.NewHTTPError(http.StatusInternalServerError, "failed to apply analysis resources; see operator logs")
 	}
 
 	log.Infof("spec launch succeeded for analysis %s", spec.AnalysisID)

--- a/operator/handlers.go
+++ b/operator/handlers.go
@@ -83,6 +83,10 @@ type Operator struct {
 	gatewayProvider         string
 	imagePullSecretName     string
 	resourceDefaults        vicebuild.ResourceDefaults
+	// disableSpecLaunch turns off the operator-side spec build path: the
+	// operator advertises SpecVersion 0 (so app-exposer routes it a legacy
+	// bundle) and rejects direct spec launches. The per-operator rollback lever.
+	disableSpecLaunch bool
 }
 
 // OperatorOptions aggregates everything NewOperator needs. Held as a
@@ -123,6 +127,7 @@ type OperatorOptions struct {
 	GatewayProvider         string
 	ImagePullSecretName     string
 	ResourceDefaults        vicebuild.ResourceDefaults
+	DisableSpecLaunch       bool
 }
 
 // Validate confirms the wiring-critical fields are present. The caller
@@ -192,6 +197,7 @@ func NewOperator(opts OperatorOptions) (*Operator, error) {
 		gatewayProvider:         opts.GatewayProvider,
 		imagePullSecretName:     opts.ImagePullSecretName,
 		resourceDefaults:        opts.ResourceDefaults,
+		disableSpecLaunch:       opts.DisableSpecLaunch,
 	}, nil
 }
 
@@ -294,7 +300,11 @@ func (o *Operator) HandleCapacity(c echo.Context) error {
 	}
 	cap.GPUVendor = string(o.gpuVendor)
 	cap.SupportedGPUModels = o.gpuModels
-	cap.SpecVersion = operatorclient.CurrentVICESpecVersion
+	// Advertise spec support unless it's been switched off, in which case 0
+	// tells the scheduler to send this operator a legacy bundle instead.
+	if !o.disableSpecLaunch {
+		cap.SpecVersion = operatorclient.CurrentVICESpecVersion
+	}
 	return c.JSON(http.StatusOK, cap)
 }
 
@@ -425,9 +435,18 @@ func (o *Operator) applyBundleAndEgress(ctx context.Context, bundle *operatorcli
 //	@Failure		400		{object}	common.ErrorResponse
 //	@Failure		409		{object}	common.ErrorResponse
 //	@Failure		500		{object}	common.ErrorResponse
+//	@Failure		503		{object}	common.ErrorResponse	"Spec launch disabled on this operator"
 //	@Router			/analyses/spec [post]
 func (o *Operator) HandleLaunchSpec(c echo.Context) error {
 	ctx := c.Request().Context()
+
+	// Defensive backstop: with spec launch disabled the operator advertises
+	// SpecVersion 0, so the scheduler shouldn't route a spec here at all. A 503
+	// is transient, so a spec that arrives anyway is retried on another operator
+	// rather than failing the launch outright.
+	if o.disableSpecLaunch {
+		return echo.NewHTTPError(http.StatusServiceUnavailable, "spec launch is disabled on this operator")
+	}
 
 	var spec operatorclient.VICESpec
 	if err := c.Bind(&spec); err != nil {

--- a/operator/handlers.go
+++ b/operator/handlers.go
@@ -387,8 +387,10 @@ func (o *Operator) HandleLaunch(c echo.Context) error {
 	}
 
 	if err := o.applyBundleAndEgress(ctx, &bundle); err != nil {
+		// Log the full error server-side; return a generic message so cluster
+		// internals don't leak in the response body (matches HandleLaunchSpec).
 		log.Errorf("launch failed for analysis %s: %v", bundle.AnalysisID, err)
-		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+		return echo.NewHTTPError(http.StatusInternalServerError, "failed to apply analysis resources; see operator logs")
 	}
 
 	log.Infof("launch succeeded for analysis %s", bundle.AnalysisID)
@@ -441,9 +443,9 @@ func (o *Operator) HandleLaunchSpec(c echo.Context) error {
 	ctx := c.Request().Context()
 
 	// Defensive backstop: with spec launch disabled the operator advertises
-	// SpecVersion 0, so the scheduler shouldn't route a spec here at all. A 503
-	// is transient, so a spec that arrives anyway is retried on another operator
-	// rather than failing the launch outright.
+	// SpecVersion 0, so the scheduler never routes a spec here. This guards
+	// direct callers (admin tools, integration tests). A 503 is transient, so
+	// such a caller treats it as retryable rather than a permanent failure.
 	if o.disableSpecLaunch {
 		return echo.NewHTTPError(http.StatusServiceUnavailable, "spec launch is disabled on this operator")
 	}
@@ -479,8 +481,11 @@ func (o *Operator) HandleLaunchSpec(c echo.Context) error {
 	cfg := o.viceBuildConfig()
 	bundle, err := cfg.BuildBundle(&spec)
 	if err != nil {
+		// Log the full error (may contain iRODS paths and internal mount
+		// layout) server-side; return a generic message so cluster internals
+		// don't leak in the response body.
 		log.Errorf("building objects for analysis %s failed: %v; this usually means a malformed spec (e.g. an unrecognized input type)", spec.AnalysisID, err)
-		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
+		return echo.NewHTTPError(http.StatusBadRequest, "failed to build k8s objects from spec; see operator logs")
 	}
 
 	if err := o.applyBundleAndEgress(ctx, bundle); err != nil {

--- a/operator/handlers_launch_spec_test.go
+++ b/operator/handlers_launch_spec_test.go
@@ -161,6 +161,23 @@ func TestHandleLaunchSpecValidation(t *testing.T) {
 	}
 }
 
+// TestHandleLaunchSpecDisabled confirms the spec endpoint refuses launches when
+// spec launch is disabled, returning a transient 503 so a stray spec is retried
+// elsewhere rather than failing outright.
+func TestHandleLaunchSpecDisabled(t *testing.T) {
+	op, clientset, _ := newTestOperator(t, 10)
+	configureBuild(op)
+	op.disableSpecLaunch = true
+
+	rec, err := postSpec(t, op, specTestSpec())
+	assert.Equal(t, http.StatusServiceUnavailable, statusFromResult(t, rec, err))
+
+	// Nothing should have been created.
+	deps, listErr := clientset.AppsV1().Deployments("vice-apps").List(context.Background(), metav1.ListOptions{})
+	require.NoError(t, listErr)
+	assert.Empty(t, deps.Items, "no resources should be created when spec launch is disabled")
+}
+
 // prefillSlot occupies the operator's single capacity slot with an existing
 // VICE deployment.
 func prefillSlot(t *testing.T, op *Operator) {

--- a/operator/handlers_launch_spec_test.go
+++ b/operator/handlers_launch_spec_test.go
@@ -1,0 +1,183 @@
+package operator
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/cyverse-de/app-exposer/constants"
+	"github.com/cyverse-de/app-exposer/operatorclient"
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	apiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func specTestSpec() operatorclient.VICESpec {
+	return operatorclient.VICESpec{
+		SpecVersion: operatorclient.CurrentVICESpecVersion,
+		AnalysisID:  "spec-analysis-1",
+		ExternalID:  "spec-external-1",
+		JobName:     "My Spec Analysis",
+		AppID:       "app-1",
+		AppName:     "JupyterLab",
+		UserID:      "user-1",
+		Submitter:   "someuser",
+		UserLoginIP: "10.0.0.1",
+		Container: operatorclient.ContainerSpec{
+			Image:      "cyverse/jupyter",
+			Tag:        "latest",
+			UID:        1000,
+			Ports:      []int{8888},
+			WorkingDir: "/de-app-work",
+		},
+		UserHome: "/cyverse/home/someuser",
+	}
+}
+
+// configureBuild sets the build-path config the test operator needs; the shared
+// newTestOperator helper leaves these zero because the legacy path doesn't use
+// them.
+func configureBuild(op *Operator) {
+	op.porklockImage = "discoenv/vice-file-transfers"
+	op.porklockTag = "latest"
+	op.viceProxyImage = "harbor.cyverse.org/de/vice-proxy:latest"
+	op.frontendBaseURL = "https://cyverse.run"
+	op.irodsZone = "cyverse"
+	op.gatewayProvider = "traefik"
+	op.imagePullSecretName = "vice-image-pull-secret"
+}
+
+func postSpec(t *testing.T, op *Operator, spec operatorclient.VICESpec) (*httptest.ResponseRecorder, error) {
+	t.Helper()
+	body, err := json.Marshal(spec)
+	require.NoError(t, err)
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/analyses/spec", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	return rec, op.HandleLaunchSpec(c)
+}
+
+func statusFromResult(t *testing.T, rec *httptest.ResponseRecorder, err error) int {
+	t.Helper()
+	if err != nil {
+		he, ok := err.(*echo.HTTPError)
+		require.True(t, ok, "expected *echo.HTTPError, got %T: %v", err, err)
+		return he.Code
+	}
+	return rec.Code
+}
+
+// TestHandleLaunchSpecCreatesResources is the Phase 2 integration test: a
+// VICESpec POSTed to the operator is built into cluster-correct objects and
+// applied, including the per-analysis egress NetworkPolicy keyed on analysis-id.
+func TestHandleLaunchSpecCreatesResources(t *testing.T) {
+	op, clientset, gwClientset := newTestOperator(t, 10)
+	configureBuild(op)
+
+	rec, err := postSpec(t, op, specTestSpec())
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusCreated, rec.Code)
+
+	ctx := context.Background()
+	ns := "vice-apps"
+
+	dep, err := clientset.AppsV1().Deployments(ns).Get(ctx, "spec-external-1", metav1.GetOptions{})
+	require.NoError(t, err, "deployment should exist")
+	assert.Equal(t, "spec-analysis-1", dep.Labels[constants.AnalysisIDLabel])
+	require.Len(t, dep.Spec.Template.Spec.ImagePullSecrets, 1, "image pull secret should be set from operator config")
+	assert.Equal(t, "vice-image-pull-secret", dep.Spec.Template.Spec.ImagePullSecrets[0].Name)
+
+	_, err = clientset.CoreV1().Services(ns).Get(ctx, "vice-spec-external-1", metav1.GetOptions{})
+	assert.NoError(t, err, "service should exist")
+
+	_, err = gwClientset.GatewayV1().HTTPRoutes(ns).Get(ctx, "spec-external-1", metav1.GetOptions{})
+	assert.NoError(t, err, "httproute should exist")
+
+	// Excludes, permissions, and input-path-list ConfigMaps.
+	cms, err := clientset.CoreV1().ConfigMaps(ns).List(ctx, metav1.ListOptions{})
+	require.NoError(t, err)
+	assert.Len(t, cms.Items, 3, "excludes, permissions, and input-path-list ConfigMaps")
+
+	_, err = clientset.CoreV1().PersistentVolumeClaims(ns).Get(ctx, "working-dir-spec-external-1", metav1.GetOptions{})
+	assert.NoError(t, err, "working-dir PVC should exist")
+
+	_, err = clientset.PolicyV1().PodDisruptionBudgets(ns).Get(ctx, "spec-external-1", metav1.GetOptions{})
+	assert.NoError(t, err, "PDB should exist")
+
+	np, err := clientset.NetworkingV1().NetworkPolicies(ns).Get(ctx, "vice-egress-spec-analysis-1", metav1.GetOptions{})
+	require.NoError(t, err, "per-analysis egress NetworkPolicy should exist")
+	assert.Equal(t, "spec-analysis-1", np.Labels[constants.AnalysisIDLabel])
+}
+
+func TestHandleLaunchSpecValidation(t *testing.T) {
+	tests := []struct {
+		name       string
+		mutate     func(*operatorclient.VICESpec)
+		maxSlots   int
+		setup      func(t *testing.T, op *Operator)
+		wantStatus int
+	}{
+		{name: "valid", mutate: func(*operatorclient.VICESpec) {}, maxSlots: 10, wantStatus: http.StatusCreated},
+		{name: "missing image", mutate: func(s *operatorclient.VICESpec) { s.Container.Image = "" }, maxSlots: 10, wantStatus: http.StatusBadRequest},
+		{name: "missing analysisID", mutate: func(s *operatorclient.VICESpec) { s.AnalysisID = "" }, maxSlots: 10, wantStatus: http.StatusBadRequest},
+		{
+			name:       "spec version too new",
+			mutate:     func(s *operatorclient.VICESpec) { s.SpecVersion = operatorclient.CurrentVICESpecVersion + 1 },
+			maxSlots:   10,
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:     "at capacity",
+			mutate:   func(*operatorclient.VICESpec) {},
+			maxSlots: 1,
+			setup: func(t *testing.T, op *Operator) {
+				t.Helper()
+				prefillSlot(t, op)
+			},
+			wantStatus: http.StatusConflict,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			op, _, _ := newTestOperator(t, tt.maxSlots)
+			configureBuild(op)
+			if tt.setup != nil {
+				tt.setup(t, op)
+			}
+			spec := specTestSpec()
+			tt.mutate(&spec)
+			rec, err := postSpec(t, op, spec)
+			assert.Equal(t, tt.wantStatus, statusFromResult(t, rec, err))
+		})
+	}
+}
+
+// prefillSlot occupies the operator's single capacity slot with an existing
+// VICE deployment.
+func prefillSlot(t *testing.T, op *Operator) {
+	t.Helper()
+	dep := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "existing-dep",
+			Labels: map[string]string{constants.AppTypeLabel: "interactive"},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "existing"}},
+			Template: apiv1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "existing"}},
+				Spec:       apiv1.PodSpec{Containers: []apiv1.Container{{Name: "c", Image: "img"}}},
+			},
+		},
+	}
+	_, err := op.clientset.AppsV1().Deployments("vice-apps").Create(context.Background(), dep, metav1.CreateOptions{})
+	require.NoError(t, err)
+}

--- a/operator/imagecache_test.go
+++ b/operator/imagecache_test.go
@@ -250,10 +250,10 @@ func TestHandleGetCachedImageNotFound(t *testing.T) {
 // per-image endpoints. Malformed IDs must not be forwarded to the K8s API.
 func TestImageCacheIDValidation(t *testing.T) {
 	tests := []struct {
-		name     string
-		id       string
-		wantGet  int // expected status from HandleGetCachedImage
-		wantDel  int // expected status from HandleDeleteCachedImage
+		name    string
+		id      string
+		wantGet int // expected status from HandleGetCachedImage
+		wantDel int // expected status from HandleDeleteCachedImage
 	}{
 		{name: "empty id", id: "", wantGet: http.StatusNotFound, wantDel: http.StatusOK},
 		{name: "uppercase rejected", id: "Bad-Slug", wantGet: http.StatusNotFound, wantDel: http.StatusOK},

--- a/operator/landing_test.go
+++ b/operator/landing_test.go
@@ -15,9 +15,9 @@ func TestHandleLandingPage(t *testing.T) {
 	// theme from the shared partials. Asserting on a marker from each confirms
 	// the partials parsed and rendered, not just that the page returned 200.
 	wantContains := []string{
-		"VICE Operator",                                  // page heading
-		"API Documentation",                              // docs link text
-		"/docs/index.html",                               // docs link target
+		"VICE Operator",     // page heading
+		"API Documentation", // docs link text
+		"/docs/index.html",  // docs link target
 		"Powered by CyVerse at The University of Arizona", // footer partial
 		`viewBox="0 0 157.37 37.79"`,                      // brand/logo partial
 	}

--- a/operator/transform_images_test.go
+++ b/operator/transform_images_test.go
@@ -50,35 +50,35 @@ func TestTransformImageRefs(t *testing.T) {
 	}}
 
 	tests := []struct {
-		name           string
-		initIn, mainIn []string
+		name               string
+		initIn, mainIn     []string
 		wantInit, wantMain []string
 	}{
 		{
-			name: "no images match: deployment unchanged",
-			initIn: []string{"harbor.cyverse.org/de/unrelated:1"},
-			mainIn: []string{"harbor.cyverse.org/de/also-unrelated:2"},
+			name:     "no images match: deployment unchanged",
+			initIn:   []string{"harbor.cyverse.org/de/unrelated:1"},
+			mainIn:   []string{"harbor.cyverse.org/de/also-unrelated:2"},
 			wantInit: []string{"harbor.cyverse.org/de/unrelated:1"},
 			wantMain: []string{"harbor.cyverse.org/de/also-unrelated:2"},
 		},
 		{
-			name: "init container is rewritten",
-			initIn: []string{"harbor.cyverse.org/de/porklock:latest"},
-			mainIn: []string{"harbor.cyverse.org/de/vice-app:latest"},
+			name:     "init container is rewritten",
+			initIn:   []string{"harbor.cyverse.org/de/porklock:latest"},
+			mainIn:   []string{"harbor.cyverse.org/de/vice-app:latest"},
 			wantInit: []string{"ecr/porklock:latest"},
 			wantMain: []string{"harbor.cyverse.org/de/vice-app:latest"},
 		},
 		{
-			name: "main container is rewritten",
-			initIn: []string{},
-			mainIn: []string{"harbor.cyverse.org/de/vice-proxy:latest"},
+			name:     "main container is rewritten",
+			initIn:   []string{},
+			mainIn:   []string{"harbor.cyverse.org/de/vice-proxy:latest"},
 			wantInit: []string{},
 			wantMain: []string{"ecr/vice-proxy:latest"},
 		},
 		{
-			name: "both kinds of containers rewritten in one pass",
-			initIn: []string{"harbor.cyverse.org/de/porklock:latest"},
-			mainIn: []string{"harbor.cyverse.org/de/vice-proxy:latest", "harbor.cyverse.org/de/unrelated:3"},
+			name:     "both kinds of containers rewritten in one pass",
+			initIn:   []string{"harbor.cyverse.org/de/porklock:latest"},
+			mainIn:   []string{"harbor.cyverse.org/de/vice-proxy:latest", "harbor.cyverse.org/de/unrelated:3"},
 			wantInit: []string{"ecr/porklock:latest"},
 			wantMain: []string{"ecr/vice-proxy:latest", "harbor.cyverse.org/de/unrelated:3"},
 		},

--- a/operatorclient/client.go
+++ b/operatorclient/client.go
@@ -196,6 +196,37 @@ func (c *Client) Launch(ctx context.Context, bundle *AnalysisBundle) error {
 	return nil
 }
 
+// LaunchSpec sends a VICESpec to the operator's spec build path
+// (POST /analyses/spec). Returns ErrCapacityExhausted on 409 Conflict. The
+// scheduler only calls this for operators whose advertised SpecVersion covers
+// the spec; see Scheduler.LaunchAnalysisSpec.
+func (c *Client) LaunchSpec(ctx context.Context, spec *VICESpec) error {
+	body, err := json.Marshal(spec)
+	if err != nil {
+		return fmt.Errorf("marshalling spec: %w", err)
+	}
+
+	reqURL := c.baseURL.JoinPath("analyses", "spec").String()
+	log.Infof("operator %s: POST %s (analysis %s)", c.name, reqURL, spec.AnalysisID)
+
+	resp, err := c.doRequest(ctx, http.MethodPost, reqURL, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("spec launch request for analysis %s: %w", spec.AnalysisID, err)
+	}
+	defer common.CloseBody(resp)
+
+	if resp.StatusCode == http.StatusConflict {
+		log.Infof("operator %s: spec launch returned 409 Conflict for analysis %s", c.name, spec.AnalysisID)
+		return ErrCapacityExhausted
+	}
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		respBody, _ := io.ReadAll(resp.Body) //nolint:errcheck // best-effort error body read
+		log.Errorf("operator %s: spec launch returned %d for analysis %s: %s", c.name, resp.StatusCode, spec.AnalysisID, string(respBody))
+		return &HTTPStatusError{StatusCode: resp.StatusCode, Body: string(respBody)}
+	}
+	return nil
+}
+
 // analysisURL builds a URL for an analysis-scoped endpoint.
 func (c *Client) analysisURL(analysisID AnalysisID, subpath string) string {
 	return c.baseURL.JoinPath("analyses", string(analysisID), subpath).String()

--- a/operatorclient/scheduler.go
+++ b/operatorclient/scheduler.go
@@ -174,6 +174,48 @@ func (s *Scheduler) Sync(summaries []OperatorAdminSummary) error {
 // The first operator with available capacity gets the analysis. This
 // minimizes usage of later (potentially more expensive) clusters.
 func (s *Scheduler) LaunchAnalysis(ctx context.Context, bundle *AnalysisBundle) (uuid.UUID, string, error) {
+	return s.launchOnFirstCapable(ctx, bundle.AnalysisID, bundle.RequestedGPUVendor(), bundle.RequestedGPUModels(),
+		func(ctx context.Context, op *Client, _ *CapacityResponse) error {
+			return op.Launch(ctx, bundle)
+		})
+}
+
+// LaunchAnalysisSpec routes a VICESpec to the first capable operator, choosing
+// the wire format per operator: an operator whose advertised SpecVersion covers
+// the spec receives the spec (operator-side construction); an older,
+// spec-unaware operator receives a legacy AnalysisBundle instead. legacyBundle
+// builds that bundle on demand and is only called when a spec-unaware operator
+// is actually selected, so the common all-spec-aware path never pays to build
+// it. GPU vendor/model matching reads the spec directly rather than parsing a
+// built Deployment.
+func (s *Scheduler) LaunchAnalysisSpec(ctx context.Context, spec *VICESpec, legacyBundle func() (*AnalysisBundle, error)) (uuid.UUID, string, error) {
+	return s.launchOnFirstCapable(ctx, spec.AnalysisID, spec.RequestedGPUVendor(), spec.RequestedGPUModels(),
+		func(ctx context.Context, op *Client, capResp *CapacityResponse) error {
+			if capResp.SupportsSpecVersion(spec.SpecVersion) {
+				return op.LaunchSpec(ctx, spec)
+			}
+			log.Infof("operator %s does not support spec version %d (reports %d); falling back to legacy bundle",
+				op.Name(), spec.SpecVersion, capResp.SpecVersion)
+			bundle, err := legacyBundle()
+			if err != nil {
+				return fmt.Errorf("building legacy bundle for analysis %s: %w", spec.AnalysisID, err)
+			}
+			return op.Launch(ctx, bundle)
+		})
+}
+
+// launchOnFirstCapable tries operators in priority order and invokes launch on
+// the first one that passes the draining/capacity/GPU-vendor/GPU-model gates,
+// falling through on capacity races and transient failures. It is the shared
+// core of LaunchAnalysis (legacy bundle) and LaunchAnalysisSpec (spec); the two
+// differ only in how GPU requirements are sourced and what launch does.
+func (s *Scheduler) launchOnFirstCapable(
+	ctx context.Context,
+	analysisID AnalysisID,
+	wantVendor string,
+	wantModels []string,
+	launch func(context.Context, *Client, *CapacityResponse) error,
+) (uuid.UUID, string, error) {
 	s.mu.RLock()
 	clients := slices.Clone(s.operators)
 	s.mu.RUnlock()
@@ -195,9 +237,6 @@ func (s *Scheduler) LaunchAnalysis(ctx context.Context, bundle *AnalysisBundle) 
 		drainingSkips    int
 		lastTransient    error
 	)
-
-	wantVendor := bundle.RequestedGPUVendor()
-	wantModels := bundle.RequestedGPUModels()
 
 	for _, op := range clients {
 		// Skip operators that are draining: they stay in the pool to serve
@@ -247,7 +286,7 @@ func (s *Scheduler) LaunchAnalysis(ctx context.Context, bundle *AnalysisBundle) 
 		// Try to launch on this operator. Capacity races and transient
 		// operator-side failures fall through to the next operator; only
 		// errors that look like a bug in the request we built abort.
-		if err := op.Launch(ctx, bundle); err != nil {
+		if err := launch(ctx, op, cap); err != nil {
 			if errors.Is(err, ErrCapacityExhausted) {
 				// Race condition: capacity was available but filled before our launch.
 				log.Infof("operator %s returned 409, trying next; this usually means it reached capacity after the check but before our job was submitted", op.Name())
@@ -262,7 +301,7 @@ func (s *Scheduler) LaunchAnalysis(ctx context.Context, bundle *AnalysisBundle) 
 			return uuid.Nil, "", fmt.Errorf("launch on operator %s failed: %w", op.Name(), err)
 		}
 
-		log.Infof("analysis %s launched on operator %s (id=%s)", bundle.AnalysisID, op.Name(), op.ID())
+		log.Infof("analysis %s launched on operator %s (id=%s)", analysisID, op.Name(), op.ID())
 		return op.ID(), op.Name(), nil
 	}
 
@@ -271,7 +310,7 @@ func (s *Scheduler) LaunchAnalysis(ctx context.Context, bundle *AnalysisBundle) 
 	// isn't misled into reporting a capacity shortfall.
 	if drainingSkips == len(clients) {
 		return uuid.Nil, "", fmt.Errorf("all %d operators draining for analysis %s: %w",
-			len(clients), bundle.AnalysisID, ErrAllOperatorsDraining)
+			len(clients), analysisID, ErrAllOperatorsDraining)
 	}
 
 	// Every non-draining operator's capacity check failed. Draining operators
@@ -288,7 +327,7 @@ func (s *Scheduler) LaunchAnalysis(ctx context.Context, bundle *AnalysisBundle) 
 	// still fires when the non-draining operators are all vendor mismatches.
 	if wantVendor != "" && vendorMismatches > 0 && capacityErrors+vendorMismatches+drainingSkips == len(clients) {
 		return uuid.Nil, "", fmt.Errorf("no operator with vendor %s for analysis %s: %w",
-			wantVendor, bundle.AnalysisID, ErrNoCompatibleOperator)
+			wantVendor, analysisID, ErrNoCompatibleOperator)
 	}
 
 	// No operator advertised a compatible GPU model. Surface this distinctly
@@ -296,7 +335,7 @@ func (s *Scheduler) LaunchAnalysis(ctx context.Context, bundle *AnalysisBundle) 
 	// ErrNoCompatibleOperator and ErrAllOperatorsExhausted.
 	if len(wantModels) > 0 && modelMismatches > 0 && capacityErrors+vendorMismatches+modelMismatches+drainingSkips == len(clients) {
 		return uuid.Nil, "", fmt.Errorf("no operator with model %v for analysis %s: %w",
-			wantModels, bundle.AnalysisID, ErrNoCompatibleModel)
+			wantModels, analysisID, ErrNoCompatibleModel)
 	}
 
 	// At least one operator passed capacity check then failed the launch for
@@ -307,7 +346,7 @@ func (s *Scheduler) LaunchAnalysis(ctx context.Context, bundle *AnalysisBundle) 
 	// may also include draining or at-capacity operators, which aren't unhealthy.
 	if transientErrors > 0 && capacityErrors+transientErrors+vendorMismatches+modelMismatches+drainingSkips == len(clients) {
 		return uuid.Nil, "", fmt.Errorf("no operator could accept analysis %s (%d operators, last transient error): %w",
-			bundle.AnalysisID, len(clients), lastTransient)
+			analysisID, len(clients), lastTransient)
 	}
 
 	return uuid.Nil, "", ErrAllOperatorsExhausted

--- a/operatorclient/scheduler_spec_test.go
+++ b/operatorclient/scheduler_spec_test.go
@@ -92,9 +92,10 @@ func TestSchedulerLaunchAnalysisSpecRouting(t *testing.T) {
 	}
 }
 
-// TestSchedulerLaunchAnalysisSpecFallsThrough verifies that a spec-unaware
-// operator is used when it is the only one available, and that a mixed fleet
-// prefers the higher-priority operator regardless of path.
+// TestSchedulerLaunchAnalysisSpecMixedFleet verifies that, in a fleet mixing
+// spec-aware and spec-unaware operators, a spec-aware operator appearing first
+// in priority order is preferred and receives the spec — without the legacy
+// bundle ever being built.
 func TestSchedulerLaunchAnalysisSpecMixedFleet(t *testing.T) {
 	specAware := newSpecRoutingServer(5, CurrentVICESpecVersion)
 	legacy := newSpecRoutingServer(5, 0)

--- a/operatorclient/scheduler_spec_test.go
+++ b/operatorclient/scheduler_spec_test.go
@@ -1,0 +1,118 @@
+package operatorclient
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// specRoutingServer records which launch endpoint was hit and advertises a
+// configurable SpecVersion, so routing decisions can be asserted.
+type specRoutingServer struct {
+	server     *httptest.Server
+	specHits   atomic.Int32
+	bundleHits atomic.Int32
+}
+
+func newSpecRoutingServer(slots, specVersion int) *specRoutingServer {
+	s := &specRoutingServer{}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/capacity", func(w http.ResponseWriter, _ *http.Request) {
+		resp := CapacityResponse{
+			MaxAnalyses:     10,
+			RunningAnalyses: 10 - slots,
+			AvailableSlots:  slots,
+			SpecVersion:     specVersion,
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	})
+	mux.HandleFunc("/analyses/spec", func(w http.ResponseWriter, _ *http.Request) {
+		s.specHits.Add(1)
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+	})
+	mux.HandleFunc("/analyses", func(w http.ResponseWriter, _ *http.Request) {
+		s.bundleHits.Add(1)
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+	})
+	s.server = httptest.NewServer(mux)
+	return s
+}
+
+// TestSchedulerLaunchAnalysisSpecRouting verifies that LaunchAnalysisSpec sends
+// a spec to a spec-aware operator and falls back to the legacy bundle for a
+// spec-unaware one (SpecVersion 0), building the bundle only when needed.
+func TestSchedulerLaunchAnalysisSpecRouting(t *testing.T) {
+	tests := []struct {
+		name            string
+		specVersion     int
+		wantSpecHit     bool
+		wantBundleBuilt bool
+	}{
+		{name: "spec-aware operator gets the spec", specVersion: CurrentVICESpecVersion, wantSpecHit: true, wantBundleBuilt: false},
+		{name: "spec-unaware operator gets the bundle", specVersion: 0, wantSpecHit: false, wantBundleBuilt: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := newSpecRoutingServer(5, tt.specVersion)
+			defer srv.server.Close()
+
+			scheduler := schedulerWithConfigs(t, []OperatorConfig{{Name: "op-0", URL: srv.server.URL}})
+
+			spec := &VICESpec{SpecVersion: CurrentVICESpecVersion, AnalysisID: "a-1"}
+			var bundleBuilt bool
+			legacyBundle := func() (*AnalysisBundle, error) {
+				bundleBuilt = true
+				return &AnalysisBundle{AnalysisID: "a-1"}, nil
+			}
+
+			_, name, err := scheduler.LaunchAnalysisSpec(context.Background(), spec, legacyBundle)
+			require.NoError(t, err)
+			assert.Equal(t, "op-0", name)
+
+			if tt.wantSpecHit {
+				assert.Equal(t, int32(1), srv.specHits.Load(), "spec endpoint should be hit")
+				assert.Equal(t, int32(0), srv.bundleHits.Load(), "bundle endpoint should not be hit")
+			} else {
+				assert.Equal(t, int32(1), srv.bundleHits.Load(), "bundle endpoint should be hit")
+				assert.Equal(t, int32(0), srv.specHits.Load(), "spec endpoint should not be hit")
+			}
+			assert.Equal(t, tt.wantBundleBuilt, bundleBuilt, "legacy bundle should be built only for spec-unaware operators")
+		})
+	}
+}
+
+// TestSchedulerLaunchAnalysisSpecFallsThrough verifies that a spec-unaware
+// operator is used when it is the only one available, and that a mixed fleet
+// prefers the higher-priority operator regardless of path.
+func TestSchedulerLaunchAnalysisSpecMixedFleet(t *testing.T) {
+	specAware := newSpecRoutingServer(5, CurrentVICESpecVersion)
+	legacy := newSpecRoutingServer(5, 0)
+	defer specAware.server.Close()
+	defer legacy.server.Close()
+
+	// Priority order is list order; spec-aware first.
+	scheduler := schedulerWithConfigs(t, []OperatorConfig{
+		{Name: "spec-aware", URL: specAware.server.URL},
+		{Name: "legacy", URL: legacy.server.URL},
+	})
+
+	spec := &VICESpec{SpecVersion: CurrentVICESpecVersion, AnalysisID: "a-1"}
+	_, name, err := scheduler.LaunchAnalysisSpec(context.Background(), spec, func() (*AnalysisBundle, error) {
+		return nil, fmt.Errorf("should not build bundle when spec-aware operator is available")
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "spec-aware", name)
+	assert.Equal(t, int32(1), specAware.specHits.Load())
+	assert.Equal(t, int32(0), legacy.bundleHits.Load())
+}

--- a/operatorclient/types.go
+++ b/operatorclient/types.go
@@ -65,6 +65,18 @@ type CapacityResponse struct {
 	UsedMemory         int64    `json:"usedMemory"`        // bytes
 	GPUVendor          string   `json:"gpuVendor,omitempty"`
 	SupportedGPUModels []string `json:"supportedGPUModels,omitempty"`
+	// SpecVersion is the maximum VICESpec wire-contract version this operator
+	// can build. 0 (the zero value, also what pre-spec operators report) means
+	// the operator does not support the spec path, so the scheduler must send
+	// it a legacy AnalysisBundle instead. See operatorclient.CurrentVICESpecVersion.
+	SpecVersion int `json:"specVersion,omitempty"`
+}
+
+// SupportsSpecVersion reports whether this operator can build the given
+// VICESpec wire-contract version. Encapsulates the "operator too old → skip"
+// rule so the scheduler does not compare versions inline.
+func (c *CapacityResponse) SupportsSpecVersion(v int) bool {
+	return c.SpecVersion >= v
 }
 
 // HasCapacity reports whether this operator can accept a new analysis.

--- a/operatorclient/types.go
+++ b/operatorclient/types.go
@@ -90,9 +90,16 @@ type PodsResponse struct {
 const (
 	gpuResourceNvidia = "nvidia.com/gpu"
 	gpuResourceAMD    = "amd.com/gpu"
+)
 
-	gpuVendorNvidia = "nvidia"
-	gpuVendorAMD    = "amd"
+// Canonical GPU vendor identifiers. These are the vendor-neutral names the
+// scheduler matches on and that GPUSpec.Vendor carries; the operator maps them
+// onto cluster-specific resource names (nvidia.com/gpu, amd.com/gpu) and
+// node-label schemes at build time. Exported so both the legacy AnalysisBundle
+// path and the VICESpec path share one canonical set.
+const (
+	GPUVendorNvidia = "nvidia"
+	GPUVendorAMD    = "amd"
 )
 
 // RequestedGPUVendor inspects the bundle's containers (and init
@@ -123,9 +130,9 @@ func vendorFromResources(rl apiv1.ResourceList) string {
 	for name := range rl {
 		switch string(name) {
 		case gpuResourceNvidia:
-			return gpuVendorNvidia
+			return GPUVendorNvidia
 		case gpuResourceAMD:
-			return gpuVendorAMD
+			return GPUVendorAMD
 		}
 	}
 	return ""

--- a/operatorclient/vicespec.go
+++ b/operatorclient/vicespec.go
@@ -1,0 +1,184 @@
+package operatorclient
+
+import "fmt"
+
+// CurrentVICESpecVersion is the VICESpec wire-contract version that this build
+// of app-exposer emits and this build of vice-operator understands. The
+// operator rejects specs whose SpecVersion it cannot handle, and the scheduler
+// treats "operator too old for this spec version" as "skip this operator,"
+// the same way it treats a capacity miss. Bump this whenever VICESpec changes
+// in a way an older operator could not faithfully build.
+const CurrentVICESpecVersion = 1
+
+// VICESpec is the cluster-agnostic description of a VICE analysis that
+// app-exposer sends to a vice-operator. It carries *what the analysis is*; the
+// operator decides *how to realize it on this cluster* and builds the concrete
+// k8s objects (Deployment, Service, HTTPRoute, ConfigMaps, PVs, PVCs, PDB)
+// itself, injecting cluster-specific values at build time.
+//
+// The fields are resolved values, not raw model.Job internals: app-exposer
+// (where the model.Job methods live) computes iRODS paths, sorted arguments,
+// output directory, excludes, etc., so the operator never needs a model.Job
+// dependency. The single deliberate exception is resource asks (see
+// ResourceSpec), which ride raw because clamping to cluster limits is a policy
+// the operator owns. The authoritative field-by-field mapping is in
+// plans/operator-side-bundle-construction-field-audit.md.
+type VICESpec struct {
+	// SpecVersion identifies the wire-contract version. See
+	// CurrentVICESpecVersion. The operator rejects versions it cannot build.
+	SpecVersion int `json:"specVersion"`
+
+	// Identity & labels. These populate the fixed label set the operator
+	// stamps on every resource (the old jobInfo.JobLabels assembly). The
+	// "subdomain" label is not carried — the operator recomputes it from
+	// UserID + ExternalID via the shared common.Subdomain.
+	AnalysisID  AnalysisID `json:"analysisID"`  // job.ID; canonical id, cleanup key
+	ExternalID  ExternalID `json:"externalID"`  // job.InvocationID; basis for resource names
+	JobName     string     `json:"jobName"`     // job.Name; label "analysis-name"; required, non-empty
+	AppID       string     `json:"appID"`       //
+	AppName     string     `json:"appName"`     //
+	UserID      string     `json:"userID"`      //
+	Submitter   string     `json:"submitter"`   // raw username; operator applies UserSuffix
+	UserLoginIP string     `json:"userLoginIP"` // resolved via Apps.GetUserIP — the only DB-derived input
+
+	// The interactive analysis container. VICE is single-step by invariant,
+	// so this is one container, not a list.
+	Container ContainerSpec `json:"container"`
+
+	// Environment for the analysis container (model.Step.Environment).
+	Environment map[string]string `json:"environment,omitempty"`
+
+	// Resource asks (raw; the operator applies its own default/clamp policy)
+	// and GPU request. GPU is nil when the analysis requests no GPU.
+	Resources ResourceSpec `json:"resources"`
+	GPU       *GPUSpec     `json:"gpu,omitempty"`
+
+	// Data movement. Inputs is the full input list used to build CSI input
+	// volume mappings; InputPathListPaths is the resolved ticketless subset
+	// used to build the input-path-list ConfigMap. Ticket status never crosses
+	// the wire — it is an iRODS access-control concern handled by porklock/CSI
+	// at transfer time, not in any k8s object.
+	UserHome           string        `json:"userHome"`
+	OutputDirectory    string        `json:"outputDirectory"`              // resolved model.Job.OutputDirectory()
+	ExcludeArguments   []string      `json:"excludeArguments,omitempty"`   // resolved model.Job.ExcludeArguments()
+	Inputs             []InputSpec   `json:"inputs,omitempty"`             // all inputs — CSI volume mappings
+	InputPathListPaths []string      `json:"inputPathListPaths,omitempty"` // resolved ticketless subset
+	FileMetadata       []MetadataAVU `json:"fileMetadata,omitempty"`       // porklock upload metadata triples
+}
+
+// ContainerSpec describes the interactive analysis container. All values are
+// resolved app-exposer-side from model.Job.Steps[0].Component.Container; in
+// particular Arguments is the output of model.Step.Arguments() (executable plus
+// sorted parameters, with backwards-compat image detection already applied), so
+// the operator never re-derives DE argument semantics.
+type ContainerSpec struct {
+	Image      string   `json:"image"`
+	Tag        string   `json:"tag"`
+	UID        int      `json:"uid"`
+	Ports      []int    `json:"ports,omitempty"`
+	EntryPoint string   `json:"entryPoint,omitempty"`
+	WorkingDir string   `json:"workingDir"` // resolved; default /de-app-work
+	Arguments  []string `json:"arguments,omitempty"`
+}
+
+// ResourceSpec carries the analysis's raw resource asks. Unlike the rest of
+// VICESpec these are not pre-clamped: the default/limit policy ("what this
+// cluster grants") is cluster configuration the operator owns, so the operator
+// runs the clamp at build time. The vice-proxy sidecar's resources come
+// entirely from operator config and are not represented here.
+type ResourceSpec struct {
+	MinCPUCores       float32 `json:"minCPUCores"`                 // model MinCPUCores (request)
+	MaxCPUCores       float32 `json:"maxCPUCores"`                 // model MaxCPUCores (limit)
+	MinMemoryBytes    int64   `json:"minMemoryBytes"`              // model MinMemoryLimit (request)
+	MaxMemoryBytes    int64   `json:"maxMemoryBytes"`              // model MemoryLimit (limit)
+	MinDiskBytes      int64   `json:"minDiskBytes"`                // model MinDiskSpace; sizes the working-dir PVC
+	SharedMemoryBytes *int64  `json:"sharedMemoryBytes,omitempty"` // resolved /dev/shm device; nil when none
+}
+
+// GPUSpec is the canonical GPU request. The operator maps it onto its own
+// resource names (nvidia.com/gpu vs amd.com/gpu) and node-label scheme — the
+// work the TransformGPUVendor / TransformGPUModels transforms do today.
+// VICESpec.GPU is nil when the analysis requests no GPU.
+//
+// Vendor is canonical (GPUVendorNvidia / GPUVendorAMD). The model.Job has no
+// vendor field today, so app-exposer defaults it to nvidia — but carrying it
+// explicitly (rather than hardcoding nvidia in the scheduler) is the plumbing
+// for genuinely multi-vendor scheduling: once an analysis can express AMD, only
+// this field changes. An empty Vendor is read as nvidia for backwards
+// compatibility (see VICESpec.RequestedGPUVendor).
+type GPUSpec struct {
+	Vendor string   `json:"vendor"`           // canonical GPUVendorNvidia | GPUVendorAMD; empty defaults to nvidia
+	Count  int64    `json:"count"`            // resolved from MinGPUs/MaxGPUs (or legacy /dev/nvidia*)
+	Models []string `json:"models,omitempty"` // canonical GFD names, e.g. "NVIDIA-A10G"; empty = any
+}
+
+// InputSpec is one resolved analysis input, used to build the CSI input volume
+// mappings. IRODSPath is the resolved model.StepInput.IRODSPath() — a trailing
+// "/" denotes a collection, which is why no separate multiplicity field is
+// needed. Type selects the CSI resource-type branch.
+type InputSpec struct {
+	IRODSPath string `json:"irodsPath"`
+	Type      string `json:"type"` // fileinput | multifileselector | folderinput
+}
+
+// MetadataAVU is an attribute/value/unit metadata triple applied to the
+// analysis's output files. It mirrors model.FileMetadata but is defined here so
+// VICESpec — and therefore the operator — carries no model.Job dependency.
+type MetadataAVU struct {
+	Attribute string `json:"attribute"`
+	Value     string `json:"value"`
+	Unit      string `json:"unit"`
+}
+
+// Validate checks the spec-shape invariants the operator needs before it can
+// build k8s objects. Unlike AnalysisBundle.Validate — which re-walked already-
+// built objects to confirm their analysis-id labels — the operator guarantees
+// that label invariant by construction (it stamps the labels it builds), so
+// validation here is reduced to the required scalar fields. SpecVersion
+// compatibility is checked separately by the receiver against the versions it
+// supports, not here.
+func (s *VICESpec) Validate() error {
+	if s.AnalysisID == "" {
+		return fmt.Errorf("analysisID is required")
+	}
+	if s.ExternalID == "" {
+		return fmt.Errorf("externalID is required")
+	}
+	// JobName becomes the "analysis-name" label, which must not be empty.
+	if s.JobName == "" {
+		return fmt.Errorf("jobName is required")
+	}
+	if s.Submitter == "" {
+		return fmt.Errorf("submitter is required")
+	}
+	if s.Container.Image == "" {
+		return fmt.Errorf("container image is required")
+	}
+	return nil
+}
+
+// RequestedGPUVendor returns the canonical GPU vendor the analysis requires, or
+// "" when it requests no GPU. An unset GPU.Vendor defaults to nvidia. This is
+// the VICESpec counterpart to AnalysisBundle.RequestedGPUVendor — the scheduler
+// reads it to skip operators whose cluster GPU vendor does not match, but reads
+// it directly from the spec rather than reverse-engineering it from a built
+// Deployment.
+func (s *VICESpec) RequestedGPUVendor() string {
+	if s.GPU == nil {
+		return ""
+	}
+	if s.GPU.Vendor == "" {
+		return GPUVendorNvidia
+	}
+	return s.GPU.Vendor
+}
+
+// RequestedGPUModels returns the canonical GPU model names the analysis
+// requires, or nil when it has no model constraint. VICESpec counterpart to
+// AnalysisBundle.RequestedGPUModels.
+func (s *VICESpec) RequestedGPUModels() []string {
+	if s.GPU == nil {
+		return nil
+	}
+	return s.GPU.Models
+}

--- a/operatorclient/vicespec.go
+++ b/operatorclient/vicespec.go
@@ -154,6 +154,11 @@ func (s *VICESpec) Validate() error {
 	if s.Container.Image == "" {
 		return fmt.Errorf("container image is required")
 	}
+	// VICE apps are interactive web apps; the readiness probe and vice-proxy
+	// backend both target the first container port, so at least one is required.
+	if len(s.Container.Ports) == 0 {
+		return fmt.Errorf("container must expose at least one port")
+	}
 	return nil
 }
 

--- a/operatorclient/vicespec.go
+++ b/operatorclient/vicespec.go
@@ -77,7 +77,7 @@ type ContainerSpec struct {
 	UID        int      `json:"uid"`
 	Ports      []int    `json:"ports,omitempty"`
 	EntryPoint string   `json:"entryPoint,omitempty"`
-	WorkingDir string   `json:"workingDir"` // resolved; default /de-app-work
+	WorkingDir string   `json:"workingDir,omitempty"` // raw; empty means use the image's WORKDIR. The working-dir volume still mounts at /de-app-work.
 	Arguments  []string `json:"arguments,omitempty"`
 }
 

--- a/operatorclient/vicespec_test.go
+++ b/operatorclient/vicespec_test.go
@@ -1,0 +1,127 @@
+package operatorclient
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func validVICESpec() VICESpec {
+	return VICESpec{
+		SpecVersion: CurrentVICESpecVersion,
+		AnalysisID:  "analysis-1",
+		ExternalID:  "external-1",
+		JobName:     "my analysis",
+		AppID:       "app-1",
+		AppName:     "JupyterLab",
+		UserID:      "user-1",
+		Submitter:   "someuser",
+		UserLoginIP: "10.0.0.1",
+		Container: ContainerSpec{
+			Image:      "cyverse/jupyter",
+			Tag:        "latest",
+			UID:        1000,
+			Ports:      []int{8888},
+			WorkingDir: "/de-app-work",
+		},
+	}
+}
+
+func TestVICESpecValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		mutate  func(*VICESpec)
+		wantErr string
+	}{
+		{name: "valid", mutate: func(*VICESpec) {}},
+		{name: "missing analysisID", mutate: func(s *VICESpec) { s.AnalysisID = "" }, wantErr: "analysisID is required"},
+		{name: "missing externalID", mutate: func(s *VICESpec) { s.ExternalID = "" }, wantErr: "externalID is required"},
+		{name: "missing jobName", mutate: func(s *VICESpec) { s.JobName = "" }, wantErr: "jobName is required"},
+		{name: "missing submitter", mutate: func(s *VICESpec) { s.Submitter = "" }, wantErr: "submitter is required"},
+		{name: "missing image", mutate: func(s *VICESpec) { s.Container.Image = "" }, wantErr: "container image is required"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			spec := validVICESpec()
+			tt.mutate(&spec)
+			err := spec.Validate()
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.EqualError(t, err, tt.wantErr)
+		})
+	}
+}
+
+// TestVICESpecRoundTrip guards the wire contract: a spec survives a JSON
+// round-trip unchanged, including the nil-vs-set distinction on the optional
+// GPU and shared-memory fields.
+func TestVICESpecRoundTrip(t *testing.T) {
+	shm := int64(1 << 30)
+	spec := validVICESpec()
+	spec.Environment = map[string]string{"FOO": "bar"}
+	spec.Resources = ResourceSpec{
+		MinCPUCores:       1,
+		MaxCPUCores:       4,
+		MinMemoryBytes:    1 << 30,
+		MaxMemoryBytes:    8 << 30,
+		MinDiskBytes:      16 << 30,
+		SharedMemoryBytes: &shm,
+	}
+	spec.GPU = &GPUSpec{Vendor: GPUVendorNvidia, Count: 1, Models: []string{"NVIDIA-A10G"}}
+	spec.Inputs = []InputSpec{{IRODSPath: "/zone/home/user/in.txt", Type: "fileinput"}}
+	spec.InputPathListPaths = []string{"/zone/home/user/in.txt"}
+	spec.FileMetadata = []MetadataAVU{{Attribute: "ipc-analysis-id", Value: "analysis-1", Unit: ""}}
+
+	data, err := json.Marshal(spec)
+	require.NoError(t, err)
+
+	var got VICESpec
+	require.NoError(t, json.Unmarshal(data, &got))
+	assert.Equal(t, spec, got)
+}
+
+func TestVICESpecRequestedGPU(t *testing.T) {
+	tests := []struct {
+		name       string
+		gpu        *GPUSpec
+		wantVendor string
+		wantModels []string
+	}{
+		{name: "no gpu", gpu: nil, wantVendor: "", wantModels: nil},
+		{name: "unset vendor defaults to nvidia", gpu: &GPUSpec{Count: 1}, wantVendor: GPUVendorNvidia, wantModels: nil},
+		{name: "explicit nvidia", gpu: &GPUSpec{Vendor: GPUVendorNvidia, Count: 1}, wantVendor: GPUVendorNvidia},
+		{name: "explicit amd", gpu: &GPUSpec{Vendor: GPUVendorAMD, Count: 2}, wantVendor: GPUVendorAMD},
+		{
+			name:       "with models",
+			gpu:        &GPUSpec{Vendor: GPUVendorNvidia, Count: 1, Models: []string{"NVIDIA-A10G", "NVIDIA-L4"}},
+			wantVendor: GPUVendorNvidia,
+			wantModels: []string{"NVIDIA-A10G", "NVIDIA-L4"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			spec := validVICESpec()
+			spec.GPU = tt.gpu
+			assert.Equal(t, tt.wantVendor, spec.RequestedGPUVendor())
+			assert.Equal(t, tt.wantModels, spec.RequestedGPUModels())
+		})
+	}
+}
+
+// TestVICESpecGPUOmittedWhenNil confirms GPU and SharedMemoryBytes serialize
+// away entirely when unset, so a no-GPU analysis carries no GPU object on the
+// wire (the operator reads "absent" as "no GPU requested").
+func TestVICESpecGPUOmittedWhenNil(t *testing.T) {
+	spec := validVICESpec()
+	data, err := json.Marshal(spec)
+	require.NoError(t, err)
+	assert.NotContains(t, string(data), "\"gpu\"")
+	assert.NotContains(t, string(data), "sharedMemoryBytes")
+}

--- a/operatorclient/vicespec_test.go
+++ b/operatorclient/vicespec_test.go
@@ -41,6 +41,7 @@ func TestVICESpecValidate(t *testing.T) {
 		{name: "missing jobName", mutate: func(s *VICESpec) { s.JobName = "" }, wantErr: "jobName is required"},
 		{name: "missing submitter", mutate: func(s *VICESpec) { s.Submitter = "" }, wantErr: "submitter is required"},
 		{name: "missing image", mutate: func(s *VICESpec) { s.Container.Image = "" }, wantErr: "container image is required"},
+		{name: "no ports", mutate: func(s *VICESpec) { s.Container.Ports = nil }, wantErr: "container must expose at least one port"},
 	}
 
 	for _, tt := range tests {

--- a/operatordocs/operator_docs.go
+++ b/operatordocs/operator_docs.go
@@ -94,6 +94,61 @@ const docTemplateoperator = `{
                 }
             }
         },
+        "/analyses/spec": {
+            "post": {
+                "description": "Receives a cluster-agnostic VICESpec, builds the k8s objects for\nthis cluster, and applies them. Returns 409 if at capacity.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "analyses"
+                ],
+                "summary": "Launch a VICE analysis from a spec",
+                "parameters": [
+                    {
+                        "description": "The analysis spec to launch",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/operatorclient.VICESpec"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/common.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/common.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/common.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/analyses/{analysis-id}": {
             "delete": {
                 "description": "Deletes all K8s resources associated with an analysis.",
@@ -1327,6 +1382,10 @@ const docTemplateoperator = `{
                 "runningAnalyses": {
                     "type": "integer"
                 },
+                "specVersion": {
+                    "description": "SpecVersion is the maximum VICESpec wire-contract version this operator\ncan build. 0 (the zero value, also what pre-spec operators report) means\nthe operator does not support the spec path, so the scheduler must send\nit a legacy AnalysisBundle instead. See operatorclient.CurrentVICESpecVersion.",
+                    "type": "integer"
+                },
                 "supportedGPUModels": {
                     "type": "array",
                     "items": {
@@ -1340,6 +1399,71 @@ const docTemplateoperator = `{
                 "usedMemory": {
                     "description": "bytes",
                     "type": "integer"
+                }
+            }
+        },
+        "operatorclient.ContainerSpec": {
+            "type": "object",
+            "properties": {
+                "arguments": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "entryPoint": {
+                    "type": "string"
+                },
+                "image": {
+                    "type": "string"
+                },
+                "ports": {
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    }
+                },
+                "tag": {
+                    "type": "string"
+                },
+                "uid": {
+                    "type": "integer"
+                },
+                "workingDir": {
+                    "description": "raw; empty means use the image's WORKDIR. The working-dir volume still mounts at /de-app-work.",
+                    "type": "string"
+                }
+            }
+        },
+        "operatorclient.GPUSpec": {
+            "type": "object",
+            "properties": {
+                "count": {
+                    "description": "resolved from MinGPUs/MaxGPUs (or legacy /dev/nvidia*)",
+                    "type": "integer"
+                },
+                "models": {
+                    "description": "canonical GFD names, e.g. \"NVIDIA-A10G\"; empty = any",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "vendor": {
+                    "description": "canonical GPUVendorNvidia | GPUVendorAMD; empty defaults to nvidia",
+                    "type": "string"
+                }
+            }
+        },
+        "operatorclient.InputSpec": {
+            "type": "object",
+            "properties": {
+                "irodsPath": {
+                    "type": "string"
+                },
+                "type": {
+                    "description": "fileinput | multifileselector | folderinput",
+                    "type": "string"
                 }
             }
         },
@@ -1359,6 +1483,20 @@ const docTemplateoperator = `{
                 }
             }
         },
+        "operatorclient.MetadataAVU": {
+            "type": "object",
+            "properties": {
+                "attribute": {
+                    "type": "string"
+                },
+                "unit": {
+                    "type": "string"
+                },
+                "value": {
+                    "type": "string"
+                }
+            }
+        },
         "operatorclient.PodsResponse": {
             "type": "object",
             "properties": {
@@ -1367,6 +1505,35 @@ const docTemplateoperator = `{
                     "items": {
                         "$ref": "#/definitions/operatorclient.StatusPod"
                     }
+                }
+            }
+        },
+        "operatorclient.ResourceSpec": {
+            "type": "object",
+            "properties": {
+                "maxCPUCores": {
+                    "description": "model MaxCPUCores (limit)",
+                    "type": "number"
+                },
+                "maxMemoryBytes": {
+                    "description": "model MemoryLimit (limit)",
+                    "type": "integer"
+                },
+                "minCPUCores": {
+                    "description": "model MinCPUCores (request)",
+                    "type": "number"
+                },
+                "minDiskBytes": {
+                    "description": "model MinDiskSpace; sizes the working-dir PVC",
+                    "type": "integer"
+                },
+                "minMemoryBytes": {
+                    "description": "model MinMemoryLimit (request)",
+                    "type": "integer"
+                },
+                "sharedMemoryBytes": {
+                    "description": "resolved /dev/shm device; nil when none",
+                    "type": "integer"
                 }
             }
         },
@@ -1417,6 +1584,106 @@ const docTemplateoperator = `{
                     "items": {
                         "type": "string"
                     }
+                }
+            }
+        },
+        "operatorclient.VICESpec": {
+            "type": "object",
+            "properties": {
+                "analysisID": {
+                    "description": "Identity \u0026 labels. These populate the fixed label set the operator\nstamps on every resource (the old jobInfo.JobLabels assembly). The\n\"subdomain\" label is not carried — the operator recomputes it from\nUserID + ExternalID via the shared common.Subdomain.",
+                    "type": "string"
+                },
+                "appID": {
+                    "type": "string"
+                },
+                "appName": {
+                    "type": "string"
+                },
+                "container": {
+                    "description": "The interactive analysis container. VICE is single-step by invariant,\nso this is one container, not a list.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/operatorclient.ContainerSpec"
+                        }
+                    ]
+                },
+                "environment": {
+                    "description": "Environment for the analysis container (model.Step.Environment).",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "excludeArguments": {
+                    "description": "resolved model.Job.ExcludeArguments()",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "externalID": {
+                    "description": "job.InvocationID; basis for resource names",
+                    "type": "string"
+                },
+                "fileMetadata": {
+                    "description": "porklock upload metadata triples",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/operatorclient.MetadataAVU"
+                    }
+                },
+                "gpu": {
+                    "$ref": "#/definitions/operatorclient.GPUSpec"
+                },
+                "inputPathListPaths": {
+                    "description": "resolved ticketless subset",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "inputs": {
+                    "description": "all inputs — CSI volume mappings",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/operatorclient.InputSpec"
+                    }
+                },
+                "jobName": {
+                    "description": "job.Name; label \"analysis-name\"; required, non-empty",
+                    "type": "string"
+                },
+                "outputDirectory": {
+                    "description": "resolved model.Job.OutputDirectory()",
+                    "type": "string"
+                },
+                "resources": {
+                    "description": "Resource asks (raw; the operator applies its own default/clamp policy)\nand GPU request. GPU is nil when the analysis requests no GPU.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/operatorclient.ResourceSpec"
+                        }
+                    ]
+                },
+                "specVersion": {
+                    "description": "SpecVersion identifies the wire-contract version. See\nCurrentVICESpecVersion. The operator rejects versions it cannot build.",
+                    "type": "integer"
+                },
+                "submitter": {
+                    "description": "raw username; operator applies UserSuffix",
+                    "type": "string"
+                },
+                "userHome": {
+                    "description": "Data movement. Inputs is the full input list used to build CSI input\nvolume mappings; InputPathListPaths is the resolved ticketless subset\nused to build the input-path-list ConfigMap. Ticket status never crosses\nthe wire — it is an iRODS access-control concern handled by porklock/CSI\nat transfer time, not in any k8s object.",
+                    "type": "string"
+                },
+                "userID": {
+                    "type": "string"
+                },
+                "userLoginIP": {
+                    "description": "resolved via Apps.GetUserIP — the only DB-derived input",
+                    "type": "string"
                 }
             }
         },

--- a/operatordocs/operator_docs.go
+++ b/operatordocs/operator_docs.go
@@ -145,6 +145,12 @@ const docTemplateoperator = `{
                         "schema": {
                             "$ref": "#/definitions/common.ErrorResponse"
                         }
+                    },
+                    "503": {
+                        "description": "Spec launch disabled on this operator",
+                        "schema": {
+                            "$ref": "#/definitions/common.ErrorResponse"
+                        }
                     }
                 }
             }

--- a/operatordocs/operator_swagger.json
+++ b/operatordocs/operator_swagger.json
@@ -87,6 +87,61 @@
                 }
             }
         },
+        "/analyses/spec": {
+            "post": {
+                "description": "Receives a cluster-agnostic VICESpec, builds the k8s objects for\nthis cluster, and applies them. Returns 409 if at capacity.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "analyses"
+                ],
+                "summary": "Launch a VICE analysis from a spec",
+                "parameters": [
+                    {
+                        "description": "The analysis spec to launch",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/operatorclient.VICESpec"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/common.ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/common.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/common.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/analyses/{analysis-id}": {
             "delete": {
                 "description": "Deletes all K8s resources associated with an analysis.",
@@ -1320,6 +1375,10 @@
                 "runningAnalyses": {
                     "type": "integer"
                 },
+                "specVersion": {
+                    "description": "SpecVersion is the maximum VICESpec wire-contract version this operator\ncan build. 0 (the zero value, also what pre-spec operators report) means\nthe operator does not support the spec path, so the scheduler must send\nit a legacy AnalysisBundle instead. See operatorclient.CurrentVICESpecVersion.",
+                    "type": "integer"
+                },
                 "supportedGPUModels": {
                     "type": "array",
                     "items": {
@@ -1333,6 +1392,71 @@
                 "usedMemory": {
                     "description": "bytes",
                     "type": "integer"
+                }
+            }
+        },
+        "operatorclient.ContainerSpec": {
+            "type": "object",
+            "properties": {
+                "arguments": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "entryPoint": {
+                    "type": "string"
+                },
+                "image": {
+                    "type": "string"
+                },
+                "ports": {
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    }
+                },
+                "tag": {
+                    "type": "string"
+                },
+                "uid": {
+                    "type": "integer"
+                },
+                "workingDir": {
+                    "description": "raw; empty means use the image's WORKDIR. The working-dir volume still mounts at /de-app-work.",
+                    "type": "string"
+                }
+            }
+        },
+        "operatorclient.GPUSpec": {
+            "type": "object",
+            "properties": {
+                "count": {
+                    "description": "resolved from MinGPUs/MaxGPUs (or legacy /dev/nvidia*)",
+                    "type": "integer"
+                },
+                "models": {
+                    "description": "canonical GFD names, e.g. \"NVIDIA-A10G\"; empty = any",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "vendor": {
+                    "description": "canonical GPUVendorNvidia | GPUVendorAMD; empty defaults to nvidia",
+                    "type": "string"
+                }
+            }
+        },
+        "operatorclient.InputSpec": {
+            "type": "object",
+            "properties": {
+                "irodsPath": {
+                    "type": "string"
+                },
+                "type": {
+                    "description": "fileinput | multifileselector | folderinput",
+                    "type": "string"
                 }
             }
         },
@@ -1352,6 +1476,20 @@
                 }
             }
         },
+        "operatorclient.MetadataAVU": {
+            "type": "object",
+            "properties": {
+                "attribute": {
+                    "type": "string"
+                },
+                "unit": {
+                    "type": "string"
+                },
+                "value": {
+                    "type": "string"
+                }
+            }
+        },
         "operatorclient.PodsResponse": {
             "type": "object",
             "properties": {
@@ -1360,6 +1498,35 @@
                     "items": {
                         "$ref": "#/definitions/operatorclient.StatusPod"
                     }
+                }
+            }
+        },
+        "operatorclient.ResourceSpec": {
+            "type": "object",
+            "properties": {
+                "maxCPUCores": {
+                    "description": "model MaxCPUCores (limit)",
+                    "type": "number"
+                },
+                "maxMemoryBytes": {
+                    "description": "model MemoryLimit (limit)",
+                    "type": "integer"
+                },
+                "minCPUCores": {
+                    "description": "model MinCPUCores (request)",
+                    "type": "number"
+                },
+                "minDiskBytes": {
+                    "description": "model MinDiskSpace; sizes the working-dir PVC",
+                    "type": "integer"
+                },
+                "minMemoryBytes": {
+                    "description": "model MinMemoryLimit (request)",
+                    "type": "integer"
+                },
+                "sharedMemoryBytes": {
+                    "description": "resolved /dev/shm device; nil when none",
+                    "type": "integer"
                 }
             }
         },
@@ -1410,6 +1577,106 @@
                     "items": {
                         "type": "string"
                     }
+                }
+            }
+        },
+        "operatorclient.VICESpec": {
+            "type": "object",
+            "properties": {
+                "analysisID": {
+                    "description": "Identity \u0026 labels. These populate the fixed label set the operator\nstamps on every resource (the old jobInfo.JobLabels assembly). The\n\"subdomain\" label is not carried — the operator recomputes it from\nUserID + ExternalID via the shared common.Subdomain.",
+                    "type": "string"
+                },
+                "appID": {
+                    "type": "string"
+                },
+                "appName": {
+                    "type": "string"
+                },
+                "container": {
+                    "description": "The interactive analysis container. VICE is single-step by invariant,\nso this is one container, not a list.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/operatorclient.ContainerSpec"
+                        }
+                    ]
+                },
+                "environment": {
+                    "description": "Environment for the analysis container (model.Step.Environment).",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "excludeArguments": {
+                    "description": "resolved model.Job.ExcludeArguments()",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "externalID": {
+                    "description": "job.InvocationID; basis for resource names",
+                    "type": "string"
+                },
+                "fileMetadata": {
+                    "description": "porklock upload metadata triples",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/operatorclient.MetadataAVU"
+                    }
+                },
+                "gpu": {
+                    "$ref": "#/definitions/operatorclient.GPUSpec"
+                },
+                "inputPathListPaths": {
+                    "description": "resolved ticketless subset",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "inputs": {
+                    "description": "all inputs — CSI volume mappings",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/operatorclient.InputSpec"
+                    }
+                },
+                "jobName": {
+                    "description": "job.Name; label \"analysis-name\"; required, non-empty",
+                    "type": "string"
+                },
+                "outputDirectory": {
+                    "description": "resolved model.Job.OutputDirectory()",
+                    "type": "string"
+                },
+                "resources": {
+                    "description": "Resource asks (raw; the operator applies its own default/clamp policy)\nand GPU request. GPU is nil when the analysis requests no GPU.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/operatorclient.ResourceSpec"
+                        }
+                    ]
+                },
+                "specVersion": {
+                    "description": "SpecVersion identifies the wire-contract version. See\nCurrentVICESpecVersion. The operator rejects versions it cannot build.",
+                    "type": "integer"
+                },
+                "submitter": {
+                    "description": "raw username; operator applies UserSuffix",
+                    "type": "string"
+                },
+                "userHome": {
+                    "description": "Data movement. Inputs is the full input list used to build CSI input\nvolume mappings; InputPathListPaths is the resolved ticketless subset\nused to build the input-path-list ConfigMap. Ticket status never crosses\nthe wire — it is an iRODS access-control concern handled by porklock/CSI\nat transfer time, not in any k8s object.",
+                    "type": "string"
+                },
+                "userID": {
+                    "type": "string"
+                },
+                "userLoginIP": {
+                    "description": "resolved via Apps.GetUserIP — the only DB-derived input",
+                    "type": "string"
                 }
             }
         },

--- a/operatordocs/operator_swagger.json
+++ b/operatordocs/operator_swagger.json
@@ -138,6 +138,12 @@
                         "schema": {
                             "$ref": "#/definitions/common.ErrorResponse"
                         }
+                    },
+                    "503": {
+                        "description": "Spec launch disabled on this operator",
+                        "schema": {
+                            "$ref": "#/definitions/common.ErrorResponse"
+                        }
                     }
                 }
             }

--- a/operatordocs/operator_swagger.yaml
+++ b/operatordocs/operator_swagger.yaml
@@ -298,6 +298,13 @@ definitions:
         type: integer
       runningAnalyses:
         type: integer
+      specVersion:
+        description: |-
+          SpecVersion is the maximum VICESpec wire-contract version this operator
+          can build. 0 (the zero value, also what pre-spec operators report) means
+          the operator does not support the spec path, so the scheduler must send
+          it a legacy AnalysisBundle instead. See operatorclient.CurrentVICESpecVersion.
+        type: integer
       supportedGPUModels:
         items:
           type: string
@@ -309,6 +316,51 @@ definitions:
         description: bytes
         type: integer
     type: object
+  operatorclient.ContainerSpec:
+    properties:
+      arguments:
+        items:
+          type: string
+        type: array
+      entryPoint:
+        type: string
+      image:
+        type: string
+      ports:
+        items:
+          type: integer
+        type: array
+      tag:
+        type: string
+      uid:
+        type: integer
+      workingDir:
+        description: raw; empty means use the image's WORKDIR. The working-dir volume
+          still mounts at /de-app-work.
+        type: string
+    type: object
+  operatorclient.GPUSpec:
+    properties:
+      count:
+        description: resolved from MinGPUs/MaxGPUs (or legacy /dev/nvidia*)
+        type: integer
+      models:
+        description: canonical GFD names, e.g. "NVIDIA-A10G"; empty = any
+        items:
+          type: string
+        type: array
+      vendor:
+        description: canonical GPUVendorNvidia | GPUVendorAMD; empty defaults to nvidia
+        type: string
+    type: object
+  operatorclient.InputSpec:
+    properties:
+      irodsPath:
+        type: string
+      type:
+        description: fileinput | multifileselector | folderinput
+        type: string
+    type: object
   operatorclient.LogoutUserRequest:
     properties:
       username:
@@ -319,12 +371,42 @@ definitions:
       sessions_invalidated:
         type: integer
     type: object
+  operatorclient.MetadataAVU:
+    properties:
+      attribute:
+        type: string
+      unit:
+        type: string
+      value:
+        type: string
+    type: object
   operatorclient.PodsResponse:
     properties:
       pods:
         items:
           $ref: '#/definitions/operatorclient.StatusPod'
         type: array
+    type: object
+  operatorclient.ResourceSpec:
+    properties:
+      maxCPUCores:
+        description: model MaxCPUCores (limit)
+        type: number
+      maxMemoryBytes:
+        description: model MemoryLimit (limit)
+        type: integer
+      minCPUCores:
+        description: model MinCPUCores (request)
+        type: number
+      minDiskBytes:
+        description: model MinDiskSpace; sizes the working-dir PVC
+        type: integer
+      minMemoryBytes:
+        description: model MinMemoryLimit (request)
+        type: integer
+      sharedMemoryBytes:
+        description: resolved /dev/shm device; nil when none
+        type: integer
     type: object
   operatorclient.StatusDeployment:
     properties:
@@ -357,6 +439,89 @@ definitions:
         items:
           type: string
         type: array
+    type: object
+  operatorclient.VICESpec:
+    properties:
+      analysisID:
+        description: |-
+          Identity & labels. These populate the fixed label set the operator
+          stamps on every resource (the old jobInfo.JobLabels assembly). The
+          "subdomain" label is not carried — the operator recomputes it from
+          UserID + ExternalID via the shared common.Subdomain.
+        type: string
+      appID:
+        type: string
+      appName:
+        type: string
+      container:
+        allOf:
+        - $ref: '#/definitions/operatorclient.ContainerSpec'
+        description: |-
+          The interactive analysis container. VICE is single-step by invariant,
+          so this is one container, not a list.
+      environment:
+        additionalProperties:
+          type: string
+        description: Environment for the analysis container (model.Step.Environment).
+        type: object
+      excludeArguments:
+        description: resolved model.Job.ExcludeArguments()
+        items:
+          type: string
+        type: array
+      externalID:
+        description: job.InvocationID; basis for resource names
+        type: string
+      fileMetadata:
+        description: porklock upload metadata triples
+        items:
+          $ref: '#/definitions/operatorclient.MetadataAVU'
+        type: array
+      gpu:
+        $ref: '#/definitions/operatorclient.GPUSpec'
+      inputPathListPaths:
+        description: resolved ticketless subset
+        items:
+          type: string
+        type: array
+      inputs:
+        description: all inputs — CSI volume mappings
+        items:
+          $ref: '#/definitions/operatorclient.InputSpec'
+        type: array
+      jobName:
+        description: job.Name; label "analysis-name"; required, non-empty
+        type: string
+      outputDirectory:
+        description: resolved model.Job.OutputDirectory()
+        type: string
+      resources:
+        allOf:
+        - $ref: '#/definitions/operatorclient.ResourceSpec'
+        description: |-
+          Resource asks (raw; the operator applies its own default/clamp policy)
+          and GPU request. GPU is nil when the analysis requests no GPU.
+      specVersion:
+        description: |-
+          SpecVersion identifies the wire-contract version. See
+          CurrentVICESpecVersion. The operator rejects versions it cannot build.
+        type: integer
+      submitter:
+        description: raw username; operator applies UserSuffix
+        type: string
+      userHome:
+        description: |-
+          Data movement. Inputs is the full input list used to build CSI input
+          volume mappings; InputPathListPaths is the resolved ticketless subset
+          used to build the input-path-list ConfigMap. Ticket status never crosses
+          the wire — it is an iRODS access-control concern handled by porklock/CSI
+          at transfer time, not in any k8s object.
+        type: string
+      userID:
+        type: string
+      userLoginIP:
+        description: resolved via Apps.GetUserIP — the only DB-derived input
+        type: string
     type: object
   reporting.ConfigMapInfo:
     properties:
@@ -11187,6 +11352,44 @@ paths:
           schema:
             $ref: '#/definitions/common.ErrorResponse'
       summary: Check if analysis URL is ready
+      tags:
+      - analyses
+  /analyses/spec:
+    post:
+      consumes:
+      - application/json
+      description: |-
+        Receives a cluster-agnostic VICESpec, builds the k8s objects for
+        this cluster, and applies them. Returns 409 if at capacity.
+      parameters:
+      - description: The analysis spec to launch
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/operatorclient.VICESpec'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/common.ErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/common.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/common.ErrorResponse'
+      summary: Launch a VICE analysis from a spec
       tags:
       - analyses
   /capacity:

--- a/operatordocs/operator_swagger.yaml
+++ b/operatordocs/operator_swagger.yaml
@@ -11389,6 +11389,10 @@ paths:
           description: Internal Server Error
           schema:
             $ref: '#/definitions/common.ErrorResponse'
+        "503":
+          description: Spec launch disabled on this operator
+          schema:
+            $ref: '#/definitions/common.ErrorResponse'
       summary: Launch a VICE analysis from a spec
       tags:
       - analyses

--- a/plans/operator-side-bundle-construction-contract.md
+++ b/plans/operator-side-bundle-construction-contract.md
@@ -1,0 +1,166 @@
+# The `VICESpec` contract
+
+Phase 0, step 3 of the
+[migration plan](operator-side-bundle-construction-migration.md). The
+[design doc](operator-side-bundle-construction.md) is the *what & why*; the
+[field audit](operator-side-bundle-construction-field-audit.md) is the
+authoritative field-to-source mapping. This doc is the **contract**: who owns
+each field, how the contract versions, and how the scheduler treats an operator
+that is too old to honor it.
+
+The types live in `operatorclient/vicespec.go` (`VICESpec`, `ContainerSpec`,
+`ResourceSpec`, `GPUSpec`, `InputSpec`, `MetadataAVU`), next to the
+`AnalysisBundle` they will eventually replace. Nothing builds or consumes them
+yet (Phase 0 is contract-only).
+
+## Direction of the contract
+
+```
+app-exposer  ──── VICESpec (what the analysis is) ────▶  vice-operator
+  owns the analysis + the fleet decision                 owns the cluster
+```
+
+app-exposer resolves the analysis (DB, apps, quota, permissions), maps
+`model.Job → VICESpec`, picks a target operator, and POSTs the spec. The
+operator builds every k8s object from the spec, injecting cluster-specific
+values at build time, and applies them. The line: **app-exposer owns *what*;
+the operator owns *how*.**
+
+## Field ownership
+
+Every value needed to build the k8s objects comes from exactly one of three
+owners. The contract is the set of fields where the owner is **app-exposer**
+(they ride in `VICESpec`); the other two owners are recorded here so the
+boundary is unambiguous.
+
+### Owned by app-exposer — carried in `VICESpec`
+
+These are analysis-intrinsic or DB-derived; the operator cannot compute them.
+app-exposer resolves them (running the `model.Job` methods, where that knowledge
+lives) so the operator receives primitives and needs no `model.Job` dependency.
+
+| Field | Source | Notes |
+| --- | --- | --- |
+| `AnalysisID` | `job.ID` | canonical id; the cleanup label key |
+| `ExternalID` | `job.InvocationID` | basis for every resource name |
+| `JobName` | `job.Name` | becomes the `analysis-name` label; **required, non-empty** |
+| `AppID` / `AppName` | `job.AppID` / `job.AppName` | labels |
+| `UserID` / `Submitter` | `job.UserID` / `job.Submitter` | labels; operator applies `UserSuffix` to `Submitter` |
+| `UserLoginIP` | `Apps.GetUserIP(ctx, job.UserID)` | **the one DB-derived input**; resolved once app-exposer-side |
+| `Container.*` | `job.Steps[0].Component.Container` | image/tag/uid/ports/entrypoint/workdir; `Arguments` is resolved `Step.Arguments()` |
+| `Environment` | `job.Steps[0].Environment` | |
+| `Resources.*` | container resource asks | **raw, not clamped** — see Versioning note on policy ownership |
+| `GPU` | `MinGPUs`/`MaxGPUs`/`GPUModels` (or legacy `/dev/nvidia*`) | `nil` ⇒ no GPU; vendor-neutral (see open item) |
+| `UserHome` | `job.UserHome` | |
+| `OutputDirectory` | resolved `job.OutputDirectory()` | |
+| `ExcludeArguments` | resolved `job.ExcludeArguments()` | |
+| `Inputs` | all `Steps[].Config.Inputs`, resolved | full list → CSI input volume mappings |
+| `InputPathListPaths` | ticketless subset, resolved to `[]string` | input-path-list ConfigMap |
+| `FileMetadata` | `job.FileMetadata` | porklock upload metadata triples |
+
+The `subdomain` label is deliberately **not** carried: the operator recomputes
+it from `UserID` + `ExternalID` via the shared `common.Subdomain`.
+
+### Owned by the operator — cluster config, never on the wire
+
+The cluster-specific `Incluster.Init` values the builders read today move to
+operator config (field audit §5). The operator already holds peers of several
+(`baseDomain`, `userSuffix`, `clusterConfigSecret`, `localStorageClass`, GPU
+vendor/model fields, gateway refs, `imageRewriter`); the rest are added in
+Phase 1 (`PorklockImage/Tag`, `ViceProxyImage`, `UseCSIDriver`,
+`FrontendBaseURL`, `ViceDomain`, `IRODSZone`, `InputPathListIdentifier`, …).
+The **`resourcing` default/clamp policy** is operator-owned too: the asks ride
+raw in `ResourceSpec`, and the operator applies "what this cluster grants." The
+**vice-proxy sidecar** is built entirely from operator config — it has *no*
+`VICESpec` input at all (audit §4). The four contested namespace/secret values
+(VICE namespace, backend/gateway namespace, image-pull secret, cluster-config
+secret) are operator-owned; two are already overridden operator-side today
+(audit §8.5).
+
+### Static — constants that travel with the builder code
+
+The ~30 `constants` names (file names, volume names, CSI names, port
+names/numbers, label keys) are static; they move into `vicebuild/` with the
+builders and never cross the wire (audit §6).
+
+## Versioning
+
+The bundle stops being self-describing k8s objects and becomes an explicit
+app-exposer↔operator contract, so it must version.
+
+- `VICESpec.SpecVersion` carries the wire-contract version.
+  `operatorclient.CurrentVICESpecVersion` (currently **1**) is what this build
+  emits and understands.
+- **Bump `CurrentVICESpecVersion`** whenever `VICESpec` changes in a way an
+  older operator could not faithfully build (new required field, changed
+  semantics of an existing field). Purely additive *optional* fields that older
+  operators can safely ignore do not require a bump, but when in doubt, bump.
+- The operator advertises the max `SpecVersion` it supports (see scheduler
+  rule). It **rejects** a spec whose version it cannot build with a clear error.
+- Because both binaries ship in one image and release together, the common case
+  is lockstep; `SpecVersion` exists only for the window where a newer
+  app-exposer talks to an operator that hasn't rolled yet.
+
+`VICESpec` is a **dedicated, minimal type, not a `model.Job` subset.** This
+keeps the operator off `model`'s batch-oriented type and its version cadence,
+documents exactly the VICE surface, and gives a stable reviewable contract. The
+cost — an explicit `model.Job → VICESpec` mapping in app-exposer — is the right
+place for that knowledge to live.
+
+## Scheduler rule: "operator too old → skip"
+
+The operator reports its max supported `SpecVersion` in the capacity/info
+response (a `SpecVersion int` field; `0` = spec path unsupported). During
+operator selection the scheduler treats version like any other fit check:
+
+- operator supports the spec version app-exposer wants to send → send `VICESpec`;
+- operator reports `0` / a version too low → **skip it**, exactly as it skips an
+  at-capacity or vendor-incompatible operator. During the migration this means
+  "fall back to building the legacy `AnalysisBundle` for that operator"; after
+  the legacy path is deleted (Phase 6) it means the operator is simply
+  ineligible until it rolls.
+
+This is the single switch that lets the object path and the spec path coexist
+and lets operators migrate one at a time. It is removed in Phase 6.
+
+## Validation
+
+`AnalysisBundle.Validate()` re-walked each built child object asserting its
+`analysis-id` label matched, because cleanup keys on that label and app-exposer
+built the objects. With construction operator-side the operator **guarantees
+that invariant by construction** — it stamps the labels it builds. So
+`VICESpec.Validate()` is reduced to the required scalar fields (`AnalysisID`,
+`ExternalID`, `JobName`, `Submitter`, `Container.Image`); `SpecVersion`
+compatibility is a separate check the receiver makes against the versions it
+supports.
+
+## GPU vendor matching — decided
+
+`GPUSpec` carries an explicit, canonical **`Vendor`** field
+(`operatorclient.GPUVendorNvidia` / `GPUVendorAMD`) alongside `Count` and
+`Models`. The `model.Job` has no vendor field today, so app-exposer defaults it
+to nvidia — matching today's behavior, where app-exposer always builds
+`nvidia.com/gpu` (`resourcing.go:407,435`) and the operator's
+`TransformGPUVendor` rewrites to AMD per cluster.
+
+**Why a field rather than a hardcoded default.** We could have dropped vendor
+from the spec and had the scheduler assume nvidia, or subsumed vendor under
+model matching. Instead the vendor rides explicitly so multi-vendor scheduling
+is real plumbing, not a future rewrite: the day an analysis can express AMD,
+only this one field changes — the scheduler, the capacity match
+(`CapacityResponse.GPUVendor`), and the operator's build path already read it.
+An empty `Vendor` is read as nvidia for backwards compatibility.
+
+**How the scheduler reads it.** `VICESpec.RequestedGPUVendor()` and
+`RequestedGPUModels()` are the spec-side counterparts of
+`AnalysisBundle.RequestedGPUVendor()` / `RequestedGPUModels()`. They return the
+same values the object path produces (vendor defaulting to nvidia, models
+verbatim) but read them directly from the spec instead of reverse-engineering
+them from a built Deployment. In Phase 3 the scheduler switches to these for
+spec-aware operators; the existing `vendorCompatible` / `modelCompatible` logic
+and `CapacityResponse` matching are unchanged.
+
+This keeps today's behavior exactly (vendor-neutral GPU analyses default to
+nvidia and so still won't land on AMD clusters) while leaving a clean seam:
+when AMD analyses become expressible, set `GPU.Vendor = GPUVendorAMD` and the
+rest of the path already does the right thing.

--- a/plans/operator-side-bundle-construction-contract.md
+++ b/plans/operator-side-bundle-construction-contract.md
@@ -123,6 +123,13 @@ operator selection the scheduler treats version like any other fit check:
 This is the single switch that lets the object path and the spec path coexist
 and lets operators migrate one at a time. It is removed in Phase 6.
 
+**Rollback lever.** A new operator advertises `CurrentVICESpecVersion` by
+default. Starting it with `--disable-spec-launch` makes it advertise `0`
+instead, so the scheduler routes it legacy bundles without an app-exposer
+redeploy; the operator also rejects any spec that reaches `/analyses/spec`
+directly with a transient 503 (so a stray spec is retried elsewhere). This is
+the per-operator "flip back to object-mode" lever the migration plan calls for.
+
 ## Validation
 
 `AnalysisBundle.Validate()` re-walked each built child object asserting its

--- a/plans/operator-side-bundle-construction-field-audit.md
+++ b/plans/operator-side-bundle-construction-field-audit.md
@@ -149,6 +149,7 @@ type ResourceSpec struct {
     SharedMemoryBytes *int64 // nil when no /dev/shm device
 }
 type GPUSpec struct { // nil on VICESpec when GPURequested is false
+    Vendor string   // canonical GPUVendorNvidia | GPUVendorAMD; empty defaults to nvidia
     Count  int64
     Models []string // canonical, e.g. "NVIDIA-A10G"
 }
@@ -157,6 +158,12 @@ type GPUSpec struct { // nil on VICESpec when GPURequested is false
 Resolve legacy `/dev/nvidia` and modern `MinGPUs/MaxGPUs` into a single
 `GPU *GPUSpec` (nil = none) app-exposer-side, so the operator never inspects
 `Devices`. Likewise resolve `/dev/shm` into `SharedMemoryBytes`.
+
+`GPUSpec.Vendor` is carried explicitly even though `model.Job` has no vendor
+field (app-exposer defaults it to nvidia). This was a deliberate call to make
+multi-vendor scheduling real plumbing rather than a future scheduler rewrite —
+see the [contract doc](operator-side-bundle-construction-contract.md)'s GPU
+section. The scheduler reads it via `VICESpec.RequestedGPUVendor()`.
 
 **Decision (audit §8 item 4 — chased down): move the `resourcing` defaults to
 the operator.** Investigation confirms these are genuinely cluster policy, and

--- a/plans/operator-side-bundle-construction-field-audit.md
+++ b/plans/operator-side-bundle-construction-field-audit.md
@@ -1,0 +1,378 @@
+# Field-level audit: inputs to VICE k8s-object construction
+
+Phase 0, step 1 of the
+[migration plan](operator-side-bundle-construction-migration.md). This enumerates
+**every** input the `incluster` builders read, so the `VICESpec` in the
+[design doc](operator-side-bundle-construction.md) can be locked with nothing
+analysis-intrinsic dropped.
+
+Inputs sort into four kinds:
+- **J — `model.Job` value/method** → must surface in `VICESpec`.
+- **L — label input** (consumed by `jobInfo.JobLabels`) → surface in `VICESpec`;
+  one is DB-derived.
+- **C — `Incluster.Init` config** → moves to operator config (or already there).
+- **K — `constants` package** → static; moves with the builder code, not on the wire.
+
+Source files audited: `configmaps.go`, `services.go`, `pdb.go`,
+`deployments.go`, `transfers.go`, `volumes.go`, `httproutes/{common,traefik}.go`,
+`resourcing/resourcing.go`, `jobinfo/main.go`.
+
+## Design principle this audit settles
+
+The builders lean heavily on **computed `model.Job` methods** —
+`OutputDirectory()`, `ExcludeArguments()`, `Step.Arguments()`,
+`StepInput.IRODSPath()`, `FileMetadata.Argument()`, `Container.WorkingDirectory()`.
+These encode DE semantics (iRODS base paths, `NowDate`/`DirectoryName`,
+backwards-compat image detection, param ordering) that the operator has no
+business re-deriving.
+
+**Decision: `VICESpec` carries *resolved* values, not raw `model.Job` internals.**
+app-exposer (where the model methods live) computes them; the operator receives
+primitives. The single exception is **resource asks**, which stay raw because
+clamping to cluster limits is a cluster policy the operator owns (see §4). This
+is what keeps the operator free of a `model.Job` dependency — the strongest
+argument for a dedicated `VICESpec` over shipping the job.
+
+## 1. Identity & labels (J + L)
+
+Every builder calls `jobInfo.JobLabels` (`jobinfo/main.go:24`), which stamps a
+fixed label set on every resource. Its inputs:
+
+| Label | Source field | Notes |
+| --- | --- | --- |
+| `external-id` | `job.InvocationID` | |
+| `analysis-id` | `job.ID` | == bundle `AnalysisID`; cleanup key |
+| `app-name` | `job.AppName` | via `common.LabelValueString` |
+| `app-id` | `job.AppID` | |
+| `username` | `job.Submitter` | via `common.LabelValueString` |
+| `user-id` | `job.UserID` | |
+| `analysis-name` | `job.Name` | truncated to 63 runes; **must not be empty** |
+| `app-type` | — | constant `"interactive"` |
+| `subdomain` | `common.Subdomain(job.UserID, job.InvocationID)` | pure fn; operator can recompute |
+| `login-ip` | **`Apps.GetUserIP(ctx, job.UserID)`** | **DB-derived — the one (C)-class input** |
+
+Plus naming/selector uses outside labels: `job.InvocationID` is the basis for
+every resource name (`vice-<InvocationID>`, PVC names, route name) and the
+`external-id` selector.
+
+→ `VICESpec` fields: `AnalysisID` (=`job.ID`), `ExternalID` (=`InvocationID`),
+`JobName` (=`Name`), `AppID`, `AppName`, `UserID`, `Submitter`, and resolved
+`UserLoginIP`. `subdomain` need not be carried — the operator computes it from
+`UserID`+`ExternalID` via the shared `common.Subdomain`.
+
+## 2. The interactive container (J)
+
+All under `job.Steps[0].Component.Container` unless noted.
+
+| Input | Read at | → VICESpec |
+| --- | --- | --- |
+| `Image.Name` | deployments.go:200 | `Container.Image` |
+| `Image.Tag` | deployments.go:201 | `Container.Tag` |
+| `UID` | deployments.go:209/485, volumes.go:214-215 | `Container.UID` |
+| `Ports[].ContainerPort` | deployments.go:25/220 | `Container.Ports []int` |
+| `EntryPoint` | deployments.go:228-230 | `Container.EntryPoint` |
+| `WorkingDir` / `WorkingDirectory()` | deployments.go:139/235-236 | `Container.WorkingDir` (resolved, default `/de-app-work`) |
+| `Steps[0].Arguments()` | deployments.go:239-240 | `Container.Arguments []string` (resolved: `Executable()`+sorted params) |
+| `Steps[0].Environment` | deployments.go:158 | `Environment map[string]string` |
+
+Note `Steps[0].Arguments()` (`step.go:78`) folds in backwards-compat
+image detection and param sorting — resolve app-exposer-side.
+
+## 3. Data movement & file transfer (J)
+
+| Input | Read at | → VICESpec |
+| --- | --- | --- |
+| `OutputDirectory()` | transfers.go:57, volumes.go:102 | `OutputDirectory string` (resolved) |
+| `UserHome` | volumes.go:114-115 | `UserHome string` |
+| `ExcludeArguments()` | configmaps.go:26 | `ExcludeArguments []string` (resolved) |
+| `FilterInputsWithoutTickets()` | configmaps.go:105, transfers.go:89 | drives input-path-list ConfigMap + whether porklock input staging runs |
+| all `Steps[].Config.Inputs` | volumes.go:60 (`getInputPathMappings`) | CSI input volume mappings — **uses ALL inputs, not just ticketless** |
+| `StepInput.IRODSPath()` | configmaps.go:106, volumes.go:61 | resolved per-input path |
+| `StepInput.Type` | volumes.go:64-68 | branches fileinput / multifileselector / folderinput |
+| `FileMetadata` + `FileMetadata.Argument()` | transfers.go:61-62 | porklock metadata args |
+
+**Subtlety, resolved (audit §8 items 1 & 2 — chased down):** the CSI path
+(`getInputPathMappings`) consumes the **full** input list with `Type` and
+resolved `IRODSPath`, while the input-path-list ConfigMap consumes only the
+**ticketless** subset. But **ticket status never branches anything the operator
+builds** — it is an iRODS access-control concern consumed by porklock/CSI at
+transfer time, not in k8s objects. (`FilterInputsWithTickets()` is never called
+anywhere in app-exposer; `TicketInputPathListIdentifier` is dead config — see §8.)
+
+So rather than carry `Ticket` on the wire, app-exposer **resolves both views**:
+the full input list for CSI mapping, and the ticketless path list for the
+ConfigMap, as a ready `[]string`. `Multiplicity` is not needed separately —
+`IRODSPath()` already appends a trailing `/` for collections, and `Type` drives
+the CSI resource-type branch:
+
+```go
+type InputSpec struct {
+    IRODSPath string // resolved StepInput.IRODSPath() (trailing "/" = collection)
+    Type      string // fileinput | multifileselector | folderinput
+}
+```
+
+→ on `VICESpec`: `Inputs []InputSpec` (all inputs, CSI mapping) +
+`InputPathListPaths []string` (resolved ticketless subset, input-path-list
+ConfigMap) + `FileMetadata []MetadataAVU{Attr,Value,Unit}` for the porklock
+upload command. No `Ticket`/`HasTicket` anywhere — ticket handling is entirely
+upstream of k8s-object construction.
+
+## 4. Resource requirements (J) — the raw-vs-resolved exception
+
+`resourcing.Requirements`, `GPUEnabled`, `GPUModelsRequested`,
+`SharedMemoryAmount` read these off the container:
+
+| Input | Read at | Meaning |
+| --- | --- | --- |
+| `MinCPUCores` / `MaxCPUCores` | resourcing.go:285/304 | CPU request / limit ask |
+| `MinMemoryLimit` / `MemoryLimit` | resourcing.go:322/340 | memory request / limit ask |
+| `MinDiskSpace` | resourcing.go:358, volumes.go:235 | disk ask (max across steps) |
+| `MinGPUs` / `MaxGPUs` | resourcing.go:196 | GPU count ask |
+| `GPUModels` | resourcing.go:388 | canonical model names |
+| `Devices[].HostPath == /dev/nvidia*` | resourcing.go:199-200 | **legacy** GPU detection |
+| `Devices[].HostPath == /dev/shm` + `ContainerPath` | resourcing.go:371-373 | shared-memory request (as quantity) |
+
+`resourcing.Requirements` also applies **package-level default/clamp values**
+(global setters configured at app-exposer startup). Those defaults are a
+**cluster policy** ("what this cluster grants"), distinct from the analysis ask
+("what the user wants"). Per the design principle, the asks ride in the spec raw
+and the **operator owns the clamping defaults**:
+
+```go
+type ResourceSpec struct {
+    MinCPUCores  float32
+    MaxCPUCores  float32
+    MinMemoryBytes int64
+    MaxMemoryBytes int64
+    MinDiskBytes int64
+    SharedMemoryBytes *int64 // nil when no /dev/shm device
+}
+type GPUSpec struct { // nil on VICESpec when GPURequested is false
+    Count  int64
+    Models []string // canonical, e.g. "NVIDIA-A10G"
+}
+```
+
+Resolve legacy `/dev/nvidia` and modern `MinGPUs/MaxGPUs` into a single
+`GPU *GPUSpec` (nil = none) app-exposer-side, so the operator never inspects
+`Devices`. Likewise resolve `/dev/shm` into `SharedMemoryBytes`.
+
+**Decision (audit §8 item 4 — chased down): move the `resourcing` defaults to
+the operator.** Investigation confirms these are genuinely cluster policy, and
+the move is cheap because the `resourcing` package relocates *with* the builders
+into `vicebuild/` — the clamping logic is not duplicated, it travels intact.
+Findings:
+
+- `resourcing/resourcing.go` holds **16 package-level defaults** — 7 for the
+  analysis container (CPU req/limit, mem req/limit, storage req, two
+  `do*Limit` toggles) and 9 for the vice-proxy sidecar — set via setters from
+  **CLI flags in `cmd/app-exposer/main.go:215-230`** (e.g.
+  `--default-cpu-resource-request` `1000m`, `--default-memory-resource-limit`
+  `8Gi`). These are startup flags, not koanf/env keys, and represent
+  "what this cluster grants," consistent with the per-cluster deployment model.
+- `Requirements()` logic is "use the analysis ask if non-zero, else the default;
+  apply limits only when the `do*` toggle is on." So the **asks** (`ResourceSpec`)
+  ride in the spec raw; the **defaults/toggles** become operator config; the
+  operator runs the same clamp.
+- `VICEProxyRequirements()` **ignores the analysis entirely** — the vice-proxy
+  sidecar's resources come 100% from cluster defaults. So the vice-proxy
+  container is built fully operator-side with operator config and needs **no
+  spec input at all**.
+
+Consequence for the spec: `ResourceSpec` carries only the analysis asks below;
+nothing about vice-proxy resources or default/clamp values crosses the wire.
+
+## 5. `Incluster.Init` config → operator config (C)
+
+Every config value the builders read, and whether the operator already holds an
+equivalent (from the operator-config audit):
+
+| `Init` field | Read at | Operator status |
+| --- | --- | --- |
+| `PorklockImage` | deployments.go:46/102/326 | **add** |
+| `PorklockTag` | deployments.go:46/102/326 | **add** |
+| `ViceProxyImage` | deployments.go:254 | **add** |
+| `UseCSIDriver` | deployments.go:147, volumes.go:150/278/405 | **add** (cluster capability) |
+| `FrontendBaseURL` | deployments.go:171 | **add** |
+| `ViceDomain` | bundle.go:61 → httproutes | present (`baseDomain`) |
+| `VICEBackendNamespace` | bundle.go:59 → httproutes (DENamespace) | present (`gatewayNamespace`) — reconcile |
+| `ViceNamespace` | bundle.go:60, deployments.go:225/541 | operator owns (`o.namespace`; already overrides via `normalizeNamespaces` — §8.5) |
+| `IRODSZone` | volumes.go:37/125 | **add** |
+| `UserSuffix` | configmaps.go:71 | present (`userSuffix`) |
+| `ImagePullSecretName` | deployments.go:378 | operator owns (`-image-pull-secret` / `EnsureImagePullSecret` — §8.5) |
+| `ClusterConfigSecretName` | deployments.go:307 | present (`clusterConfigSecret`) |
+| `GatewayProvider` | bundle.go:57 | implicit (operator owns its gateway) — make explicit |
+| `InputPathListIdentifier` | configmaps.go:125 | **add** |
+| `TicketInputPathListIdentifier` | — | **dead config; remove** (§8.1) |
+
+Plus the `resourcing` package-level defaults (§4) and the storage class
+(`TransformWorkingDirStorageClass` already uses operator `localStorageClass`).
+The namespace and secret rows are settled in §8.5: the operator owns all of them
+(two already override app-exposer's value today), so none cross the wire.
+
+## 6. Constants (K)
+
+The builders pull ~30 names from `constants` — file names (`ExcludesFileName`,
+`PermissionsFileName`, `InputPathListFileName`), volume names
+(`InputPathListVolumeName`, `ExcludesVolumeName`, `PermissionsVolumeName`,
+`PorklockConfigVolumeName`, `SharedMemoryVolumeName`), CSI names
+(`CSIDriverName`, `CSIDriverStorageClassName`, `CSIDriver*MountPath`,
+`CSIDriverDataVolume*Prefix`), port names/numbers (`FileTransfersPort*`,
+`VICEProxyPort*`), label keys, `ShmDevice`, `VICEGatewayName`. These are static
+and travel **with the builder code** into `vicebuild/`; none belong on the wire.
+The `constants` package is already importable by `operator/`.
+
+## 7. Consolidated `VICESpec` (audit-backed)
+
+```go
+type VICESpec struct {
+    SpecVersion int
+
+    // Identity / labels (§1)
+    AnalysisID  AnalysisID // job.ID
+    ExternalID  ExternalID // job.InvocationID
+    JobName     string     // job.Name (label "analysis-name"; required, non-empty)
+    AppID       string
+    AppName     string
+    UserID      string
+    Submitter   string
+    UserLoginIP string     // resolved via Apps.GetUserIP — the only DB-derived input
+
+    // Container (§2)
+    Container   ContainerSpec
+    Environment map[string]string
+
+    // Resources (§4)
+    Resources ResourceSpec
+    GPU       *GPUSpec // nil = none
+
+    // Data movement (§3)
+    UserHome           string
+    OutputDirectory    string
+    ExcludeArguments   []string
+    Inputs             []InputSpec   // all inputs — CSI volume mappings
+    InputPathListPaths []string      // resolved ticketless subset — input-path-list ConfigMap
+    FileMetadata       []MetadataAVU
+}
+
+type ContainerSpec struct {
+    Image      string
+    Tag        string
+    UID        int
+    Ports      []int
+    EntryPoint string
+    WorkingDir string   // resolved (default /de-app-work)
+    Arguments  []string // resolved Step.Arguments()
+}
+
+type MetadataAVU struct{ Attribute, Value, Unit string }
+// InputSpec, ResourceSpec, GPUSpec: see §3, §4.
+```
+
+Everything the builders read maps to a field above, to operator config (§5), or
+to a constant that moves with the code (§6). The lone input that cannot be
+derived cluster-side is `UserLoginIP`, threaded as a resolved value — confirming
+the design doc's central claim with no remaining unknowns at the field level.
+
+## 8. Gaps / items to confirm before locking the schema
+
+**Resolved:**
+
+1. ~~**Ticketed inputs.**~~ *Resolved (§3).* Ticket status never branches
+   anything the operator builds. `FilterInputsWithTickets()` is never called in
+   app-exposer; `TicketInputPathListIdentifier` is **dead config** — defined on
+   the `Incluster` struct (`incluster.go:43`), set from
+   `tickets_path_list.file_identifier` (`app.go:116`), referenced only in
+   `deployments_test.go:24`, never read by a builder. Tickets are an iRODS
+   access-control concern consumed by porklock/CSI at transfer time. The spec
+   carries no ticket data. **Cleanup opportunity (independent of this project):**
+   remove `TicketInputPathListIdentifier` and its flag as dead code.
+2. ~~**`InputSpec.Multiplicity`.**~~ *Resolved (§3).* Not needed —
+   `IRODSPath()` already encodes collection-ness via a trailing `/`, and `Type`
+   drives the CSI branch. `InputSpec` is just `{IRODSPath, Type}`.
+4. ~~**`resourcing` defaults ownership.**~~ *Resolved (§4): move them to the
+   operator.* They are cluster policy, the package relocates with the builders so
+   no logic is duplicated, and `VICEProxyRequirements` needs no spec input at all.
+
+3. ~~**Multi-step assumption.**~~ *Resolved: `VICESpec` models one container.*
+   VICE is single-step by invariant, not by accident: an explicit comment
+   (`incluster/analyses.go:10-12`, "VICE analyses only have a single step in the
+   database"), `ConvertToJob` hardcoding `Steps: []model.Step{step}`
+   (`cmd/vicetools/convert.go:183`), and tests asserting `require.Len(job.Steps,
+   1)` (`convert_test.go`) all confirm it. Every builder already indexes
+   `Steps[0]`; the two step-iterating helpers
+   (`getInputPathMappings`, `getPersistentVolumeCapacity`) loop over a length-1
+   slice. And because app-exposer resolves inputs (`Inputs`,
+   `InputPathListPaths`) and disk capacity (`Resources.MinDiskBytes`) into flat
+   spec fields, **the operator never iterates steps at all.** Contrast: `batch/`
+   genuinely iterates multi-step (`batch.go:77/257/909`) — that's the HPC path,
+   not VICE.
+5. ~~**Namespace/secret name reconciliation.**~~ *Resolved: the operator owns all
+   four; none go in the spec.* Two are **already** overridden operator-side today,
+   so dropping them is zero-risk:
+   - **VICE namespace** — `normalizeNamespaces` (`operator/resources.go:56-86`)
+     unconditionally rewrites every resource's namespace to `o.namespace` before
+     apply. App-exposer's `ViceNamespace` is already dead weight.
+   - **Backend/gateway namespace** — `TransformGatewayNamespace`
+     (`operator/transforms.go`) unconditionally overwrites the HTTPRoute
+     `parentRef`. App-exposer's `VICEBackendNamespace` is already overridden.
+   - **Image pull secret** — operator already ensures it
+     (`EnsureImagePullSecret`, `-image-pull-secret`); on construction-move the
+     operator sets `Deployment.ImagePullSecrets` from its own name (today
+     app-exposer sets it on a separate path — a latent mismatch this removes).
+   - **Cluster config secret** — operator already holds `clusterConfigSecret` and
+     ensures the `EnvFrom`; it sets it at build time.
+6. ~~**`common` helper importability.**~~ *Resolved: clean, after one refactor.*
+   `common`, `constants`, `resourcing` import into the operator without cycles
+   (operator already uses `common`/`constants`; `resourcing` depends only on
+   those two; operator does not import `incluster`, and vice versa). The one snag:
+   `incluster/httproutes` imports `incluster/jobinfo`, which pulls in `apps` (DB)
+   — but **only** because the route builder calls `JobLabels`. Once labels are
+   resolved app-exposer-side and passed in, the moved builder takes the label map
+   as input and drops the `jobinfo` import; `jobinfo`/`apps` stay in app-exposer
+   with the DB-coupled `GetUserIP`. See §9.
+
+## 9. Package layout and the label split (from §8.6)
+
+The import audit yields a clean target layout. The current direction is
+acyclic — `operator/` does not import `incluster/`, and `incluster/` does not
+import `operator/` — so a new `vicebuild/` imported by `operator/` introduces no
+cycle. The only thing standing in the way is how labels are produced.
+
+**Today:** every builder calls `jobInfo.JobLabels(ctx, job)`, which both
+assembles a fixed label map *and* makes the DB call `Apps.GetUserIP`
+(`jobinfo/main.go:24`). The label map assembly is pure (`common.LabelValueString`
++ `common.Subdomain` over job fields); only `GetUserIP` touches the DB. Because
+the interface and its DB-coupled implementation live in the same
+`incluster/jobinfo` package, importing the route builder drags `apps` along.
+
+**Target:** split the two halves along the line that already exists in the data —
+the DB call vs. the pure assembly.
+
+- **app-exposer keeps** `jobinfo`/`apps` and resolves `UserLoginIP` (the one DB
+  value) into the `VICESpec`, exactly as §1 requires.
+- **`vicebuild/` gets a pure `BuildLabels(spec) map[string]string`** — the body
+  of `JobLabels` minus the `GetUserIP` call, reading the resolved spec fields
+  (`AnalysisID`, `ExternalID`, `AppID`, `AppName`, `UserID`, `Submitter`,
+  `JobName`, `UserLoginIP`) and using `common.LabelValueString`/`common.Subdomain`.
+  Every moved builder (Deployment, Service, HTTPRoute, ConfigMaps, PV/PVC, PDB)
+  calls this instead of an injected `JobInfo`.
+
+This removes the `httproutes → jobinfo → apps` edge, so `vicebuild/` depends only
+on `common`, `constants`, `resourcing`, `model/v10`, and the k8s/gateway
+libraries — all cleanly importable by `operator/`. Proposed layout:
+
+```
+vicebuild/                 # operator-importable; no apps/db
+  labels.go                # BuildLabels(spec) — pure, from jobinfo.JobLabels
+  deployments.go services.go configmaps.go volumes.go pdb.go
+  httproutes/              # moved from incluster/, jobinfo dependency removed
+resourcing/                # unchanged; relocate defaults/setters to operator main
+operator/                  # imports vicebuild/, builds from VICESpec
+incluster/                 # keeps jobinfo/apps + the model.Job → VICESpec mapping
+```
+
+`incluster/jobinfo`'s `JobInfo` interface can stay where it is — once the builders
+no longer depend on it, nothing in `vicebuild/`/`operator/` imports it, so no
+separate interface-extraction package is needed.

--- a/plans/operator-side-bundle-construction-migration.md
+++ b/plans/operator-side-bundle-construction-migration.md
@@ -1,0 +1,195 @@
+# Migration plan: operator-side bundle construction
+
+Companion to [operator-side-bundle-construction.md](operator-side-bundle-construction.md).
+That doc is the *what* and *why*; this is the *how*, sequenced so the fleet keeps
+launching analyses at every step and coverage never drops.
+
+## Guiding constraints
+
+- **No big-bang.** At every commit the system launches analyses correctly. The
+  old k8s-object path and the new spec path coexist until the fleet is fully
+  cut over.
+- **Per-operator opt-in.** A given operator either understands `VICESpec` or it
+  doesn't. app-exposer chooses the path per target operator, so operators can
+  roll independently even though both binaries ship in one image.
+- **Coverage moves with code.** When a builder moves, its tests move with it in
+  the same change — never "relocate now, re-test later."
+- **Decisions before mechanics.** Lock the spec schema and the versioning story
+  (Phase 0) before writing builder code against it.
+
+## Capability negotiation
+
+The operator already reports `CapacityResponse` from its capacity endpoint. Add
+a `SpecVersion int` (max supported `VICESpec` version, `0` = spec path
+unsupported) to that response, or to a dedicated operator-info endpoint if we'd
+rather not overload capacity. The scheduler reads it during operator selection:
+
+- target supports the spec → app-exposer sends `VICESpec`.
+- target is spec-unaware (`0`) → app-exposer builds the legacy `AnalysisBundle`.
+
+This is the single switch that lets the two paths coexist and lets operators
+migrate one at a time. It is removed in Phase 6.
+
+## Phase 0 — Lock the contract (no behavior change)
+
+**Goal:** agree on `VICESpec` and the versioning rules before any builder moves.
+
+1. **Field-level audit.** *Done* —
+   [operator-side-bundle-construction-field-audit.md](operator-side-bundle-construction-field-audit.md)
+   enumerates every builder input (J/L/C/K), maps each to a `VICESpec` field,
+   operator config, or a constant, and proposes the audit-backed schema. All six
+   follow-up items are now closed (audit §8): ticketed inputs (no spec data;
+   `TicketInputPathListIdentifier` is dead code), `InputSpec.Multiplicity` (not
+   needed), `resourcing` ownership (operator), single-step (one container),
+   namespace/secret reconciliation (operator owns all four), and importability
+   (cycle-free given the `BuildLabels` split, audit §9). No open schema questions
+   remain; this phase reduces to writing the `VICESpec` types and the contract
+   doc.
+2. **Define `VICESpec`** (and `ContainerSpec`/`ResourceSpec`/`GPUSpec`/
+   `InputSpec`) in `operatorclient/` next to the existing types. Add
+   `SpecVersion`. No one builds or consumes it yet.
+3. **Write the contract doc**: which side owns which field, the versioning
+   policy, and the "operator too old → skip" scheduler rule.
+
+**Exit:** `VICESpec` compiles, is reviewed, and the audit checklist is complete.
+No runtime change. This is the natural review-with-coworkers checkpoint.
+
+## Phase 1 — Operator can build from a spec (dark, behind capability)
+
+**Goal:** the operator gains the ability to construct k8s objects from
+`VICESpec`, exercised only by tests.
+
+1. **Create `vicebuild/`** (importable by `operator/`). Move the pure
+   construction code into it: `deployments.go`, `services.go`, `httproutes/`,
+   `configmaps.go`, `volumes.go`, `pdb.go`, and helpers (`resourcing`,
+   `millicores`, porklock/iRODS mapping). Change their inputs from `model.Job`
+   to `VICESpec`. **Move the matching tests in the same change.**
+2. **Fold the transforms into construction.** Each builder takes the operator's
+   cluster config and sets cluster-correct values directly:
+   - hostname/gateway → `o.baseDomain`, `o.gatewayName/Namespace`
+   - backend → loading service
+   - GPU vendor/model → `o.gpuVendor`, `o.gpuModelMapping`, `GPUSpec`
+   - storage class → `o.localStorageClass`
+   - vice-proxy args + cluster config secret
+   - image refs → `o.imageRewriter`
+   - permissions ConfigMap always built
+   Port each `Transform*` test into the corresponding builder test, asserting the
+   built object already has the right value (no separate transform step).
+3. **Thread operator config.** Add to operator config the cluster-specific
+   `Init` fields it doesn't already hold: `PorklockImage/Tag`, `ViceProxyImage`,
+   `UseCSIDriver`, `FrontendBaseURL`, `ViceDomain`, `VICEBackendNamespace`,
+   `ViceNamespace`, `IRODSZone`, `ImagePullSecretName`, `GatewayProvider`,
+   `InputPathListIdentifier`, `TicketInputPathListIdentifier`. (`baseDomain`,
+   `userSuffix`, `clusterConfigSecret`, `localStorageClass`, GPU fields, gateway
+   refs, `imageRewriter` already exist.)
+4. **Golden-equivalence test.** For a representative set of jobs, assert that
+   `vicebuild` from a `VICESpec` produces objects equivalent to today's
+   app-exposer build + operator transforms. This is the safety net for the whole
+   migration — it proves the new path matches the old before anything live uses
+   it.
+
+**Exit:** operator builds correct objects from `VICESpec` in tests; no
+production traffic uses it yet.
+
+## Phase 2 — Operator accepts a spec on the wire (still unused by app-exposer)
+
+**Goal:** the operator's launch endpoint can receive `VICESpec`, build, and apply.
+
+1. Add a spec-accepting launch path in the operator (new endpoint, or
+   content-negotiated on the existing one). It validates the spec shape and
+   `SpecVersion`, calls `vicebuild`, then reuses the **existing**
+   `applyBundle` / egress-policy / labeling code unchanged — only the *source* of
+   the objects differs.
+2. Report `SpecVersion` in the capacity/info response.
+3. Operator integration tests against a fake clientset: POST `VICESpec` →
+   correct objects applied, labels intact, egress policy created.
+
+**Exit:** a deployed operator advertises spec support and works when called with
+a spec — but app-exposer still sends objects.
+
+## Phase 3 — app-exposer maps `model.Job → VICESpec`
+
+**Goal:** app-exposer can produce a spec; choose the path per operator.
+
+1. **`BuildVICESpec(ctx, job, analysisID)`** in app-exposer (the resolution
+   half of the old `incluster`): map `model.Job` → `VICESpec`, including
+   resolving `UserLoginIP` once (the only DB-derived field) via the existing
+   `apps.GetUserIP` path.
+2. **Scheduler decides per target:** spec-aware operator → send `VICESpec` via a
+   new `operatorclient` `LaunchSpec`; spec-unaware → keep
+   `BuildAnalysisBundle` + `Launch`.
+3. **Move GPU selection to the spec.** Replace scheduler use of
+   `AnalysisBundle.RequestedGPUVendor/RequestedGPUModels` (which parse the
+   Deployment) with reads of `VICESpec.GPU`. Keep the old methods only for the
+   legacy path until Phase 6.
+
+**Exit:** app-exposer sends specs to spec-aware operators and objects to the
+rest, chosen automatically.
+
+## Phase 4 — Roll the fleet onto the spec path
+
+**Goal:** every operator advertises and uses spec support in production.
+
+1. Deploy the new image fleet-wide (operators begin advertising `SpecVersion`).
+2. As each operator reports support, the scheduler automatically routes specs to
+   it — no app-exposer change needed per operator.
+3. **Monitor:** launch success rate, build-error logs (now operator-side — see
+   design-doc risk 5), and the golden-equivalence canary. Watch GPU clusters
+   (NVIDIA and AMD) and CSI/iRODS clusters specifically, since those exercised
+   the most transforms.
+
+**Exit:** all production operators serve the spec path; the legacy path receives
+no traffic.
+
+## Phase 5 — Soak
+
+Leave both paths in place for a defined soak window (a few release cycles).
+Keep the legacy `BuildAnalysisBundle` + transforms compiled and tested so a
+single operator can fall back if a cluster surfaces a build discrepancy. This is
+the cheap insurance interval before deletion.
+
+## Phase 6 — Delete the legacy path
+
+Once no operator has used object-mode for the full soak window:
+
+1. Remove `BuildAnalysisBundle`, the `AnalysisBundle` k8s-object fields, the
+   operator's object-accepting launch path, and the now-dead `Transform*`
+   functions (their logic lives in `vicebuild`).
+2. Remove the per-operator capability switch and the scheduler's dual-path
+   branch; `VICESpec` is the only contract.
+3. Remove `RequestedGPUVendor/RequestedGPUModels` Deployment-parsing helpers.
+4. Trim `Incluster.Init` of the cluster-specific build fields that now live only
+   on the operator.
+
+**Exit:** one contract (`VICESpec`), one build path (operator-side), app-exposer
+free of per-cluster Kubernetes knowledge.
+
+## Sequencing at a glance
+
+| Phase | Touches | Live traffic on new path | Reversible by |
+| --- | --- | --- | --- |
+| 0 Lock contract | `operatorclient/` types, docs | no | n/a |
+| 1 Operator builds (dark) | new `vicebuild/`, operator config, tests | no | revert package |
+| 2 Operator accepts spec | operator endpoint | no | feature off |
+| 3 app-exposer maps + routes | app-exposer scheduler, `BuildVICESpec` | spec-aware ops | capability switch |
+| 4 Roll fleet | deploy only | all ops | capability switch |
+| 5 Soak | none | all ops | capability switch |
+| 6 Delete legacy | remove old path | all ops | n/a |
+
+The capability switch (Phases 2–5) is the rollback lever for the entire live
+portion: flip an operator back to object-mode and app-exposer resumes building
+its objects, no redeploy of app-exposer required.
+
+## Open items to resolve while executing
+
+- **Spec vs. job-subset for the wire type.** Design doc recommends a dedicated
+  `VICESpec`. If we want extra de-risking, Phase 1 could first build from a
+  `model.Job` subset and tighten to `VICESpec` before Phase 3 — decide at Phase 0.
+- **Endpoint shape.** New `/analyses/spec` endpoint vs. content negotiation on
+  the existing launch endpoint. New endpoint is simpler to reason about and
+  delete later; decide in Phase 2.
+- **Where `SpecVersion` is advertised.** Piggyback on capacity response vs. a
+  dedicated operator-info endpoint. Decide in Phase 0.
+- **iRODS/CSI ownership audit** (design-doc risk 4): confirm the operator can own
+  the entire volume-layout decision with no DB lookup before Phase 1 moves the
+  volume builders.

--- a/plans/operator-side-bundle-construction-migration.md
+++ b/plans/operator-side-bundle-construction-migration.md
@@ -48,11 +48,18 @@ migrate one at a time. It is removed in Phase 6.
 2. **Define `VICESpec`** (and `ContainerSpec`/`ResourceSpec`/`GPUSpec`/
    `InputSpec`) in `operatorclient/` next to the existing types. Add
    `SpecVersion`. No one builds or consumes it yet.
-3. **Write the contract doc**: which side owns which field, the versioning
-   policy, and the "operator too old → skip" scheduler rule.
+3. **Write the contract doc** —
+   [operator-side-bundle-construction-contract.md](operator-side-bundle-construction-contract.md):
+   which side owns which field, the versioning policy, and the "operator too old
+   → skip" scheduler rule. It also records the one decision deferred to Phase 3
+   (GPU vendor matching, now that `GPUSpec` carries no vendor).
 
 **Exit:** `VICESpec` compiles, is reviewed, and the audit checklist is complete.
 No runtime change. This is the natural review-with-coworkers checkpoint.
+
+*Status: done — `VICESpec` and friends are defined in
+`operatorclient/vicespec.go` (with `Validate()` and round-trip tests), and the
+contract doc is written.*
 
 ## Phase 1 — Operator can build from a spec (dark, behind capability)
 

--- a/plans/operator-side-bundle-construction.md
+++ b/plans/operator-side-bundle-construction.md
@@ -1,0 +1,383 @@
+# Operator-side bundle construction: a cluster-agnostic analysis bundle
+
+## Context
+
+Today app-exposer builds **fully-formed Kubernetes objects** and ships them to
+vice-operator, which applies them to its local cluster. The wire contract is
+`operatorclient.AnalysisBundle` (`operatorclient/types.go:27`):
+
+```go
+type AnalysisBundle struct {
+    AnalysisID             AnalysisID
+    Deployment             *appsv1.Deployment
+    Service                *apiv1.Service
+    HTTPRoute              *gatewayv1.HTTPRoute
+    ConfigMaps             []*apiv1.ConfigMap
+    PersistentVolumes      []*apiv1.PersistentVolume
+    PersistentVolumeClaims []*apiv1.PersistentVolumeClaim
+    PodDisruptionBudget    *policyv1.PodDisruptionBudget
+}
+```
+
+Every field except `AnalysisID` is a raw k8s API type. App-exposer's
+`incluster.BuildAnalysisBundle` (`incluster/bundle.go:14`) assembles them from a
+`model.Job` plus a dozen cluster-config values held on the `Incluster` struct.
+
+The problem this design addresses: **app-exposer has to know the shape of every
+target cluster's Kubernetes environment.** It bakes in the Gateway API version,
+the GPU vendor's resource names and node-label scheme, the storage class, the
+image registry, the gateway reference, the iRODS CSI layout, and so on. As the
+fleet grows to clusters that differ in these dimensions (the `multi-cluster`
+work), app-exposer becomes a chokepoint: a cluster that runs a newer Gateway API
+version, a different GPU label convention, or AMD instead of NVIDIA forces a
+change in app-exposer even though nothing about the *analysis* changed.
+
+The codebase is already telling us where the seam belongs. vice-operator runs a
+**transform layer** at launch (`operator/handlers.go:257`) that rewrites the
+received objects with cluster-local values *after* app-exposer built them with
+cluster-agnostic placeholders:
+
+| Transform | What it patches in |
+| --- | --- |
+| `TransformHostnames` | HTTPRoute hostname → cluster `baseDomain` |
+| `TransformGatewayNamespace` | HTTPRoute `parentRef` → cluster gateway |
+| `TransformBackendToLoadingService` | backend → loading-page service |
+| `TransformGPUModels` | canonical GPU model → cluster node-label values |
+| `TransformGPUVendor` | `nvidia.com/gpu` ↔ `amd.com/gpu`, affinity key |
+| `TransformWorkingDirStorageClass` | working-dir PVC → cluster storage class |
+| `TransformViceProxyArgs` | per-analysis vice-proxy args + cluster config secret |
+| `TransformImageRefs` | upstream image → mirrored ref (manual-mirror mode) |
+| `EnsurePermissionsConfigMap` | seed permissions ConfigMap |
+
+This is a "build it wrong, then fix it" dance. Each transform exists *only*
+because app-exposer set a value it couldn't actually know. If the operator built
+the objects, every one of these would collapse into setting the right value the
+first time.
+
+Two more facts make the operator the natural home for construction:
+
+- **vice-operator is already a full k8s resource builder**, not a dumb applier.
+  It constructs NetworkPolicies (`operator/networkpolicy.go`), Gateways and
+  HTTPRoutes (`operator/gateway.go`), the loading-page Service
+  (`operator/loadingservice.go`), Secrets (`operator/secrets.go`), and image
+  caches (`operator/imagecache_*.go`) from scratch. It has the clientset, the
+  Gateway client, and all cluster-specific config.
+- **vice-operator has zero external dependencies** — no DB, no apps service, no
+  permissions service, no quota service. It is purely an in-cluster component.
+  That constraint is the one real design force (see "The label/IP dependency").
+
+## Goal
+
+Replace the k8s-object `AnalysisBundle` with a **higher-level, cluster-agnostic
+analysis spec**. app-exposer sends *what the analysis is*; vice-operator decides
+*how to realize it on this cluster* and applies the result.
+
+### Non-goals
+
+- Changing the batch/Argo (`adapter/`, `batch/`) path. This is VICE-only.
+- Changing the legacy `outcluster/` HTCondor path.
+- Changing the operator's own self-managed resources (gateway, loading service,
+  image cache, egress policy) — those are already operator-built and stay.
+- Moving permissions or quota enforcement into the operator. Those run in
+  app-exposer *before* launch and are not part of bundle construction.
+
+## Why this is feasible
+
+The inputs to today's builders sort into three buckets:
+
+**(A) Analysis-intrinsic** — everything comes off `model.Job`: container image,
+ports, UID, entrypoint, working dir, args, environment, resource requests, GPU
+requests, input/output paths, `UserHome`, `Submitter`, invocation ID, exclude
+arguments, app metadata. This is already a higher-level description; it just
+needs a wire shape.
+
+**(B) Cluster-specific config** — the `Incluster.Init` fields the builders read
+(`incluster/incluster.go`): `PorklockImage`/`PorklockTag`, `ViceProxyImage`,
+`UseCSIDriver`, `FrontendBaseURL`, `ViceDomain`, `VICEBackendNamespace`,
+`ViceNamespace`, `IRODSZone`, `UserSuffix`, `ImagePullSecretName`,
+`ClusterConfigSecretName`, `GatewayProvider`, `InputPathListIdentifier`. These
+*are* cluster-specific, so they belong operator-side. The operator already holds
+peers of several of them (`baseDomain`, `userSuffix`, `clusterConfigSecret`,
+`localStorageClass`, GPU fields, gateway refs, `imageRewriter`).
+
+**(C) app-exposer infrastructure** — exactly one thing: the user's login IP,
+fetched from the jobs DB via `jobInfo.JobLabels` → `apps.GetUserIP`
+(`apps/apps.go:133`) and stamped into resource labels. This is the only build
+input the operator cannot get on its own.
+
+So there is no hard blocker. (A) becomes the bundle. (B) moves to operator
+config. (C) is threaded through the bundle as a resolved value.
+
+## Design
+
+### Division of responsibility
+
+```
+app-exposer                                vice-operator
+-----------                                -------------
+- resolve analysis (DB, apps, quota,       - receive VICESpec
+  permissions)                             - build all k8s objects from spec
+- enforce quota / permissions              - inject cluster-specific values at
+- pick a target operator (scheduler)         build time (the old transforms,
+- build VICESpec from model.Job              now construction)
+- resolve DB-derived values (user IP)      - apply via upsert
+- POST VICESpec to chosen operator         - build egress NetworkPolicy (already)
+                                           - capacity check (already)
+```
+
+The line is clean: **app-exposer owns the analysis and the fleet decision; the
+operator owns the cluster.**
+
+### The wire contract: `VICESpec`
+
+Replace `AnalysisBundle` with a spec describing the analysis. The shape below is
+the initial sketch; the **field-level audit**
+([operator-side-bundle-construction-field-audit.md](operator-side-bundle-construction-field-audit.md))
+hardens it against every input the builders actually read and is the
+authoritative schema. Two things the audit settled that this sketch did not:
+the spec carries **resolved** values (computed app-exposer-side, where the
+`model.Job` methods live) rather than raw job internals — that is what keeps the
+operator free of a `model.Job` dependency — and **raw resource asks** ride on the
+wire while the `resourcing` clamp/default policy moves operator-side (see the
+audit's §4 open decision).
+
+```go
+// VICESpec is the cluster-agnostic description of a VICE analysis that
+// app-exposer sends to a vice-operator. The operator turns this into the
+// concrete k8s objects for its cluster.
+type VICESpec struct {
+    AnalysisID  AnalysisID        // analysis UUID (canonical id, drives labels)
+    ExternalID  ExternalID        // a.k.a. InvocationID
+    SpecVersion int               // wire-contract version; see "Versioning"
+
+    // Identity / ownership
+    UserID    string
+    Submitter string              // raw username (operator applies UserSuffix)
+    UserHome  string
+
+    // The interactive container (model.Job.Steps[0].Component.Container)
+    Container ContainerSpec
+
+    // Environment for the analysis container
+    Environment map[string]string
+
+    // Resource requests, already normalized to canonical units
+    Resources ResourceSpec        // CPU millicores, memory bytes, min disk
+    GPU       *GPUSpec            // nil when no GPU requested
+
+    // Data movement
+    Inputs          []InputSpec    // FilterInputsWithoutTickets
+    OutputDirectory string
+    ExcludeArguments []string
+
+    // App metadata (labels / display)
+    AppID   string
+    AppName string
+    JobName string
+
+    // Resolved values app-exposer must supply because the operator cannot
+    // (DB-derived). See "The label/IP dependency".
+    UserLoginIP string
+}
+
+type ContainerSpec struct {
+    Image       string
+    Tag         string
+    Ports       []int
+    UID         int64
+    EntryPoint  string
+    WorkingDir  string
+    Arguments   []string
+    MinDiskSpace int64
+}
+
+type ResourceSpec struct {
+    CPUMillicores int64
+    MemoryBytes   int64
+    MinDiskBytes  int64
+}
+
+// GPUSpec is canonical and vendor-neutral. The operator maps Vendor +
+// Models onto its own resource names and node-label scheme — exactly what
+// TransformGPUVendor / TransformGPUModels do today.
+type GPUSpec struct {
+    Vendor string   // "nvidia" | "amd" (canonical)
+    Models []string // canonical GFD names, e.g. "NVIDIA-A10G"
+}
+
+type InputSpec struct {
+    IRODSPath string // resolved StepInput.IRODSPath() (trailing "/" = collection)
+    Type      string // fileinput | multifileselector | folderinput
+}
+// VICESpec also carries InputPathListPaths []string — the resolved ticketless
+// subset for the input-path-list ConfigMap. Ticket status itself never crosses
+// the wire (audit §3/§8). The authoritative schema is the field audit.
+```
+
+The operator's builders consume `VICESpec` instead of `model.Job` and produce
+the same Deployment / Service / HTTPRoute / ConfigMaps / PVs / PVCs / PDB it
+applies today — but with cluster-correct values baked in, so the transform layer
+is gone.
+
+### What happens to the transforms
+
+Each transform becomes a build-time decision in the operator, not a
+post-hoc patch:
+
+| Today (transform on received object) | After (build-time in operator) |
+| --- | --- |
+| `TransformHostnames` | HTTPRoute built with `o.baseDomain` directly |
+| `TransformGatewayNamespace` | `parentRef` built with `o.gatewayName/Namespace` |
+| `TransformBackendToLoadingService` | backend built pointing at loading svc |
+| `TransformGPUModels` / `TransformGPUVendor` | affinity + resource names built from `o.gpuVendor` / `o.gpuModelMapping` and `GPUSpec` |
+| `TransformWorkingDirStorageClass` | PVC built with `o.localStorageClass` |
+| `TransformViceProxyArgs` | vice-proxy container built with the args + secret |
+| `TransformImageRefs` | image refs resolved through `o.imageRewriter` at build |
+| `EnsurePermissionsConfigMap` | permissions ConfigMap always built |
+
+The transform package and its tests do not disappear so much as **migrate into
+the builders** — the logic is the same, only its position in the pipeline moves
+from "after deserialize" to "during construct."
+
+### The label/IP dependency
+
+`jobInfo.JobLabels` decorates every resource with labels, one of which is the
+user's login IP from the jobs DB. The operator has no DB and must not get one.
+
+**Decision: app-exposer resolves it once and puts it in the spec
+(`VICESpec.UserLoginIP`).** app-exposer already calls this during the build, so
+this is a move, not new work. The operator applies the same label set it does
+today, sourcing the IP from the spec instead of a DB call. If a future label
+needs another DB-derived value, it follows the same path: resolve in
+app-exposer, carry in the spec.
+
+(Alternative considered: give the operator a narrow read endpoint to fetch user
+IP. Rejected — it reintroduces an app-exposer→operator runtime coupling and a
+new auth surface for one string. Threading the value is strictly simpler and
+keeps the operator dependency-free.)
+
+### Scheduler / operator-selection impact
+
+This is the subtlety most likely to bite. app-exposer's scheduler picks a target
+operator partly by GPU fit, and it does so today by **inspecting the built
+Deployment**:
+
+- `AnalysisBundle.RequestedGPUVendor()` reads container resource requests
+  (`operatorclient/types.go:105`)
+- `AnalysisBundle.RequestedGPUModels()` reads node-affinity match expressions
+  (`operatorclient/types.go:139`)
+
+With no Deployment in the bundle, these must read from `VICESpec.GPU` instead —
+which is strictly easier and more direct (the data is explicit rather than
+reverse-engineered from k8s objects). `CapacityResponse.GPUVendor` /
+`SupportedGPUModels` matching is unchanged; only the *requested* side moves from
+"parse the Deployment" to "read the spec field." Net simplification.
+
+### Validation
+
+`AnalysisBundle.Validate()` today walks each child object asserting the
+analysis-id label matches (so cleanup can find them). With construction
+operator-side, **the operator guarantees that invariant by construction** — it
+stamps the labels it builds. Validation shifts to spec-shape checks
+(required fields: AnalysisID, image, submitter, …) on receipt, plus the
+operator's existing capacity gate.
+
+### Code / package movement
+
+Both binaries ship from one Go module and one Docker image, so this is internal
+restructuring, not a cross-repo split:
+
+- The `incluster/` builders that are pure k8s construction —
+  `deployments.go`, `services.go`, `httproutes/`, `configmaps.go`,
+  `volumes.go`, `pdb.go` — plus their helpers (`resourcing`, `millicores`,
+  porklock/iRODS volume-mapping) move to (or are shared with) the operator. A
+  reasonable home is a new `vicebuild/` package importable by `operator/`. The
+  import audit confirms this is cycle-free: `operator/` does not import
+  `incluster/` (nor vice versa), and `common`/`constants`/`resourcing` are clean
+  leaf dependencies (field audit §9).
+- One decoupling is required: today every builder calls `jobInfo.JobLabels`,
+  which both assembles labels (pure) *and* calls the DB (`Apps.GetUserIP`). Split
+  it — app-exposer resolves `UserLoginIP` into the spec (as §1 requires), and
+  `vicebuild/` gets a pure `BuildLabels(spec)` (the assembly minus the DB call).
+  That removes the `httproutes → jobinfo → apps` edge so `vicebuild/` carries no
+  DB/apps dependency. The `resourcing` defaults/setters relocate to the
+  operator's `main` (field audit §4, §9).
+- app-exposer keeps the *resolution* half of `incluster/`: DB access (`jobinfo`/
+  `apps`), quota/permissions clients, the scheduler, and a new small
+  `BuildVICESpec` that maps `model.Job` → `VICESpec`.
+- `model.Job` (from `cyverse-de/model/v10`) is importable by both, but the
+  operator should depend on `VICESpec`, **not** `model.Job` — see Versioning.
+
+## Versioning and rollout
+
+The bundle stops being "k8s objects" (self-describing, schema-stable) and
+becomes an explicit app-exposer↔operator contract. That contract must version.
+
+- Add `SpecVersion` to `VICESpec`. The operator rejects versions it doesn't
+  understand with a clear error, and the scheduler can treat "operator too old
+  for this spec version" as "skip this operator," same as a capacity miss.
+- Because both binaries ship in the same image and are released together, the
+  common case is lockstep. `SpecVersion` exists for the window where a newer
+  app-exposer talks to an operator that hasn't rolled yet.
+
+**Recommended: define `VICESpec` as a dedicated, minimal type** rather than
+shipping a slice of `model.Job`. Reasons: a stable, reviewable contract; the
+operator does not get coupled to the full batch-oriented job model and its
+version cadence; and the spec documents exactly the VICE surface. The cost is
+an explicit `model.Job → VICESpec` mapping in app-exposer, which is
+straightforward and is the right place for that knowledge to live.
+
+(Intermediate option, if we want to de-risk in stages: first ship the relevant
+`model.Job` subset as the wire type to prove the operator-builds path end to
+end, then tighten to `VICESpec`. Noted as a possibility for the migration plan;
+not the recommended end state.)
+
+## Risks and open questions
+
+1. **Test surface moves with the code.** The builder tests
+   (`incluster/*_test.go`) move to the operator. The transform tests fold into
+   builder tests. This is mechanical but sizable; the migration plan must keep
+   coverage continuous, not "big-bang then re-test."
+
+2. **`VICESpec` completeness.** Addressed by the field-level audit
+   ([operator-side-bundle-construction-field-audit.md](operator-side-bundle-construction-field-audit.md)),
+   which maps every builder input to a spec field, operator config, or a
+   constant. All six follow-up items are now resolved (audit §8): ticketed inputs
+   carry no spec data (and `TicketInputPathListIdentifier` is dead config);
+   `InputSpec` needs no `Multiplicity`; the `resourcing` defaults move to the
+   operator; `VICESpec` models a single interactive container (VICE is single-step
+   by invariant); the operator owns all four contested namespace/secret values
+   (two already override app-exposer's today); and `vicebuild/` imports cleanly
+   into the operator once label assembly is split from the DB call (§9 of the
+   audit). No open schema questions remain.
+
+3. **Config duplication during transition.** Several `Init` fields must exist on
+   *both* sides until the cutover completes (app-exposer still builds for
+   not-yet-migrated operators). The migration plan needs a flag or per-operator
+   capability to choose "send objects" vs "send spec."
+
+4. **iRODS / CSI volume layout is genuinely cluster-specific** and already half
+   operator-side (`TransformWorkingDirStorageClass`, `localStorageClass`). The
+   PV/PVC builders read `IRODSZone` and `UseCSIDriver` from app-exposer today;
+   confirm the operator is the right owner of *all* of that (it almost certainly
+   is — storage topology is a cluster property) and that nothing in the iRODS
+   path needs DB lookups.
+
+5. **Observability of failures shifts.** A malformed analysis currently fails in
+   app-exposer where the operator/admin tooling and logs are richest. After the
+   move, build failures happen operator-side; the operator's error responses and
+   logs must carry enough context (probable cause) for triage from app-exposer's
+   launch path.
+
+## Summary
+
+This is a refactor along a seam the codebase already cut. vice-operator is
+already a cluster-aware k8s builder with no external dependencies and an existing
+transform layer whose entire reason for being is to fix up values app-exposer
+couldn't know. Moving construction into the operator collapses that transform
+layer into construction, removes app-exposer's knowledge of per-cluster
+Kubernetes specifics, and makes the fleet genuinely heterogeneous-cluster-ready.
+The only input that cannot move (the DB-derived user login IP) is threaded
+through the spec. The main work is mechanical (relocate builders, migrate config,
+map `model.Job → VICESpec`) and the main decisions are the spec schema and the
+contract versioning strategy.

--- a/plans/operator-side-bundle-construction.md
+++ b/plans/operator-side-bundle-construction.md
@@ -134,7 +134,12 @@ Replace `AnalysisBundle` with a spec describing the analysis. The shape below is
 the initial sketch; the **field-level audit**
 ([operator-side-bundle-construction-field-audit.md](operator-side-bundle-construction-field-audit.md))
 hardens it against every input the builders actually read and is the
-authoritative schema. Two things the audit settled that this sketch did not:
+authoritative schema, and the **contract doc**
+([operator-side-bundle-construction-contract.md](operator-side-bundle-construction-contract.md))
+records field ownership, versioning, and the scheduler rule. The types now exist
+in `operatorclient/vicespec.go`; `GPUSpec` carries an explicit canonical
+`Vendor` (defaulting to nvidia) so multi-vendor scheduling is real plumbing —
+see the contract doc's GPU section. Two things the audit settled that this sketch did not:
 the spec carries **resolved** values (computed app-exposer-side, where the
 `model.Job` methods live) rather than raw job internals — that is what keeps the
 operator free of a `model.Job` dependency — and **raw resource asks** ride on the

--- a/vicebuild/bundle.go
+++ b/vicebuild/bundle.go
@@ -1,0 +1,37 @@
+package vicebuild
+
+import (
+	"github.com/cyverse-de/app-exposer/operatorclient"
+	apiv1 "k8s.io/api/core/v1"
+)
+
+// BuildBundle assembles every Kubernetes object for a VICE analysis from the
+// spec and this cluster's Config. The result is the same AnalysisBundle shape
+// app-exposer used to build and ship — but with cluster-correct values baked in
+// at construction, so no post-hoc transform pass is required. This is the
+// operator-side construction entry point.
+//
+// The returned bundle reuses operatorclient.AnalysisBundle as the in-memory
+// container so the operator's existing applyBundle/egress/labeling code can
+// consume it unchanged; nothing here is serialized back over the wire.
+func (c *Config) BuildBundle(spec *operatorclient.VICESpec) (*operatorclient.AnalysisBundle, error) {
+	pvs, err := c.persistentVolumes(spec)
+	if err != nil {
+		return nil, err
+	}
+
+	return &operatorclient.AnalysisBundle{
+		AnalysisID: spec.AnalysisID,
+		Deployment: c.Deployment(spec),
+		Service:    c.Service(spec),
+		HTTPRoute:  c.HTTPRoute(spec),
+		ConfigMaps: []*apiv1.ConfigMap{
+			c.ExcludesConfigMap(spec),
+			c.PermissionsConfigMap(spec),
+			c.InputPathListConfigMap(spec),
+		},
+		PersistentVolumes:      pvs,
+		PersistentVolumeClaims: c.volumeClaims(spec),
+		PodDisruptionBudget:    c.PodDisruptionBudget(spec),
+	}, nil
+}

--- a/vicebuild/config.go
+++ b/vicebuild/config.go
@@ -1,0 +1,122 @@
+// Package vicebuild constructs the concrete Kubernetes objects for a VICE
+// analysis from a cluster-agnostic operatorclient.VICESpec plus a cluster
+// Config. It is the operator-side counterpart to app-exposer's incluster
+// builders: where incluster builds cluster-agnostic objects that the operator
+// then rewrites via its transform layer, vicebuild folds those transforms into
+// construction and emits cluster-correct objects directly.
+//
+// vicebuild carries no DB, apps, or model.Job dependency — every analysis value
+// arrives resolved in the VICESpec, and every cluster value arrives in Config.
+// That is what lets the operator import it.
+package vicebuild
+
+import (
+	"github.com/cyverse-de/app-exposer/common"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+var log = common.Log
+
+// Config holds the cluster-specific values the builders need — the operator's
+// equivalent of the old incluster.Init fields plus the values its transform
+// layer used to inject. The operator populates this once from its own
+// configuration; nothing here is analysis-specific.
+type Config struct {
+	// Container images.
+	PorklockImage  string
+	PorklockTag    string
+	ViceProxyImage string
+
+	// Storage and iRODS.
+	UseCSIDriver bool
+	IRODSZone    string
+	// LocalStorageClass is applied to the per-analysis working-dir PVC. Empty
+	// means "use the cluster default" (the old TransformWorkingDirStorageClass).
+	LocalStorageClass string
+
+	// Frontend URL and routing domain.
+	FrontendBaseURL string
+	// BaseDomain is the cluster's hostname domain (e.g. "cyverse.run",
+	// "localhost"); the HTTPRoute hostname is "<subdomain>.<BaseDomain>". This
+	// is what TransformHostnames used to rewrite in.
+	BaseDomain string
+
+	// Namespaces and gateway. Namespace is where the analysis resources live;
+	// GatewayNamespace/GatewayName identify the Gateway the HTTPRoute attaches
+	// to (the old TransformGatewayNamespace). GatewayProvider selects any
+	// provider-specific HTTPRoute decoration (e.g. "traefik").
+	Namespace        string
+	GatewayNamespace string
+	GatewayName      string
+	GatewayProvider  string
+
+	// Secrets.
+	ImagePullSecretName     string
+	ClusterConfigSecretName string
+
+	// UserSuffix is appended to the submitter username where Keycloak expects
+	// the fully-qualified form (permissions ConfigMap, CSI proxy user).
+	UserSuffix string
+
+	// InputPathListIdentifier is the first line of the porklock input-path-list
+	// file; it identifies the list format to the transfer tool.
+	InputPathListIdentifier string
+
+	// GPU mapping. GPUVendor is the cluster's vendor ("nvidia"/"amd"); the
+	// builders emit that vendor's resource name and affinity keys directly
+	// (the old TransformGPUVendor). GPUModelAffinityKey and GPUModelMapping
+	// translate canonical GFD model names onto the cluster's node-label scheme
+	// (the old TransformGPUModels); a zero key + empty mapping is the identity.
+	GPUVendor           string
+	GPUModelAffinityKey string
+	GPUModelMapping     map[string]string
+
+	// Loading-page service the HTTPRoute backend points at until the analysis
+	// is ready (the old TransformBackendToLoadingService).
+	LoadingServiceName string
+	LoadingServicePort int32
+
+	// ImageRewriter, when non-nil, rewrites container image refs to their
+	// mirrored counterparts (the old TransformImageRefs, manual-mirror mode).
+	// Nil is the identity.
+	ImageRewriter func(string) string
+
+	// Resources holds the default/clamp policy for analysis and vice-proxy
+	// resource requirements — "what this cluster grants." These were
+	// app-exposer's resourcing package-level defaults; per the design they are
+	// cluster policy and live operator-side.
+	Resources ResourceDefaults
+}
+
+// ResourceDefaults is the cluster's resource default/clamp policy. The analysis
+// asks ride raw in the VICESpec; these fill in unset asks and bound the result.
+// The Do*Limit toggles mirror the old resourcing flags: when false, that limit
+// is omitted entirely (no ceiling imposed).
+type ResourceDefaults struct {
+	DefaultCPURequest resource.Quantity
+	DefaultCPULimit   resource.Quantity
+	DefaultMemRequest resource.Quantity
+	DefaultMemLimit   resource.Quantity
+	DefaultStorage    resource.Quantity
+	DoCPULimit        bool
+	DoMemLimit        bool
+
+	ViceProxyCPURequest resource.Quantity
+	ViceProxyCPULimit   resource.Quantity
+	ViceProxyMemRequest resource.Quantity
+	ViceProxyMemLimit   resource.Quantity
+	ViceProxyStorage    resource.Quantity
+	ViceProxyStorageLim resource.Quantity
+	DoViceProxyCPULimit bool
+	DoViceProxyMemLimit bool
+	DoViceProxyStorage  bool
+}
+
+// rewriteImage applies the configured image rewriter, or returns ref unchanged
+// when no rewriter is configured.
+func (c *Config) rewriteImage(ref string) string {
+	if c.ImageRewriter == nil {
+		return ref
+	}
+	return c.ImageRewriter(ref)
+}

--- a/vicebuild/configmaps.go
+++ b/vicebuild/configmaps.go
@@ -1,0 +1,77 @@
+package vicebuild
+
+import (
+	"strings"
+
+	"github.com/cyverse-de/app-exposer/constants"
+	"github.com/cyverse-de/app-exposer/operatorclient"
+	apiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// ExcludesConfigMap builds the ConfigMap listing paths porklock must not upload
+// to iRODS. Always present.
+func (c *Config) ExcludesConfigMap(spec *operatorclient.VICESpec) *apiv1.ConfigMap {
+	return &apiv1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   excludesConfigMapName(spec),
+			Labels: BuildLabels(spec),
+		},
+		Data: map[string]string{
+			constants.ExcludesFileName: linesWithTrailingNewline(spec.ExcludeArguments),
+		},
+	}
+}
+
+// PermissionsConfigMap builds the owner-only allowed-users ConfigMap. The
+// suffix is appended to match the form stored in the Keycloak JWT
+// preferred_username; this folds in the operator's EnsurePermissionsConfigMap
+// fallback by always building the ConfigMap here.
+func (c *Config) PermissionsConfigMap(spec *operatorclient.VICESpec) *apiv1.ConfigMap {
+	owner := spec.Submitter
+	if !strings.HasSuffix(owner, c.UserSuffix) {
+		owner += c.UserSuffix
+	}
+	return &apiv1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   permissionsConfigMapName(spec),
+			Labels: BuildLabels(spec),
+		},
+		Data: map[string]string{
+			constants.PermissionsFileName: owner + "\n",
+		},
+	}
+}
+
+// InputPathListConfigMap builds the porklock input-path-list ConfigMap. The
+// first line is the cluster's list-format identifier; the remaining lines are
+// the resolved ticketless input paths. Built unconditionally (matching the
+// legacy bundle); it is only referenced by a volume when there are ticketless
+// inputs.
+func (c *Config) InputPathListConfigMap(spec *operatorclient.VICESpec) *apiv1.ConfigMap {
+	lines := append([]string{c.InputPathListIdentifier}, spec.InputPathListPaths...)
+	return &apiv1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   inputPathListConfigMapName(spec),
+			Labels: BuildLabels(spec),
+		},
+		Data: map[string]string{
+			constants.InputPathListFileName: linesWithTrailingNewline(lines),
+		},
+	}
+}
+
+// linesWithTrailingNewline joins lines with "\n" and appends a trailing newline,
+// matching the per-line fmt.Fprintf("%s\n", …) the incluster builders used.
+// An empty slice yields the empty string.
+func linesWithTrailingNewline(lines []string) string {
+	if len(lines) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	for _, l := range lines {
+		b.WriteString(l)
+		b.WriteByte('\n')
+	}
+	return b.String()
+}

--- a/vicebuild/deployments.go
+++ b/vicebuild/deployments.go
@@ -125,7 +125,7 @@ func (c *Config) analysisContainer(spec *operatorclient.VICESpec) apiv1.Containe
 			PeriodSeconds:       31,
 			ProbeHandler: apiv1.ProbeHandler{
 				HTTPGet: &apiv1.HTTPGetAction{
-					Port:   intstr.FromInt(spec.Container.Ports[0]),
+					Port:   intstr.FromInt32(int32(spec.Container.Ports[0])),
 					Scheme: apiv1.URISchemeHTTP,
 					Path:   "/",
 				},
@@ -183,7 +183,7 @@ func (c *Config) viceProxyContainer(spec *operatorclient.VICESpec) apiv1.Contain
 		ReadinessProbe: &apiv1.Probe{
 			ProbeHandler: apiv1.ProbeHandler{
 				HTTPGet: &apiv1.HTTPGetAction{
-					Port:   intstr.FromInt(int(constants.VICEProxyPort)),
+					Port:   intstr.FromInt32(constants.VICEProxyPort),
 					Scheme: apiv1.URISchemeHTTP,
 					Path:   "/url-ready",
 				},
@@ -224,7 +224,7 @@ func (c *Config) fileTransfersContainer(spec *operatorclient.VICESpec) apiv1.Con
 		ReadinessProbe: &apiv1.Probe{
 			ProbeHandler: apiv1.ProbeHandler{
 				HTTPGet: &apiv1.HTTPGetAction{
-					Port:   intstr.FromInt(int(constants.FileTransfersPort)),
+					Port:   intstr.FromInt32(constants.FileTransfersPort),
 					Scheme: apiv1.URISchemeHTTP,
 					Path:   "/",
 				},

--- a/vicebuild/deployments.go
+++ b/vicebuild/deployments.go
@@ -1,0 +1,394 @@
+package vicebuild
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/cyverse-de/app-exposer/common"
+	"github.com/cyverse-de/app-exposer/constants"
+	"github.com/cyverse-de/app-exposer/operatorclient"
+	appsv1 "k8s.io/api/apps/v1"
+	apiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+// amdModelAffinityKey is the AMD node-label key the old TransformGPUVendor
+// renamed the canonical GPU-model key to on AMD clusters.
+const amdModelAffinityKey = "amd.com/gpu.product"
+
+func analysisPorts(spec *operatorclient.VICESpec) []apiv1.ContainerPort {
+	ports := make([]apiv1.ContainerPort, 0, len(spec.Container.Ports))
+	for i, p := range spec.Container.Ports {
+		ports = append(ports, apiv1.ContainerPort{
+			ContainerPort: int32(p),
+			Name:          fmt.Sprintf("tcp-a-%d", i),
+			Protocol:      apiv1.ProtocolTCP,
+		})
+	}
+	return ports
+}
+
+func uidPtr(spec *operatorclient.VICESpec) *int64 {
+	return constants.Int64Ptr(int64(spec.Container.UID))
+}
+
+// inputStagingContainer is the porklock init container that stages inputs on
+// non-CSI clusters.
+func (c *Config) inputStagingContainer(spec *operatorclient.VICESpec) apiv1.Container {
+	return apiv1.Container{
+		Name:            constants.FileTransfersInitContainerName,
+		Image:           c.rewriteImage(fmt.Sprintf("%s:%s", c.PorklockImage, c.PorklockTag)),
+		Command:         append(fileTransferCommand(spec), "--no-service"),
+		ImagePullPolicy: apiv1.PullAlways,
+		WorkingDir:      constants.InputPathListMountPath,
+		VolumeMounts:    c.fileTransfersVolumeMounts(spec),
+		Ports: []apiv1.ContainerPort{
+			{Name: constants.FileTransfersPortName, ContainerPort: constants.FileTransfersPort, Protocol: apiv1.ProtocolTCP},
+		},
+		SecurityContext: &apiv1.SecurityContext{
+			RunAsUser:  uidPtr(spec),
+			RunAsGroup: uidPtr(spec),
+			Capabilities: &apiv1.Capabilities{
+				Drop: []apiv1.Capability{"SETPCAP", "AUDIT_WRITE", "KILL", "SETGID", "SETUID", "NET_BIND_SERVICE", "SYS_CHROOT", "SETFCAP", "FSETID", "MKNOD"},
+				Add:  []apiv1.Capability{"NET_ADMIN", "NET_RAW"},
+			},
+		},
+	}
+}
+
+// workingDirPrepContainer initializes the working-dir volume on CSI clusters,
+// reusing the porklock image for its shell.
+func (c *Config) workingDirPrepContainer(spec *operatorclient.VICESpec) apiv1.Container {
+	return apiv1.Container{
+		Name:            constants.WorkingDirInitContainerName,
+		Image:           c.rewriteImage(fmt.Sprintf("%s:%s", c.PorklockImage, c.PorklockTag)),
+		Command:         []string{"init_working_dir.sh", constants.CSIDriverLocalMountPath, c.zoneMountPath()},
+		ImagePullPolicy: apiv1.PullAlways,
+		WorkingDir:      constants.WorkingDirInitContainerMountPath,
+		VolumeMounts: []apiv1.VolumeMount{
+			{Name: workingDirVolumeName(spec), MountPath: constants.WorkingDirInitContainerMountPath, ReadOnly: false},
+		},
+		SecurityContext: &apiv1.SecurityContext{
+			RunAsUser:  uidPtr(spec),
+			RunAsGroup: uidPtr(spec),
+			Capabilities: &apiv1.Capabilities{
+				Drop: []apiv1.Capability{"SETPCAP", "AUDIT_WRITE", "KILL", "SETGID", "SETUID", "NET_BIND_SERVICE", "SYS_CHROOT", "SETFCAP", "FSETID", "NET_RAW", "MKNOD"},
+			},
+		},
+	}
+}
+
+func (c *Config) initContainers(spec *operatorclient.VICESpec) []apiv1.Container {
+	if c.UseCSIDriver {
+		return []apiv1.Container{c.workingDirPrepContainer(spec)}
+	}
+	return []apiv1.Container{c.inputStagingContainer(spec)}
+}
+
+// analysisContainer builds the interactive analysis container.
+func (c *Config) analysisContainer(spec *operatorclient.VICESpec) apiv1.Container {
+	env := make([]apiv1.EnvVar, 0, len(spec.Environment)+3)
+	for k, v := range spec.Environment {
+		env = append(env, apiv1.EnvVar{Name: k, Value: v})
+	}
+
+	// Build the per-analysis frontend URL: <subdomain>.<FrontendBaseURL host>.
+	frontURL, err := url.Parse(c.FrontendBaseURL)
+	if err != nil {
+		log.Warnf("failed to parse FrontendBaseURL %q: %v", c.FrontendBaseURL, err)
+		frontURL = &url.URL{}
+	}
+	frontURL.Host = fmt.Sprintf("%s.%s", common.Subdomain(spec.UserID, string(spec.ExternalID)), frontURL.Host)
+
+	env = append(env,
+		apiv1.EnvVar{Name: "REDIRECT_URL", Value: frontURL.String()},
+		apiv1.EnvVar{Name: "IPLANT_USER", Value: spec.Submitter},
+		apiv1.EnvVar{Name: "IPLANT_EXECUTION_ID", Value: string(spec.ExternalID)},
+	)
+
+	resources := c.analysisRequirements(spec)
+	container := apiv1.Container{
+		Name:            constants.AnalysisContainerName,
+		Image:           c.rewriteImage(fmt.Sprintf("%s:%s", spec.Container.Image, spec.Container.Tag)),
+		ImagePullPolicy: apiv1.PullAlways,
+		Env:             env,
+		Resources:       resources,
+		VolumeMounts:    c.podVolumeMounts(spec),
+		Ports:           analysisPorts(spec),
+		SecurityContext: &apiv1.SecurityContext{RunAsUser: uidPtr(spec), RunAsGroup: uidPtr(spec)},
+		ReadinessProbe: &apiv1.Probe{
+			InitialDelaySeconds: 0,
+			TimeoutSeconds:      30,
+			SuccessThreshold:    1,
+			FailureThreshold:    10,
+			PeriodSeconds:       31,
+			ProbeHandler: apiv1.ProbeHandler{
+				HTTPGet: &apiv1.HTTPGetAction{
+					Port:   intstr.FromInt(spec.Container.Ports[0]),
+					Scheme: apiv1.URISchemeHTTP,
+					Path:   "/",
+				},
+			},
+		},
+	}
+	if spec.Container.EntryPoint != "" {
+		container.Command = []string{spec.Container.EntryPoint}
+	}
+	if spec.Container.WorkingDir != "" {
+		container.WorkingDir = spec.Container.WorkingDir
+	}
+	if len(spec.Container.Arguments) != 0 {
+		container.Args = append(container.Args, spec.Container.Arguments...)
+	}
+	return container
+}
+
+// viceProxyContainer builds the vice-proxy sidecar with per-analysis args, the
+// cluster-config-secret envFrom, and the permissions mount — folding in the old
+// TransformViceProxyArgs.
+func (c *Config) viceProxyContainer(spec *operatorclient.VICESpec) apiv1.Container {
+	backendURL := "http://localhost:60000"
+	if len(spec.Container.Ports) > 0 {
+		backendURL = fmt.Sprintf("http://localhost:%d", spec.Container.Ports[0])
+	} else {
+		log.Warnf("analysis %s has no ports; vice-proxy backend defaulting to %s", spec.AnalysisID, backendURL)
+	}
+
+	container := apiv1.Container{
+		Name:    constants.VICEProxyContainerName,
+		Image:   c.rewriteImage(c.ViceProxyImage),
+		Command: []string{"vice-proxy"},
+		Args: []string{
+			"--analysis-id", string(spec.AnalysisID),
+			"--backend-url", backendURL,
+			"--ws-backend-url", backendURL,
+			"--listen-addr", fmt.Sprintf("0.0.0.0:%d", constants.VICEProxyPort),
+		},
+		ImagePullPolicy: apiv1.PullAlways,
+		Ports: []apiv1.ContainerPort{
+			{Name: constants.VICEProxyPortName, ContainerPort: constants.VICEProxyPort, Protocol: apiv1.ProtocolTCP},
+		},
+		VolumeMounts: []apiv1.VolumeMount{
+			{Name: constants.PermissionsVolumeName, MountPath: constants.PermissionsMountPath, ReadOnly: true},
+		},
+		SecurityContext: &apiv1.SecurityContext{
+			RunAsUser:  uidPtr(spec),
+			RunAsGroup: uidPtr(spec),
+			Capabilities: &apiv1.Capabilities{
+				Drop: []apiv1.Capability{"SETPCAP", "AUDIT_WRITE", "KILL", "SETGID", "SETUID", "SYS_CHROOT", "SETFCAP", "FSETID", "NET_RAW", "MKNOD"},
+			},
+		},
+		Resources: c.viceProxyRequirements(),
+		ReadinessProbe: &apiv1.Probe{
+			ProbeHandler: apiv1.ProbeHandler{
+				HTTPGet: &apiv1.HTTPGetAction{
+					Port:   intstr.FromInt(int(constants.VICEProxyPort)),
+					Scheme: apiv1.URISchemeHTTP,
+					Path:   "/url-ready",
+				},
+			},
+		},
+	}
+
+	if c.ClusterConfigSecretName != "" {
+		optional := true
+		container.EnvFrom = []apiv1.EnvFromSource{
+			{SecretRef: &apiv1.SecretEnvSource{
+				LocalObjectReference: apiv1.LocalObjectReference{Name: c.ClusterConfigSecretName},
+				Optional:             &optional,
+			}},
+		}
+	}
+	return container
+}
+
+func (c *Config) fileTransfersContainer(spec *operatorclient.VICESpec) apiv1.Container {
+	return apiv1.Container{
+		Name:            constants.FileTransfersContainerName,
+		Image:           c.rewriteImage(fmt.Sprintf("%s:%s", c.PorklockImage, c.PorklockTag)),
+		Command:         fileTransferCommand(spec),
+		ImagePullPolicy: apiv1.PullAlways,
+		WorkingDir:      constants.InputPathListMountPath,
+		VolumeMounts:    c.fileTransfersVolumeMounts(spec),
+		Ports: []apiv1.ContainerPort{
+			{Name: constants.FileTransfersPortName, ContainerPort: constants.FileTransfersPort, Protocol: apiv1.ProtocolTCP},
+		},
+		SecurityContext: &apiv1.SecurityContext{
+			RunAsUser:  uidPtr(spec),
+			RunAsGroup: uidPtr(spec),
+			Capabilities: &apiv1.Capabilities{
+				Drop: []apiv1.Capability{"SETPCAP", "AUDIT_WRITE", "KILL", "SETGID", "SETUID", "NET_BIND_SERVICE", "SYS_CHROOT", "SETFCAP", "FSETID", "NET_RAW", "MKNOD"},
+			},
+		},
+		ReadinessProbe: &apiv1.Probe{
+			ProbeHandler: apiv1.ProbeHandler{
+				HTTPGet: &apiv1.HTTPGetAction{
+					Port:   intstr.FromInt(int(constants.FileTransfersPort)),
+					Scheme: apiv1.URISchemeHTTP,
+					Path:   "/",
+				},
+			},
+		},
+	}
+}
+
+// containers returns the pod's containers: vice-proxy, the file-transfers
+// sidecar (non-CSI only), then the analysis container.
+func (c *Config) containers(spec *operatorclient.VICESpec) []apiv1.Container {
+	out := []apiv1.Container{c.viceProxyContainer(spec)}
+	if !c.UseCSIDriver {
+		out = append(out, c.fileTransfersContainer(spec))
+	}
+	out = append(out, c.analysisContainer(spec))
+	return out
+}
+
+func (c *Config) imagePullSecrets() []apiv1.LocalObjectReference {
+	if c.ImagePullSecretName != "" {
+		return []apiv1.LocalObjectReference{{Name: c.ImagePullSecretName}}
+	}
+	return []apiv1.LocalObjectReference{}
+}
+
+// gpuModelAffinityKey returns the node-label key for GPU-model affinity on this
+// cluster, folding in TransformGPUModels (key override) and TransformGPUVendor
+// (AMD rename). The canonical key is used unless the cluster overrides it; an
+// AMD cluster that hasn't overridden the key gets the AMD rename.
+func (c *Config) gpuModelAffinityKey() string {
+	if c.GPUModelAffinityKey != "" && c.GPUModelAffinityKey != constants.GPUModelAffinityKey {
+		return c.GPUModelAffinityKey
+	}
+	if c.GPUVendor == operatorclient.GPUVendorAMD {
+		return amdModelAffinityKey
+	}
+	return constants.GPUModelAffinityKey
+}
+
+// gpuModelValues maps canonical GPU model names onto this cluster's node-label
+// values, folding in TransformGPUModels. An empty mapping is the identity;
+// values absent from a non-empty mapping are dropped.
+func (c *Config) gpuModelValues(models []string) []string {
+	if len(c.GPUModelMapping) == 0 {
+		return models
+	}
+	out := make([]string, 0, len(models))
+	for _, m := range models {
+		if mapped, ok := c.GPUModelMapping[m]; ok {
+			out = append(out, mapped)
+		}
+	}
+	return out
+}
+
+// nodeSelectorRequirements builds the required node-affinity terms: the base
+// analysis selector, plus GPU device and GPU-model selectors when a GPU is
+// requested.
+func (c *Config) nodeSelectorRequirements(spec *operatorclient.VICESpec) []apiv1.NodeSelectorRequirement {
+	reqs := []apiv1.NodeSelectorRequirement{
+		{Key: constants.AnalysisAffinityKey, Operator: apiv1.NodeSelectorOperator(constants.AnalysisAffinityOperator)},
+	}
+	if spec.GPU == nil {
+		return reqs
+	}
+	reqs = append(reqs, apiv1.NodeSelectorRequirement{
+		Key:      constants.GPUAffinityKey,
+		Operator: apiv1.NodeSelectorOperator(constants.GPUAffinityOperator),
+		Values:   []string{constants.GPUAffinityValue},
+	})
+	if values := c.gpuModelValues(spec.GPU.Models); len(values) > 0 {
+		reqs = append(reqs, apiv1.NodeSelectorRequirement{
+			Key:      c.gpuModelAffinityKey(),
+			Operator: apiv1.NodeSelectorOperator(constants.GPUModelAffinityOperator),
+			Values:   values,
+		})
+	}
+	return reqs
+}
+
+func (c *Config) tolerations(spec *operatorclient.VICESpec) []apiv1.Toleration {
+	tolerations := []apiv1.Toleration{
+		{Key: "analysis", Operator: apiv1.TolerationOpExists},
+	}
+	if spec.GPU != nil {
+		tolerations = append(tolerations, apiv1.Toleration{
+			Key:      constants.GPUTolerationKey,
+			Operator: apiv1.TolerationOperator(constants.GPUTolerationOperator),
+			Value:    constants.GPUTolerationValue,
+			Effect:   apiv1.TaintEffect(constants.GPUTolerationEffect),
+		})
+	}
+	return tolerations
+}
+
+// Deployment builds the analysis Deployment with all cluster-specific values
+// (GPU vendor/model, images, resources) baked in.
+func (c *Config) Deployment(spec *operatorclient.VICESpec) *appsv1.Deployment {
+	labels := BuildLabels(spec)
+	autoMount := false
+
+	preferredSchedTerms := []apiv1.PreferredSchedulingTerm{
+		{
+			Weight: 1,
+			Preference: apiv1.NodeSelectorTerm{
+				MatchExpressions: []apiv1.NodeSelectorRequirement{
+					{Key: "vice", Operator: apiv1.NodeSelectorOpExists},
+				},
+			},
+		},
+	}
+
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   deploymentName(spec),
+			Labels: labels,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: constants.Int32Ptr(1),
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{constants.ExternalIDLabel: string(spec.ExternalID)},
+			},
+			Template: apiv1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: labels},
+				Spec: apiv1.PodSpec{
+					Hostname:                     common.Subdomain(spec.UserID, string(spec.ExternalID)),
+					RestartPolicy:                apiv1.RestartPolicyAlways,
+					Volumes:                      c.podVolumes(spec),
+					InitContainers:               c.initContainers(spec),
+					Containers:                   c.containers(spec),
+					ImagePullSecrets:             c.imagePullSecrets(),
+					AutomountServiceAccountToken: &autoMount,
+					SecurityContext: &apiv1.PodSecurityContext{
+						RunAsUser:  uidPtr(spec),
+						RunAsGroup: uidPtr(spec),
+						FSGroup:    uidPtr(spec),
+					},
+					Tolerations: c.tolerations(spec),
+					Affinity: &apiv1.Affinity{
+						PodAntiAffinity: &apiv1.PodAntiAffinity{
+							PreferredDuringSchedulingIgnoredDuringExecution: []apiv1.WeightedPodAffinityTerm{
+								{
+									Weight: 100,
+									PodAffinityTerm: apiv1.PodAffinityTerm{
+										LabelSelector: &metav1.LabelSelector{
+											MatchLabels: map[string]string{constants.AppTypeLabel: string(constants.Interactive)},
+										},
+										TopologyKey: "kubernetes.io/hostname",
+									},
+								},
+							},
+						},
+						NodeAffinity: &apiv1.NodeAffinity{
+							RequiredDuringSchedulingIgnoredDuringExecution: &apiv1.NodeSelector{
+								NodeSelectorTerms: []apiv1.NodeSelectorTerm{
+									{MatchExpressions: c.nodeSelectorRequirements(spec)},
+								},
+							},
+							PreferredDuringSchedulingIgnoredDuringExecution: preferredSchedTerms,
+						},
+					},
+				},
+			},
+		},
+	}
+}

--- a/vicebuild/deployments.go
+++ b/vicebuild/deployments.go
@@ -251,11 +251,13 @@ func (c *Config) imagePullSecrets() []apiv1.LocalObjectReference {
 	return []apiv1.LocalObjectReference{}
 }
 
-// gpuModelAffinityKey returns the node-label key for GPU-model affinity on this
-// cluster, folding in TransformGPUModels (key override) and TransformGPUVendor
-// (AMD rename). The canonical key is used unless the cluster overrides it; an
-// AMD cluster that hasn't overridden the key gets the AMD rename.
-func (c *Config) gpuModelAffinityKey() string {
+// resolvedGPUModelAffinityKey returns the node-label key for GPU-model affinity
+// on this cluster, folding in TransformGPUModels (key override) and
+// TransformGPUVendor (AMD rename). The canonical key is used unless the cluster
+// overrides it via Config.GPUModelAffinityKey; an AMD cluster that hasn't
+// overridden the key gets the AMD rename. Distinct from the raw
+// Config.GPUModelAffinityKey field, which may be empty.
+func (c *Config) resolvedGPUModelAffinityKey() string {
 	if c.GPUModelAffinityKey != "" && c.GPUModelAffinityKey != constants.GPUModelAffinityKey {
 		return c.GPUModelAffinityKey
 	}
@@ -298,7 +300,7 @@ func (c *Config) nodeSelectorRequirements(spec *operatorclient.VICESpec) []apiv1
 	})
 	if values := c.gpuModelValues(spec.GPU.Models); len(values) > 0 {
 		reqs = append(reqs, apiv1.NodeSelectorRequirement{
-			Key:      c.gpuModelAffinityKey(),
+			Key:      c.resolvedGPUModelAffinityKey(),
 			Operator: apiv1.NodeSelectorOperator(constants.GPUModelAffinityOperator),
 			Values:   values,
 		})

--- a/vicebuild/deployments_test.go
+++ b/vicebuild/deployments_test.go
@@ -1,6 +1,7 @@
 package vicebuild
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/cyverse-de/app-exposer/constants"
@@ -204,12 +205,8 @@ func TestImageRefsFolded(t *testing.T) {
 
 	dep := cfg.Deployment(spec)
 	for _, c := range append(dep.Spec.Template.Spec.InitContainers, dep.Spec.Template.Spec.Containers...) {
-		assert.Truef(t, hasPrefix(c.Image, "mirror.example.com/"), "image %q for container %q not rewritten", c.Image, c.Name)
+		assert.Truef(t, strings.HasPrefix(c.Image, "mirror.example.com/"), "image %q for container %q not rewritten", c.Image, c.Name)
 	}
-}
-
-func hasPrefix(s, prefix string) bool {
-	return len(s) >= len(prefix) && s[:len(prefix)] == prefix
 }
 
 // TestDeploymentCSIvsNonCSI confirms the init container and sidecar set switches

--- a/vicebuild/deployments_test.go
+++ b/vicebuild/deployments_test.go
@@ -1,0 +1,237 @@
+package vicebuild
+
+import (
+	"testing"
+
+	"github.com/cyverse-de/app-exposer/constants"
+	"github.com/cyverse-de/app-exposer/operatorclient"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apiv1 "k8s.io/api/core/v1"
+)
+
+// findContainer returns the named container from a slice, failing the test if
+// it is absent.
+func findContainer(t *testing.T, containers []apiv1.Container, name string) apiv1.Container {
+	t.Helper()
+	for _, c := range containers {
+		if c.Name == name {
+			return c
+		}
+	}
+	t.Fatalf("container %q not found", name)
+	return apiv1.Container{}
+}
+
+func gpuSpec(vendor string, count int64, models ...string) *operatorclient.GPUSpec {
+	return &operatorclient.GPUSpec{Vendor: vendor, Count: count, Models: models}
+}
+
+// TestDeploymentGPUVendorFolded confirms TransformGPUVendor is folded into
+// construction: the analysis container carries the cluster vendor's GPU
+// resource name with requests == limits, and no foreign vendor name leaks in.
+func TestDeploymentGPUVendorFolded(t *testing.T) {
+	tests := []struct {
+		name      string
+		vendor    string
+		wantName  apiv1.ResourceName
+		otherName apiv1.ResourceName
+	}{
+		{name: "nvidia", vendor: operatorclient.GPUVendorNvidia, wantName: "nvidia.com/gpu", otherName: "amd.com/gpu"},
+		{name: "amd", vendor: operatorclient.GPUVendorAMD, wantName: "amd.com/gpu", otherName: "nvidia.com/gpu"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := testConfig()
+			cfg.GPUVendor = tt.vendor
+			spec := testSpec()
+			spec.GPU = gpuSpec(tt.vendor, 2)
+
+			dep := cfg.Deployment(spec)
+			analysis := findContainer(t, dep.Spec.Template.Spec.Containers, constants.AnalysisContainerName)
+
+			req := analysis.Resources.Requests[tt.wantName]
+			lim := analysis.Resources.Limits[tt.wantName]
+			assert.Equal(t, int64(2), req.Value(), "GPU request count")
+			assert.True(t, req.Equal(lim), "GPU requests must equal limits for extended resources")
+
+			_, hasReq := analysis.Resources.Requests[tt.otherName]
+			_, hasLim := analysis.Resources.Limits[tt.otherName]
+			assert.False(t, hasReq || hasLim, "foreign GPU vendor name %q must not appear", tt.otherName)
+		})
+	}
+}
+
+// TestDeploymentGPUModelAffinityFolded confirms TransformGPUModels is folded in:
+// the model-affinity key and values reflect the cluster's node-label scheme.
+func TestDeploymentGPUModelAffinityFolded(t *testing.T) {
+	tests := []struct {
+		name       string
+		vendor     string
+		key        string
+		mapping    map[string]string
+		models     []string
+		wantKey    string
+		wantValues []string
+		wantNoTerm bool
+	}{
+		{
+			name:       "nvidia default key identity",
+			vendor:     operatorclient.GPUVendorNvidia,
+			models:     []string{"NVIDIA-A10G"},
+			wantKey:    constants.GPUModelAffinityKey,
+			wantValues: []string{"NVIDIA-A10G"},
+		},
+		{
+			name:       "eks key + value mapping",
+			vendor:     operatorclient.GPUVendorNvidia,
+			key:        "eks.amazonaws.com/instance-gpu-name",
+			mapping:    map[string]string{"NVIDIA-A10G": "a10g"},
+			models:     []string{"NVIDIA-A10G"},
+			wantKey:    "eks.amazonaws.com/instance-gpu-name",
+			wantValues: []string{"a10g"},
+		},
+		{
+			name:    "amd renames canonical key",
+			vendor:  operatorclient.GPUVendorAMD,
+			models:  []string{"some-amd-model"},
+			wantKey: amdModelAffinityKey,
+			// no mapping → identity passthrough of values
+			wantValues: []string{"some-amd-model"},
+		},
+		{
+			name:       "unmapped values drop the model term",
+			vendor:     operatorclient.GPUVendorNvidia,
+			key:        "eks.amazonaws.com/instance-gpu-name",
+			mapping:    map[string]string{"NVIDIA-L4": "l4"},
+			models:     []string{"NVIDIA-A10G"},
+			wantNoTerm: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := testConfig()
+			cfg.GPUVendor = tt.vendor
+			cfg.GPUModelAffinityKey = tt.key
+			cfg.GPUModelMapping = tt.mapping
+			spec := testSpec()
+			spec.GPU = gpuSpec(tt.vendor, 1, tt.models...)
+
+			dep := cfg.Deployment(spec)
+			terms := dep.Spec.Template.Spec.Affinity.NodeAffinity.
+				RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchExpressions
+
+			var modelExpr *apiv1.NodeSelectorRequirement
+			for i := range terms {
+				if terms[i].Key == tt.wantKey {
+					modelExpr = &terms[i]
+				}
+				// the canonical "gpu=true" device selector must always be present
+			}
+			assert.Contains(t, keysOf(terms), constants.GPUAffinityKey, "base gpu selector present")
+
+			if tt.wantNoTerm {
+				for _, term := range terms {
+					assert.NotEqual(t, tt.key, term.Key, "model term should be dropped when all values unmapped")
+				}
+				return
+			}
+			require.NotNil(t, modelExpr, "expected model affinity term with key %q", tt.wantKey)
+			assert.Equal(t, tt.wantValues, modelExpr.Values)
+		})
+	}
+}
+
+func keysOf(reqs []apiv1.NodeSelectorRequirement) []string {
+	out := make([]string, 0, len(reqs))
+	for _, r := range reqs {
+		out = append(out, r.Key)
+	}
+	return out
+}
+
+// TestDeploymentNoGPU confirms a non-GPU analysis gets no GPU resources,
+// tolerations, or affinity terms.
+func TestDeploymentNoGPU(t *testing.T) {
+	dep := testConfig().Deployment(testSpec())
+	analysis := findContainer(t, dep.Spec.Template.Spec.Containers, constants.AnalysisContainerName)
+	for name := range analysis.Resources.Requests {
+		assert.NotContains(t, string(name), "gpu")
+	}
+	assert.NotContains(t, keysOf(dep.Spec.Template.Spec.Affinity.NodeAffinity.
+		RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchExpressions),
+		constants.GPUAffinityKey)
+}
+
+// TestViceProxyArgsFolded confirms TransformViceProxyArgs is folded in: the
+// vice-proxy container carries per-analysis args, the cluster-config envFrom,
+// and the permissions mount, all at construction time.
+func TestViceProxyArgsFolded(t *testing.T) {
+	cfg := testConfig()
+	cfg.ClusterConfigSecretName = "cluster-config"
+	spec := testSpec()
+	spec.Container.Ports = []int{8888}
+
+	dep := cfg.Deployment(spec)
+	proxy := findContainer(t, dep.Spec.Template.Spec.Containers, constants.VICEProxyContainerName)
+
+	assert.Equal(t, []string{"vice-proxy"}, proxy.Command)
+	assert.Contains(t, proxy.Args, "--analysis-id")
+	assert.Contains(t, proxy.Args, string(spec.AnalysisID))
+	assert.Contains(t, proxy.Args, "http://localhost:8888")
+
+	require.Len(t, proxy.EnvFrom, 1)
+	assert.Equal(t, "cluster-config", proxy.EnvFrom[0].SecretRef.Name)
+
+	var hasPermsMount bool
+	for _, vm := range proxy.VolumeMounts {
+		if vm.Name == constants.PermissionsVolumeName {
+			hasPermsMount = true
+		}
+	}
+	assert.True(t, hasPermsMount, "permissions volume mount present")
+}
+
+// TestImageRefsFolded confirms TransformImageRefs is folded in: a configured
+// rewriter is applied to every container image.
+func TestImageRefsFolded(t *testing.T) {
+	cfg := testConfig()
+	cfg.PorklockImage = "porklock"
+	cfg.PorklockTag = "latest"
+	cfg.ViceProxyImage = "vice-proxy:latest"
+	cfg.ImageRewriter = func(ref string) string { return "mirror.example.com/" + ref }
+	spec := testSpec()
+
+	dep := cfg.Deployment(spec)
+	for _, c := range append(dep.Spec.Template.Spec.InitContainers, dep.Spec.Template.Spec.Containers...) {
+		assert.Truef(t, hasPrefix(c.Image, "mirror.example.com/"), "image %q for container %q not rewritten", c.Image, c.Name)
+	}
+}
+
+func hasPrefix(s, prefix string) bool {
+	return len(s) >= len(prefix) && s[:len(prefix)] == prefix
+}
+
+// TestDeploymentCSIvsNonCSI confirms the init container and sidecar set switches
+// on the cluster's CSI capability.
+func TestDeploymentCSIvsNonCSI(t *testing.T) {
+	t.Run("CSI enabled", func(t *testing.T) {
+		cfg := testConfig()
+		cfg.UseCSIDriver = true
+		dep := cfg.Deployment(testSpec())
+		require.Len(t, dep.Spec.Template.Spec.InitContainers, 1)
+		assert.Equal(t, constants.WorkingDirInitContainerName, dep.Spec.Template.Spec.InitContainers[0].Name)
+		// No file-transfers sidecar under CSI.
+		for _, c := range dep.Spec.Template.Spec.Containers {
+			assert.NotEqual(t, constants.FileTransfersContainerName, c.Name)
+		}
+	})
+	t.Run("CSI disabled", func(t *testing.T) {
+		cfg := testConfig()
+		cfg.UseCSIDriver = false
+		dep := cfg.Deployment(testSpec())
+		require.Len(t, dep.Spec.Template.Spec.InitContainers, 1)
+		assert.Equal(t, constants.FileTransfersInitContainerName, dep.Spec.Template.Spec.InitContainers[0].Name)
+		findContainer(t, dep.Spec.Template.Spec.Containers, constants.FileTransfersContainerName)
+	})
+}

--- a/vicebuild/httproutes.go
+++ b/vicebuild/httproutes.go
@@ -1,0 +1,96 @@
+package vicebuild
+
+import (
+	"fmt"
+
+	"github.com/cyverse-de/app-exposer/common"
+	"github.com/cyverse-de/app-exposer/operatorclient"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+// Gateway defaults and the traefik CORS middleware reference, matching the
+// incluster httproutes builders.
+const (
+	defaultGatewayName = gatewayv1.ObjectName("vice")
+
+	traefikProvider     = "traefik"
+	corsMiddlewareGroup = gatewayv1.Group("traefik.io")
+	corsMiddlewareKind  = gatewayv1.Kind("Middleware")
+	corsMiddlewareName  = gatewayv1.ObjectName("vice-cors-headers")
+)
+
+// HTTPRoute builds the analysis's Gateway API HTTPRoute with cluster-correct
+// values baked in: the hostname uses the cluster BaseDomain (old
+// TransformHostnames), the parentRef points at the cluster gateway (old
+// TransformGatewayNamespace), and the backend points at the loading-page
+// service (old TransformBackendToLoadingService). Provider-specific decoration
+// (e.g. traefik CORS) is applied last.
+func (c *Config) HTTPRoute(spec *operatorclient.VICESpec) *gatewayv1.HTTPRoute {
+	subdomain := common.Subdomain(spec.UserID, string(spec.ExternalID))
+	hostname := gatewayv1.Hostname(fmt.Sprintf("%s.%s", subdomain, c.BaseDomain))
+
+	gatewayNamespace := c.GatewayNamespace
+	if gatewayNamespace == "" {
+		gatewayNamespace = c.Namespace
+	}
+	gwNamespace := gatewayv1.Namespace(gatewayNamespace)
+
+	gatewayName := defaultGatewayName
+	if c.GatewayName != "" {
+		gatewayName = gatewayv1.ObjectName(c.GatewayName)
+	}
+
+	backendName := gatewayv1.ObjectName(c.LoadingServiceName)
+	backendPort := gatewayv1.PortNumber(c.LoadingServicePort)
+
+	route := &gatewayv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      routeName(spec),
+			Namespace: c.Namespace,
+			Labels:    BuildLabels(spec),
+		},
+		Spec: gatewayv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayv1.CommonRouteSpec{
+				ParentRefs: []gatewayv1.ParentReference{
+					{Namespace: &gwNamespace, Name: gatewayName},
+				},
+			},
+			Hostnames: []gatewayv1.Hostname{hostname},
+			Rules: []gatewayv1.HTTPRouteRule{
+				{
+					BackendRefs: []gatewayv1.HTTPBackendRef{
+						{
+							BackendRef: gatewayv1.BackendRef{
+								BackendObjectReference: gatewayv1.BackendObjectReference{
+									Name: backendName,
+									Port: &backendPort,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	if c.GatewayProvider == traefikProvider {
+		addTraefikCORS(route)
+	}
+	return route
+}
+
+// addTraefikCORS attaches the CORS-headers middleware extension filter to every
+// rule, matching the traefik HTTPRoute builder.
+func addTraefikCORS(route *gatewayv1.HTTPRoute) {
+	for i := range route.Spec.Rules {
+		route.Spec.Rules[i].Filters = append(route.Spec.Rules[i].Filters, gatewayv1.HTTPRouteFilter{
+			Type: gatewayv1.HTTPRouteFilterExtensionRef,
+			ExtensionRef: &gatewayv1.LocalObjectReference{
+				Group: corsMiddlewareGroup,
+				Kind:  corsMiddlewareKind,
+				Name:  corsMiddlewareName,
+			},
+		})
+	}
+}

--- a/vicebuild/labels.go
+++ b/vicebuild/labels.go
@@ -1,0 +1,41 @@
+package vicebuild
+
+import (
+	"github.com/cyverse-de/app-exposer/common"
+	"github.com/cyverse-de/app-exposer/constants"
+	"github.com/cyverse-de/app-exposer/operatorclient"
+)
+
+// BuildLabels assembles the fixed label set stamped on every resource for an
+// analysis. It is the pure half of the old incluster jobinfo.JobLabels: the
+// label assembly stays here, while the one DB-derived value (the user's login
+// IP) is resolved app-exposer-side and arrives as spec.UserLoginIP. Splitting
+// it this way is what removes vicebuild's dependency on the apps/DB layer.
+//
+// The analysis-id label is the cleanup key, so every builder labels its objects
+// with this set; the operator thereby guarantees the cleanup invariant by
+// construction rather than validating it after the fact.
+func BuildLabels(spec *operatorclient.VICESpec) map[string]string {
+	return map[string]string{
+		constants.ExternalIDLabel:   string(spec.ExternalID),
+		constants.AnalysisIDLabel:   string(spec.AnalysisID),
+		constants.AppNameLabel:      common.LabelValueString(spec.AppName),
+		constants.AppIDLabel:        spec.AppID,
+		constants.UsernameLabel:     common.LabelValueString(spec.Submitter),
+		constants.UserIDLabel:       spec.UserID,
+		constants.AnalysisNameLabel: common.LabelValueString(truncateAnalysisName(spec.JobName)),
+		constants.AppTypeLabel:      string(constants.Interactive),
+		constants.SubdomainLabel:    common.Subdomain(spec.UserID, string(spec.ExternalID)),
+		constants.LoginIPLabel:      spec.UserLoginIP,
+	}
+}
+
+// truncateAnalysisName clamps the analysis name to the 63-rune label limit,
+// matching jobinfo.JobLabels. Validation guarantees JobName is non-empty.
+func truncateAnalysisName(name string) string {
+	runes := []rune(name)
+	if len(runes) > 63 {
+		runes = runes[:63]
+	}
+	return string(runes)
+}

--- a/vicebuild/names.go
+++ b/vicebuild/names.go
@@ -1,0 +1,40 @@
+package vicebuild
+
+import (
+	"fmt"
+
+	"github.com/cyverse-de/app-exposer/constants"
+	"github.com/cyverse-de/app-exposer/operatorclient"
+)
+
+// Resource names are all derived from the analysis's ExternalID (a.k.a.
+// InvocationID), matching the incluster builders so cleanup-by-label and the
+// status/exit paths keep finding the same objects.
+
+func deploymentName(spec *operatorclient.VICESpec) string { return string(spec.ExternalID) }
+func routeName(spec *operatorclient.VICESpec) string      { return string(spec.ExternalID) }
+func pdbName(spec *operatorclient.VICESpec) string        { return string(spec.ExternalID) }
+func serviceName(spec *operatorclient.VICESpec) string {
+	return fmt.Sprintf("vice-%s", spec.ExternalID)
+}
+func excludesConfigMapName(spec *operatorclient.VICESpec) string {
+	return fmt.Sprintf("%s-%s", constants.ExcludesFileName, spec.ExternalID)
+}
+func permissionsConfigMapName(spec *operatorclient.VICESpec) string {
+	return fmt.Sprintf("%s-%s", constants.PermissionsConfigMapPrefix, spec.ExternalID)
+}
+func inputPathListConfigMapName(spec *operatorclient.VICESpec) string {
+	return fmt.Sprintf("%s-%s", constants.InputPathListFileName, spec.ExternalID)
+}
+func workingDirVolumeName(spec *operatorclient.VICESpec) string {
+	return fmt.Sprintf("%s-%s", constants.WorkingDirVolumeName, spec.ExternalID)
+}
+func csiDataVolumeName(spec *operatorclient.VICESpec) string {
+	return fmt.Sprintf("%s-%s", constants.CSIDriverDataVolumeNamePrefix, spec.ExternalID)
+}
+func csiDataVolumeClaimName(spec *operatorclient.VICESpec) string {
+	return fmt.Sprintf("%s-%s", constants.CSIDriverDataVolumeClaimNamePrefix, spec.ExternalID)
+}
+func csiDataVolumeHandle(spec *operatorclient.VICESpec) string {
+	return fmt.Sprintf("%s-handle-%s", constants.CSIDriverDataVolumeNamePrefix, spec.ExternalID)
+}

--- a/vicebuild/pdb.go
+++ b/vicebuild/pdb.go
@@ -1,0 +1,29 @@
+package vicebuild
+
+import (
+	"github.com/cyverse-de/app-exposer/constants"
+	"github.com/cyverse-de/app-exposer/operatorclient"
+	policyv1 "k8s.io/api/policy/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+// PodDisruptionBudget builds the analysis PDB with maxUnavailable=0, so a
+// voluntary disruption (node drain, etc.) never evicts the single analysis pod.
+func (c *Config) PodDisruptionBudget(spec *operatorclient.VICESpec) *policyv1.PodDisruptionBudget {
+	maxUnavailable := intstr.FromInt(0)
+	return &policyv1.PodDisruptionBudget{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   pdbName(spec),
+			Labels: BuildLabels(spec),
+		},
+		Spec: policyv1.PodDisruptionBudgetSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					constants.ExternalIDLabel: string(spec.ExternalID),
+				},
+			},
+			MaxUnavailable: &maxUnavailable,
+		},
+	}
+}

--- a/vicebuild/pdb.go
+++ b/vicebuild/pdb.go
@@ -11,7 +11,7 @@ import (
 // PodDisruptionBudget builds the analysis PDB with maxUnavailable=0, so a
 // voluntary disruption (node drain, etc.) never evicts the single analysis pod.
 func (c *Config) PodDisruptionBudget(spec *operatorclient.VICESpec) *policyv1.PodDisruptionBudget {
-	maxUnavailable := intstr.FromInt(0)
+	maxUnavailable := intstr.FromInt32(0)
 	return &policyv1.PodDisruptionBudget{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   pdbName(spec),

--- a/vicebuild/resources.go
+++ b/vicebuild/resources.go
@@ -1,0 +1,117 @@
+package vicebuild
+
+import (
+	"fmt"
+
+	"github.com/cyverse-de/app-exposer/operatorclient"
+	apiv1 "k8s.io/api/core/v1"
+	resourcev1 "k8s.io/apimachinery/pkg/api/resource"
+)
+
+// GPU resource names by canonical vendor. vicebuild emits the cluster vendor's
+// name directly, folding in the old TransformGPUVendor rename.
+const (
+	gpuResourceNvidia = "nvidia.com/gpu"
+	gpuResourceAMD    = "amd.com/gpu"
+)
+
+// gpuResourceName returns the extended-resource name for the cluster's GPU
+// vendor. Defaults to the NVIDIA name for an empty/unknown vendor, matching the
+// legacy path where bundles always carried nvidia.com/gpu.
+func gpuResourceName(vendor string) apiv1.ResourceName {
+	if vendor == operatorclient.GPUVendorAMD {
+		return apiv1.ResourceName(gpuResourceAMD)
+	}
+	return apiv1.ResourceName(gpuResourceNvidia)
+}
+
+// analysisRequirements builds the analysis container's ResourceRequirements from
+// the raw asks in the spec and the cluster's default/clamp policy. It mirrors
+// resourcing.Requirements but reads resolved primitives instead of a
+// model.Analysis, and emits the cluster's GPU resource name with requests equal
+// to limits (folding in the old equalizeGPUResources, since spec.GPU.Count is
+// already the resolved effective count).
+func (c *Config) analysisRequirements(spec *operatorclient.VICESpec) apiv1.ResourceRequirements {
+	d := c.Resources
+	reqs := apiv1.ResourceList{
+		apiv1.ResourceCPU:              cpuQuantity(spec.Resources.MinCPUCores, d.DefaultCPURequest),
+		apiv1.ResourceMemory:           bytesQuantity(spec.Resources.MinMemoryBytes, d.DefaultMemRequest),
+		apiv1.ResourceEphemeralStorage: bytesQuantity(spec.Resources.MinDiskBytes, d.DefaultStorage),
+	}
+	limits := apiv1.ResourceList{}
+	if d.DoCPULimit {
+		limits[apiv1.ResourceCPU] = cpuQuantity(spec.Resources.MaxCPUCores, d.DefaultCPULimit)
+	}
+	if d.DoMemLimit {
+		limits[apiv1.ResourceMemory] = bytesQuantity(spec.Resources.MaxMemoryBytes, d.DefaultMemLimit)
+	}
+
+	if spec.GPU != nil {
+		name := gpuResourceName(c.GPUVendor)
+		count := spec.GPU.Count
+		if count <= 0 {
+			count = 1
+		}
+		qty := *resourcev1.NewQuantity(count, resourcev1.DecimalSI)
+		reqs[name] = qty
+		limits[name] = qty
+	}
+
+	return apiv1.ResourceRequirements{Requests: reqs, Limits: limits}
+}
+
+// viceProxyRequirements builds the vice-proxy sidecar's ResourceRequirements
+// entirely from cluster config — the sidecar's resources never depend on the
+// analysis (resourcing.VICEProxyRequirements ignored it too).
+func (c *Config) viceProxyRequirements() apiv1.ResourceRequirements {
+	d := c.Resources
+	out := apiv1.ResourceRequirements{
+		Requests: apiv1.ResourceList{
+			apiv1.ResourceCPU:              d.ViceProxyCPURequest,
+			apiv1.ResourceMemory:           d.ViceProxyMemRequest,
+			apiv1.ResourceEphemeralStorage: d.ViceProxyStorage,
+		},
+	}
+	limits := apiv1.ResourceList{}
+	if d.DoViceProxyCPULimit {
+		limits[apiv1.ResourceCPU] = d.ViceProxyCPULimit
+	}
+	if d.DoViceProxyMemLimit {
+		limits[apiv1.ResourceMemory] = d.ViceProxyMemLimit
+	}
+	if d.DoViceProxyStorage {
+		limits[apiv1.ResourceEphemeralStorage] = d.ViceProxyStorageLim
+	}
+	if len(limits) > 0 {
+		out.Limits = limits
+	}
+	return out
+}
+
+// cpuQuantity converts a CPU-cores ask to a milli-core Quantity, matching the
+// "%fm" formatting resourcing used. A zero ask falls back to the cluster default.
+func cpuQuantity(cores float32, fallback resourcev1.Quantity) resourcev1.Quantity {
+	if cores == 0 {
+		return fallback
+	}
+	q, err := resourcev1.ParseQuantity(fmt.Sprintf("%fm", cores*1000))
+	if err != nil {
+		log.Warnf("malformed CPU quantity from %f cores: %v; using cluster default", cores, err)
+		return fallback
+	}
+	return q
+}
+
+// bytesQuantity converts a byte ask to a Quantity, matching resourcing's "%d"
+// formatting. A zero ask falls back to the cluster default.
+func bytesQuantity(bytes int64, fallback resourcev1.Quantity) resourcev1.Quantity {
+	if bytes == 0 {
+		return fallback
+	}
+	q, err := resourcev1.ParseQuantity(fmt.Sprintf("%d", bytes))
+	if err != nil {
+		log.Warnf("malformed byte quantity from %d: %v; using cluster default", bytes, err)
+		return fallback
+	}
+	return q
+}

--- a/vicebuild/resources.go
+++ b/vicebuild/resources.go
@@ -52,7 +52,15 @@ func (c *Config) analysisRequirements(spec *operatorclient.VICESpec) apiv1.Resou
 		if count <= 0 {
 			count = 1
 		}
-		qty := *resourcev1.NewQuantity(count, resourcev1.DecimalSI)
+		// Parse from the integer string (rather than NewQuantity) so the
+		// quantity's cached string form matches what the analysis definition
+		// path produces — keeps the emitted resource identical to the legacy
+		// build, which the golden-equivalence test asserts.
+		qty, err := resourcev1.ParseQuantity(fmt.Sprintf("%d", count))
+		if err != nil {
+			log.Warnf("malformed GPU quantity %d: %v; defaulting to 1", count, err)
+			qty = resourcev1.MustParse("1")
+		}
 		reqs[name] = qty
 		limits[name] = qty
 	}

--- a/vicebuild/services.go
+++ b/vicebuild/services.go
@@ -1,0 +1,39 @@
+package vicebuild
+
+import (
+	"github.com/cyverse-de/app-exposer/constants"
+	"github.com/cyverse-de/app-exposer/operatorclient"
+	apiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+// Service builds the Service fronting the analysis pod: the file-transfers port
+// and the vice-proxy port, selected by external-id.
+func (c *Config) Service(spec *operatorclient.VICESpec) *apiv1.Service {
+	return &apiv1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   serviceName(spec),
+			Labels: BuildLabels(spec),
+		},
+		Spec: apiv1.ServiceSpec{
+			Selector: map[string]string{
+				constants.ExternalIDLabel: string(spec.ExternalID),
+			},
+			Ports: []apiv1.ServicePort{
+				{
+					Name:       constants.FileTransfersPortName,
+					Protocol:   apiv1.ProtocolTCP,
+					Port:       constants.FileTransfersPort,
+					TargetPort: intstr.FromInt32(constants.FileTransfersPort),
+				},
+				{
+					Name:       constants.VICEProxyPortName,
+					Protocol:   apiv1.ProtocolTCP,
+					Port:       constants.VICEProxyServicePort,
+					TargetPort: intstr.FromInt32(constants.VICEProxyPort),
+				},
+			},
+		},
+	}
+}

--- a/vicebuild/transfers.go
+++ b/vicebuild/transfers.go
@@ -1,0 +1,59 @@
+package vicebuild
+
+import (
+	"path"
+
+	"github.com/cyverse-de/app-exposer/constants"
+	"github.com/cyverse-de/app-exposer/operatorclient"
+	apiv1 "k8s.io/api/core/v1"
+)
+
+// fileTransferCommand returns the command for the vice-file-transfers
+// service/init container (non-CSI clusters). Metadata triples become repeated
+// -m args, matching model.FileMetadata.Argument().
+func fileTransferCommand(spec *operatorclient.VICESpec) []string {
+	cmd := []string{
+		"/vice-file-transfers",
+		"--listen-port", "60001",
+		"--user", spec.Submitter,
+		"--excludes-file", path.Join(constants.ExcludesMountPath, constants.ExcludesFileName),
+		"--path-list-file", path.Join(constants.InputPathListMountPath, constants.InputPathListFileName),
+		"--upload-destination", spec.OutputDirectory,
+		"--irods-config", constants.IRODSConfigFilePath,
+		"--invocation-id", string(spec.ExternalID),
+	}
+	for _, m := range spec.FileMetadata {
+		cmd = append(cmd, "-m", m.Attribute+","+m.Value+","+m.Unit)
+	}
+	return cmd
+}
+
+// fileTransfersVolumeMounts returns the mounts for the file-transfers and
+// input-staging containers (non-CSI clusters).
+func (c *Config) fileTransfersVolumeMounts(spec *operatorclient.VICESpec) []apiv1.VolumeMount {
+	mounts := []apiv1.VolumeMount{
+		{
+			Name:      constants.PorklockConfigVolumeName,
+			MountPath: constants.PorklockConfigMountPath,
+			ReadOnly:  true,
+		},
+		{
+			Name:      workingDirVolumeName(spec),
+			MountPath: constants.FileTransfersInputsMountPath,
+			ReadOnly:  false,
+		},
+		{
+			Name:      constants.ExcludesVolumeName,
+			MountPath: constants.ExcludesMountPath,
+			ReadOnly:  true,
+		},
+	}
+	if hasTicketlessInputs(spec) {
+		mounts = append(mounts, apiv1.VolumeMount{
+			Name:      constants.InputPathListVolumeName,
+			MountPath: constants.InputPathListMountPath,
+			ReadOnly:  true,
+		})
+	}
+	return mounts
+}

--- a/vicebuild/vicebuild_test.go
+++ b/vicebuild/vicebuild_test.go
@@ -1,0 +1,129 @@
+package vicebuild
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/cyverse-de/app-exposer/common"
+	"github.com/cyverse-de/app-exposer/constants"
+	"github.com/cyverse-de/app-exposer/operatorclient"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func testSpec() *operatorclient.VICESpec {
+	return &operatorclient.VICESpec{
+		SpecVersion: operatorclient.CurrentVICESpecVersion,
+		AnalysisID:  "analysis-1",
+		ExternalID:  "external-1",
+		JobName:     "My Analysis",
+		AppID:       "app-1",
+		AppName:     "JupyterLab",
+		UserID:      "user-1",
+		Submitter:   "someuser",
+		UserLoginIP: "10.0.0.1",
+		Container: operatorclient.ContainerSpec{
+			Image:      "cyverse/jupyter",
+			Tag:        "latest",
+			UID:        1000,
+			Ports:      []int{8888},
+			WorkingDir: "/de-app-work",
+		},
+		UserHome: "/iplant/home/someuser",
+	}
+}
+
+func testConfig() *Config {
+	return &Config{
+		UserSuffix:              "@iplantcollaborative.org",
+		InputPathListIdentifier: "# application/vnd.de.path-list+csv; version=1",
+	}
+}
+
+// TestBuildLabelsMatchesJobInfo locks the contract that BuildLabels(spec) emits
+// the same label set jobinfo.JobLabels does, with the DB-derived login IP
+// arriving via the spec. The keys come straight from the constants package, so
+// this asserts each key's presence and value rather than reaching into jobinfo
+// (which carries an apps/DB dependency the test would otherwise drag in).
+func TestBuildLabelsMatchesJobInfo(t *testing.T) {
+	spec := testSpec()
+	labels := BuildLabels(spec)
+
+	want := map[string]string{
+		constants.ExternalIDLabel:   "external-1",
+		constants.AnalysisIDLabel:   "analysis-1",
+		constants.AppNameLabel:      common.LabelValueString("JupyterLab"),
+		constants.AppIDLabel:        "app-1",
+		constants.UsernameLabel:     common.LabelValueString("someuser"),
+		constants.UserIDLabel:       "user-1",
+		constants.AnalysisNameLabel: common.LabelValueString("My Analysis"),
+		constants.AppTypeLabel:      "interactive",
+		constants.SubdomainLabel:    common.Subdomain("user-1", "external-1"),
+		constants.LoginIPLabel:      "10.0.0.1",
+	}
+	assert.Equal(t, want, labels)
+}
+
+func TestBuildLabelsTruncatesAnalysisName(t *testing.T) {
+	spec := testSpec()
+	spec.JobName = strings.Repeat("x", 100)
+	labels := BuildLabels(spec)
+	assert.LessOrEqual(t, len([]rune(labels[constants.AnalysisNameLabel])), 63)
+}
+
+func TestExcludesConfigMap(t *testing.T) {
+	spec := testSpec()
+	spec.ExcludeArguments = []string{"/path/a", "/path/b"}
+	cm := testConfig().ExcludesConfigMap(spec)
+
+	assert.Equal(t, "excludes-file-external-1", cm.Name)
+	assert.Equal(t, "analysis-1", cm.Labels[constants.AnalysisIDLabel])
+	assert.Equal(t, "/path/a\n/path/b\n", cm.Data[constants.ExcludesFileName])
+}
+
+func TestPermissionsConfigMap(t *testing.T) {
+	tests := []struct {
+		name      string
+		submitter string
+		want      string
+	}{
+		{name: "bare username gets suffix", submitter: "someuser", want: "someuser@iplantcollaborative.org\n"},
+		{name: "already-suffixed left alone", submitter: "someuser@iplantcollaborative.org", want: "someuser@iplantcollaborative.org\n"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			spec := testSpec()
+			spec.Submitter = tt.submitter
+			cm := testConfig().PermissionsConfigMap(spec)
+			assert.Equal(t, "permissions-external-1", cm.Name)
+			assert.Equal(t, tt.want, cm.Data[constants.PermissionsFileName])
+		})
+	}
+}
+
+func TestInputPathListConfigMap(t *testing.T) {
+	cfg := testConfig()
+	spec := testSpec()
+	spec.InputPathListPaths = []string{"/iplant/home/someuser/in1.txt", "/iplant/home/someuser/in2/"}
+
+	cm := cfg.InputPathListConfigMap(spec)
+	require.NotNil(t, cm)
+	assert.Equal(t, "input-path-list-external-1", cm.Name)
+	want := cfg.InputPathListIdentifier + "\n/iplant/home/someuser/in1.txt\n/iplant/home/someuser/in2/\n"
+	assert.Equal(t, want, cm.Data[constants.InputPathListFileName])
+}
+
+func TestService(t *testing.T) {
+	svc := testConfig().Service(testSpec())
+	assert.Equal(t, "vice-external-1", svc.Name)
+	assert.Equal(t, "external-1", svc.Spec.Selector[constants.ExternalIDLabel])
+	require.Len(t, svc.Spec.Ports, 2)
+	assert.Equal(t, constants.VICEProxyServicePort, svc.Spec.Ports[1].Port)
+}
+
+func TestPodDisruptionBudget(t *testing.T) {
+	pdb := testConfig().PodDisruptionBudget(testSpec())
+	assert.Equal(t, "external-1", pdb.Name)
+	assert.Equal(t, int32(0), pdb.Spec.MaxUnavailable.IntVal)
+	assert.Equal(t, "external-1", pdb.Spec.Selector.MatchLabels[constants.ExternalIDLabel])
+}

--- a/vicebuild/volumes.go
+++ b/vicebuild/volumes.go
@@ -1,0 +1,315 @@
+package vicebuild
+
+import (
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/cyverse-de/app-exposer/constants"
+	"github.com/cyverse-de/app-exposer/operatorclient"
+	apiv1 "k8s.io/api/core/v1"
+	resourcev1 "k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// defaultStorageCapacity is the floor/placeholder capacity for the working-dir
+// PVC and the CSI data volume, matching the incluster default.
+var defaultStorageCapacity = resourcev1.MustParse("5Gi")
+
+// IRODSFSPathMapping is one mount entry for the iRODS CSI driver. Mirrors
+// incluster.IRODSFSPathMapping; redefined here so vicebuild stays independent
+// of the legacy package.
+type IRODSFSPathMapping struct {
+	IRODSPath           string `json:"irods_path"`
+	MappingPath         string `json:"mapping_path"`
+	ResourceType        string `json:"resource_type"` // file or dir
+	ReadOnly            bool   `json:"read_only"`
+	CreateDir           bool   `json:"create_dir"`
+	IgnoreNotExistError bool   `json:"ignore_not_exist_error"`
+}
+
+func (c *Config) zoneMountPath() string {
+	return fmt.Sprintf("%s/%s", constants.CSIDriverLocalMountPath, c.IRODSZone)
+}
+
+// inputPathMappings builds the CSI mount entries for the analysis's inputs.
+// Uses the full input list (not just the ticketless subset): CSI mounts every
+// input regardless of ticket status.
+func inputPathMappings(spec *operatorclient.VICESpec) ([]IRODSFSPathMapping, error) {
+	mappings := []IRODSFSPathMapping{}
+	occupied := map[string]string{} // mount path -> irods path
+
+	for _, input := range spec.Inputs {
+		if input.IRODSPath == "" {
+			continue
+		}
+		var resourceType string
+		switch strings.ToLower(input.Type) {
+		case "fileinput", "multifileselector":
+			resourceType = "file"
+		case "folderinput":
+			resourceType = "dir"
+		default:
+			return nil, fmt.Errorf("unknown step input type - %s", input.Type)
+		}
+
+		mountPath := fmt.Sprintf("%s/%s", constants.CSIDriverInputVolumeMountPath, filepath.Base(input.IRODSPath))
+		if existing, ok := occupied[mountPath]; ok {
+			return nil, fmt.Errorf("tried to mount an input file %s at %s already used by - %s", input.IRODSPath, mountPath, existing)
+		}
+		occupied[mountPath] = input.IRODSPath
+
+		mappings = append(mappings, IRODSFSPathMapping{
+			IRODSPath:           input.IRODSPath,
+			MappingPath:         mountPath,
+			ResourceType:        resourceType,
+			ReadOnly:            true,
+			CreateDir:           false,
+			IgnoreNotExistError: true,
+		})
+	}
+	return mappings, nil
+}
+
+func (c *Config) sharedPathMapping() IRODSFSPathMapping {
+	sharedHomeFullPath := fmt.Sprintf("/%s/home/shared", c.IRODSZone)
+	return IRODSFSPathMapping{
+		IRODSPath:           sharedHomeFullPath,
+		MappingPath:         sharedHomeFullPath,
+		ResourceType:        "dir",
+		IgnoreNotExistError: true,
+	}
+}
+
+// persistentVolumes builds the CSI data PersistentVolume (when CSI is enabled).
+// Returns nil when CSI is disabled — the cluster's own storage provisions the
+// working-dir PVC.
+func (c *Config) persistentVolumes(spec *operatorclient.VICESpec) ([]*apiv1.PersistentVolume, error) {
+	if !c.UseCSIDriver {
+		return nil, nil
+	}
+
+	mappings := []IRODSFSPathMapping{}
+	inputMappings, err := inputPathMappings(spec)
+	if err != nil {
+		return nil, err
+	}
+	mappings = append(mappings, inputMappings...)
+	mappings = append(mappings, IRODSFSPathMapping{
+		IRODSPath:           spec.OutputDirectory,
+		MappingPath:         constants.CSIDriverOutputVolumeMountPath,
+		ResourceType:        "dir",
+		ReadOnly:            false,
+		CreateDir:           true,
+		IgnoreNotExistError: true,
+	})
+	if spec.UserHome != "" {
+		mappings = append(mappings, IRODSFSPathMapping{
+			IRODSPath:    spec.UserHome,
+			MappingPath:  spec.UserHome,
+			ResourceType: "dir",
+		})
+	}
+	mappings = append(mappings, c.sharedPathMapping())
+
+	mappingsJSON, err := json.Marshal(mappings)
+	if err != nil {
+		return nil, err
+	}
+
+	labels := BuildLabels(spec)
+	labels["volume-name"] = csiDataVolumeName(spec)
+
+	volmode := apiv1.PersistentVolumeFilesystem
+	uid := fmt.Sprintf("%d", spec.Container.UID)
+	pv := &apiv1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   csiDataVolumeName(spec),
+			Labels: labels,
+		},
+		Spec: apiv1.PersistentVolumeSpec{
+			Capacity:                      apiv1.ResourceList{apiv1.ResourceStorage: defaultStorageCapacity},
+			VolumeMode:                    &volmode,
+			AccessModes:                   []apiv1.PersistentVolumeAccessMode{apiv1.ReadWriteMany},
+			PersistentVolumeReclaimPolicy: apiv1.PersistentVolumeReclaimRetain,
+			StorageClassName:              constants.CSIDriverStorageClassName,
+			PersistentVolumeSource: apiv1.PersistentVolumeSource{
+				CSI: &apiv1.CSIPersistentVolumeSource{
+					Driver:       constants.CSIDriverName,
+					VolumeHandle: csiDataVolumeHandle(spec),
+					VolumeAttributes: map[string]string{
+						"client":              "irodsfuse",
+						"path_mapping_json":   string(mappingsJSON),
+						"no_permission_check": "true",
+						// iRODS proxy access expects the bare username without the
+						// domain suffix (e.g. "someuser", not the @-qualified form).
+						"clientUser": strings.SplitN(spec.Submitter, "@", 2)[0],
+						"uid":        uid,
+						"gid":        uid,
+					},
+				},
+			},
+		},
+	}
+	return []*apiv1.PersistentVolume{pv}, nil
+}
+
+// persistentVolumeCapacity returns the working-dir PVC capacity: the analysis's
+// disk ask, floored at the default.
+func persistentVolumeCapacity(spec *operatorclient.VICESpec) resourcev1.Quantity {
+	capacity := max(defaultStorageCapacity.Value(), spec.Resources.MinDiskBytes)
+	return *resourcev1.NewQuantity(capacity, resourcev1.BinarySI)
+}
+
+// volumeClaims builds the working-dir PVC (with the cluster's storage class
+// folded in — the old TransformWorkingDirStorageClass) and, when CSI is
+// enabled, the iRODS data-volume claim.
+func (c *Config) volumeClaims(spec *operatorclient.VICESpec) []*apiv1.PersistentVolumeClaim {
+	labels := BuildLabels(spec)
+
+	workingDir := &apiv1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   workingDirVolumeName(spec),
+			Labels: labels,
+		},
+		Spec: apiv1.PersistentVolumeClaimSpec{
+			AccessModes: []apiv1.PersistentVolumeAccessMode{apiv1.ReadWriteOnce},
+			Resources: apiv1.VolumeResourceRequirements{
+				Requests: apiv1.ResourceList{apiv1.ResourceStorage: persistentVolumeCapacity(spec)},
+			},
+		},
+	}
+	// Fold in TransformWorkingDirStorageClass: empty means "cluster default".
+	if c.LocalStorageClass != "" {
+		sc := c.LocalStorageClass
+		workingDir.Spec.StorageClassName = &sc
+	}
+	claims := []*apiv1.PersistentVolumeClaim{workingDir}
+
+	if c.UseCSIDriver {
+		storageClass := constants.CSIDriverStorageClassName
+		claims = append(claims, &apiv1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   csiDataVolumeClaimName(spec),
+				Labels: labels,
+			},
+			Spec: apiv1.PersistentVolumeClaimSpec{
+				AccessModes:      []apiv1.PersistentVolumeAccessMode{apiv1.ReadWriteMany},
+				StorageClassName: &storageClass,
+				VolumeName:       csiDataVolumeName(spec),
+				Resources: apiv1.VolumeResourceRequirements{
+					Requests: apiv1.ResourceList{apiv1.ResourceStorage: defaultStorageCapacity},
+				},
+			},
+		})
+	}
+	return claims
+}
+
+// workingDirMountPath is the in-container path the working-dir volume mounts at;
+// it is the resolved container working directory.
+func workingDirMountPath(spec *operatorclient.VICESpec) string {
+	return spec.Container.WorkingDir
+}
+
+// hasTicketlessInputs reports whether the input-path-list volume/mount is
+// needed (porklock staging only runs for ticketless inputs).
+func hasTicketlessInputs(spec *operatorclient.VICESpec) bool {
+	return len(spec.InputPathListPaths) > 0
+}
+
+// podVolumeMounts returns the analysis container's volume mounts for the
+// persistent and CSI data volumes plus shared memory.
+func (c *Config) podVolumeMounts(spec *operatorclient.VICESpec) []apiv1.VolumeMount {
+	mounts := []apiv1.VolumeMount{
+		{
+			Name:      workingDirVolumeName(spec),
+			MountPath: workingDirMountPath(spec),
+			ReadOnly:  false,
+		},
+	}
+	if c.UseCSIDriver {
+		mounts = append(mounts, apiv1.VolumeMount{
+			Name:      csiDataVolumeClaimName(spec),
+			MountPath: constants.CSIDriverLocalMountPath,
+		})
+	}
+	if spec.Resources.SharedMemoryBytes != nil {
+		mounts = append(mounts, apiv1.VolumeMount{
+			Name:      constants.SharedMemoryVolumeName,
+			MountPath: constants.ShmDevice,
+			ReadOnly:  false,
+		})
+	}
+	return mounts
+}
+
+// podVolumes returns the pod-level Volumes for the analysis Deployment.
+func (c *Config) podVolumes(spec *operatorclient.VICESpec) []apiv1.Volume {
+	volumes := []apiv1.Volume{}
+
+	if hasTicketlessInputs(spec) {
+		volumes = append(volumes, apiv1.Volume{
+			Name: constants.InputPathListVolumeName,
+			VolumeSource: apiv1.VolumeSource{
+				ConfigMap: &apiv1.ConfigMapVolumeSource{
+					LocalObjectReference: apiv1.LocalObjectReference{Name: inputPathListConfigMapName(spec)},
+				},
+			},
+		})
+	}
+
+	volumes = append(volumes, apiv1.Volume{
+		Name: workingDirVolumeName(spec),
+		VolumeSource: apiv1.VolumeSource{
+			PersistentVolumeClaim: &apiv1.PersistentVolumeClaimVolumeSource{ClaimName: workingDirVolumeName(spec)},
+		},
+	})
+	if c.UseCSIDriver {
+		volumes = append(volumes, apiv1.Volume{
+			Name: csiDataVolumeClaimName(spec),
+			VolumeSource: apiv1.VolumeSource{
+				PersistentVolumeClaim: &apiv1.PersistentVolumeClaimVolumeSource{ClaimName: csiDataVolumeClaimName(spec)},
+			},
+		})
+	} else {
+		volumes = append(volumes, apiv1.Volume{
+			Name: constants.PorklockConfigVolumeName,
+			VolumeSource: apiv1.VolumeSource{
+				Secret: &apiv1.SecretVolumeSource{SecretName: constants.PorklockConfigSecretName},
+			},
+		})
+	}
+
+	volumes = append(volumes,
+		apiv1.Volume{
+			Name: constants.ExcludesVolumeName,
+			VolumeSource: apiv1.VolumeSource{
+				ConfigMap: &apiv1.ConfigMapVolumeSource{
+					LocalObjectReference: apiv1.LocalObjectReference{Name: excludesConfigMapName(spec)},
+				},
+			},
+		},
+		apiv1.Volume{
+			Name: constants.PermissionsVolumeName,
+			VolumeSource: apiv1.VolumeSource{
+				ConfigMap: &apiv1.ConfigMapVolumeSource{
+					LocalObjectReference: apiv1.LocalObjectReference{Name: permissionsConfigMapName(spec)},
+				},
+			},
+		},
+	)
+
+	if spec.Resources.SharedMemoryBytes != nil {
+		size := resourcev1.NewQuantity(*spec.Resources.SharedMemoryBytes, resourcev1.BinarySI)
+		volumes = append(volumes, apiv1.Volume{
+			Name: constants.SharedMemoryVolumeName,
+			VolumeSource: apiv1.VolumeSource{
+				EmptyDir: &apiv1.EmptyDirVolumeSource{Medium: "Memory", SizeLimit: size},
+			},
+		})
+	}
+
+	return volumes
+}

--- a/vicebuild/volumes.go
+++ b/vicebuild/volumes.go
@@ -207,9 +207,20 @@ func (c *Config) volumeClaims(spec *operatorclient.VICESpec) []*apiv1.Persistent
 	return claims
 }
 
-// workingDirMountPath is the in-container path the working-dir volume mounts at;
-// it is the resolved container working directory.
+// defaultWorkingDir is the working-dir volume mount path used when the job
+// submission did not specify a container working directory. Mirrors
+// model.Container.WorkingDirectory()'s default; the spec carries the raw
+// (possibly empty) WorkingDir so the analysis container's WorkingDir field is
+// only set when the job actually specified one (otherwise the image's own
+// WORKDIR applies), while the volume still mounts at a known path.
+const defaultWorkingDir = "/de-app-work"
+
+// workingDirMountPath is the in-container path the working-dir volume mounts at.
+// It resolves the default when the spec carries no explicit working directory.
 func workingDirMountPath(spec *operatorclient.VICESpec) string {
+	if spec.Container.WorkingDir == "" {
+		return defaultWorkingDir
+	}
 	return spec.Container.WorkingDir
 }
 

--- a/vicebuild/volumes_test.go
+++ b/vicebuild/volumes_test.go
@@ -1,0 +1,125 @@
+package vicebuild
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/cyverse-de/app-exposer/constants"
+	"github.com/cyverse-de/app-exposer/operatorclient"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apiv1 "k8s.io/api/core/v1"
+)
+
+// TestWorkingDirStorageClassFolded confirms TransformWorkingDirStorageClass is
+// folded in: the working-dir PVC carries the cluster's storage class, or none
+// (cluster default) when unset, while the CSI claim keeps its own class.
+func TestWorkingDirStorageClassFolded(t *testing.T) {
+	t.Run("storage class set", func(t *testing.T) {
+		cfg := testConfig()
+		cfg.LocalStorageClass = "gp3"
+		claims := cfg.volumeClaims(testSpec())
+		wd := claims[0]
+		require.NotNil(t, wd.Spec.StorageClassName)
+		assert.Equal(t, "gp3", *wd.Spec.StorageClassName)
+	})
+	t.Run("empty means cluster default", func(t *testing.T) {
+		cfg := testConfig()
+		cfg.LocalStorageClass = ""
+		claims := cfg.volumeClaims(testSpec())
+		assert.Nil(t, claims[0].Spec.StorageClassName, "unset storage class lets the cluster default apply")
+	})
+}
+
+func TestVolumeClaimsCSI(t *testing.T) {
+	cfg := testConfig()
+	cfg.UseCSIDriver = true
+	claims := cfg.volumeClaims(testSpec())
+	require.Len(t, claims, 2)
+	assert.Equal(t, "working-dir-external-1", claims[0].Name)
+	assert.Equal(t, "csi-data-volume-claim-external-1", claims[1].Name)
+	require.NotNil(t, claims[1].Spec.StorageClassName)
+	assert.Equal(t, constants.CSIDriverStorageClassName, *claims[1].Spec.StorageClassName)
+}
+
+func TestPersistentVolumesCSIDisabled(t *testing.T) {
+	cfg := testConfig()
+	cfg.UseCSIDriver = false
+	pvs, err := cfg.persistentVolumes(testSpec())
+	require.NoError(t, err)
+	assert.Nil(t, pvs)
+}
+
+// TestPersistentVolumesCSIMappings confirms the CSI PV encodes the full input
+// list plus output, home, and shared mappings, and uses the bare proxy
+// username.
+func TestPersistentVolumesCSIMappings(t *testing.T) {
+	cfg := testConfig()
+	cfg.UseCSIDriver = true
+	cfg.IRODSZone = "iplant"
+	spec := testSpec()
+	spec.Submitter = "someuser@iplantcollaborative.org"
+	spec.OutputDirectory = "/iplant/home/someuser/out"
+	spec.Inputs = []operatorclient.InputSpec{
+		{IRODSPath: "/iplant/home/someuser/in.txt", Type: "fileinput"},
+		{IRODSPath: "/iplant/home/someuser/dir/", Type: "folderinput"},
+	}
+
+	pvs, err := cfg.persistentVolumes(spec)
+	require.NoError(t, err)
+	require.Len(t, pvs, 1)
+	attrs := pvs[0].Spec.CSI.VolumeAttributes
+	assert.Equal(t, "someuser", attrs["clientUser"], "CSI proxy user is the bare username")
+
+	var mappings []IRODSFSPathMapping
+	require.NoError(t, json.Unmarshal([]byte(attrs["path_mapping_json"]), &mappings))
+	// 2 inputs + output + home + shared = 5
+	require.Len(t, mappings, 5)
+	assert.Equal(t, "file", mappings[0].ResourceType)
+	assert.Equal(t, "dir", mappings[1].ResourceType)
+}
+
+func TestPersistentVolumeCapacity(t *testing.T) {
+	tests := []struct {
+		name      string
+		diskBytes int64
+		wantMin   int64
+	}{
+		{name: "below default floors at 5Gi", diskBytes: 1 << 20, wantMin: 5 << 30},
+		{name: "above default uses ask", diskBytes: 20 << 30, wantMin: 20 << 30},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			spec := testSpec()
+			spec.Resources.MinDiskBytes = tt.diskBytes
+			q := persistentVolumeCapacity(spec)
+			assert.Equal(t, tt.wantMin, q.Value())
+		})
+	}
+}
+
+// TestInputPathListVolumePresence confirms the input-path-list volume only
+// appears when there are ticketless inputs.
+func TestInputPathListVolumePresence(t *testing.T) {
+	cfg := testConfig()
+	cfg.UseCSIDriver = true
+
+	t.Run("no ticketless inputs", func(t *testing.T) {
+		vols := cfg.podVolumes(testSpec())
+		assert.NotContains(t, volumeNames(vols), constants.InputPathListVolumeName)
+	})
+	t.Run("with ticketless inputs", func(t *testing.T) {
+		spec := testSpec()
+		spec.InputPathListPaths = []string{"/iplant/home/someuser/in.txt"}
+		vols := cfg.podVolumes(spec)
+		assert.Contains(t, volumeNames(vols), constants.InputPathListVolumeName)
+	})
+}
+
+func volumeNames(vols []apiv1.Volume) []string {
+	out := make([]string, 0, len(vols))
+	for _, v := range vols {
+		out = append(out, v.Name)
+	}
+	return out
+}


### PR DESCRIPTION
## Operator-side bundle construction (cluster-agnostic `VICESpec`)

Moves VICE Kubernetes-object construction out of app-exposer and into vice-operator. app-exposer now sends a cluster-agnostic **`VICESpec`** ("what the analysis is") and the operator builds the concrete objects for its own cluster ("how to realize it"), folding the old post-hoc transform layer into construction. This removes app-exposer's knowledge of per-cluster Kubernetes specifics (Gateway API version, GPU vendor/labels, storage class, image registry, iRODS/CSI layout) and makes the fleet genuinely heterogeneous-cluster-ready.

Implements the three design docs in `plans/operator-side-bundle-construction*.md`. **Phases 0–3 (all the code) are done; Phases 4–6 are operational** (fleet rollout, soak, legacy deletion) and not part of this PR.

### What's here, by phase

- **Phase 0 — contract** (`operatorclient/vicespec.go`): `VICESpec` + `ContainerSpec`/`ResourceSpec`/`GPUSpec`/`InputSpec`/`MetadataAVU`, `CurrentVICESpecVersion`, `Validate()`, and `RequestedGPUVendor/Models` accessors. Contract doc in `plans/`.
- **Phase 1 — `vicebuild/`**: new package that builds the full object set (Deployment, Service, HTTPRoute, ConfigMaps, PVs/PVCs, PDB) from `VICESpec` + a cluster `Config`. All nine operator transforms are folded into construction (hostname, gateway ns, loading-service backend, GPU vendor/model, storage class, vice-proxy args, image refs, permissions ConfigMap). No DB/apps/`model.Job` dependency.
- **Phase 2 — operator accepts the spec**: `POST /analyses/spec` (`HandleLaunchSpec`); capacity response advertises `SpecVersion`; `applyBundle`+egress factored into a shared tail; operator gains the build config + resource-default policy, threaded from `cmd/vice-operator` flags.
- **Phase 3 — app-exposer maps + routes**: `incluster.BuildVICESpec` resolves `model.Job → VICESpec` (every DE-semantic method evaluated app-exposer-side; the one DB value, login IP, resolved here); `Scheduler.LaunchAnalysisSpec` routes per operator — spec-aware operators get the spec, older ones get a legacy `AnalysisBundle` built on demand; GPU matching reads the spec.

### Key decisions

1. **Fresh `vicebuild` package; legacy `incluster` builders untouched.** The legacy path needs *pre*-transform objects (the old operator transforms them); the new path needs *post*-transform objects. These are genuinely different outputs, so a single dual-mode builder would be a brittle config matrix. The temporary duplication is sanctioned by the migration plan's coexistence model and removed in Phase 6. Net effect: **zero risk to the working launch path.**
2. **Golden-equivalence test as the safety net** (`incluster/golden_equivalence_test.go`): asserts `vicebuild(BuildVICESpec(job))` equals the legacy `BuildAnalysisBundle(job)` + operator transforms, across CSI/non-CSI × no-GPU / NVIDIA+model / EKS-mapping / AMD. It already caught two real divergences (GPU quantity representation, working-dir field semantics), now fixed.
3. **`GPUSpec.Vendor` carried explicitly** (defaulting to nvidia) rather than hardcoding nvidia in the scheduler — so multi-vendor scheduling is real plumbing: the day an analysis can express AMD, only that field changes.
4. **Per-operator capability negotiation** via `CapacityResponse.SpecVersion` (0 = unsupported). This is the single switch that lets both paths coexist and lets operators migrate one at a time; it's the rollback lever for the entire live rollout (flip an operator back to object-mode, no app-exposer redeploy).
5. **Resource default/clamp policy is operator config**, parsed straight into `vicebuild.ResourceDefaults` in the operator binary — keeping `resourcing` (and `model`) out of the `operator`/`vicebuild` packages. Flag defaults mirror app-exposer's so a cluster behaves identically on both paths.

### Testing

`go build ./...`, `go test ./...`, and `golangci-lint run ./...` are all clean. New tests cover: spec validation + JSON round-trip; every folded transform; the operator spec-launch integration path (fake clientset); capacity `SpecVersion` advertising; `BuildVICESpec` field mapping; scheduler spec-vs-bundle routing; and the golden-equivalence matrix.

### Not in this PR / follow-ups

- **Phases 4–6** (deploy fleet-wide, soak, delete the legacy path) are operational and time-gated.
- **Millicores reservation** still uses app-exposer's `resourcing` defaults; for spec-path launches on an operator with different defaults the reserved value can be slightly off (commented at the source). Unify in Phase 4. In single-operator prod the defaults match, so no discrepancy today.
- Pre-existing dead inner `if` in `scheduler.isTransientLaunchError` (behavior already correct) left untouched to keep the diff focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
