### PR TITLE
Mirror the build descriptor to vice-operator on release

### DIFF
--- a/.github/workflows/skaffold-build.yml
+++ b/.github/workflows/skaffold-build.yml
@@ -9,7 +9,11 @@ on:
 
 jobs:
   call-workflow-passing-data:
-    uses: cyverse-de/github-workflows/.github/workflows/skaffold-build.yml@v0.4.0
+    uses: cyverse-de/github-workflows/.github/workflows/skaffold-build.yml@v0.4.1
+    with:
+      # vice-operator ships the app-exposer image, so mirror this build's
+      # descriptor into its deployments role too.
+      extra-service-names: vice-operator
     secrets:
       harbor-username: ${{ secrets.HARBOR_USERNAME }}
       harbor-password: ${{ secrets.HARBOR_PASSWORD }}


### PR DESCRIPTION
## Problem

vice-operator ships the exact `harbor.cyverse.org/de/app-exposer` image (deployed with `command: ["/vice-operator"]`), so `deployments/ansible/roles/services/vice-operator/files/vice-operator.json` must byte-match `app-exposer.json`. On a release, the pipeline only refreshed `app-exposer.json`, so `vice-operator.json` drifted and vice-operator kept deploying a stale image until someone fixed it by hand.

## Change

Adopt the `extra-service-names` input added to the shared `skaffold-build.yml` workflow (github-workflows `v0.4.1`): its commit step copies the freshly-built descriptor into each extra service role and stages it in the same commit.

- Bump the reusable workflow pin `@v0.4.0` → `@v0.4.1` (the tag that includes `extra-service-names`).
- Pass `extra-service-names: vice-operator`.

On the next app-exposer `v*` release, the Actions Bot commit to `deployments/main` updates both `app-exposer.json` and `vice-operator.json` together.

## Note

The mirror copy runs only in the CI workflow. A local `build_it.yml --tags app-exposer` / `build_release.yml` still won't refresh `vice-operator.json` (build `--tags vice-operator` directly if you need that locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)