### PR TITLE
Let vice-proxy trust a private CA

### DIFF
--- a/cmd/vice-operator/main.go
+++ b/cmd/vice-operator/main.go
@@ -77,6 +77,8 @@ func main() {
 		disableInternetAccess bool
 		userSuffix            string
 		localStorageClass     string
+		caBundleConfigMap     string
+		caBundleKey           string
 		statusListenerURL     string
 		statusLeaseNamespace  string
 		statusLeaseName       string
@@ -169,6 +171,8 @@ func main() {
 	flag.BoolVar(&disableInternetAccess, "disable-internet-access", false, "Block analysis pods from reaching the public internet; only DNS, explicit host/CIDR exceptions, and pod exceptions are allowed")
 	flag.StringVar(&userSuffix, "user-suffix", constants.DefaultUserSuffix, "Domain suffix appended to usernames if not already present")
 	flag.StringVar(&localStorageClass, "local-storage-class", "", "StorageClass for the per-analysis working-dir PVC (e.g. openebs-hostpath, gp3); empty means use the cluster's default storage class")
+	flag.StringVar(&caBundleConfigMap, "ca-bundle-configmap", "", "ConfigMap in --namespace holding the CA that vice-proxy must trust to reach Keycloak; needed only where the DE's certificates chain to a private CA. Empty leaves the vice-proxy image's trust store alone.")
+	flag.StringVar(&caBundleKey, "ca-bundle-key", constants.CABundleKey, "Key within --ca-bundle-configmap holding the PEM bundle")
 	flag.StringVar(&statusListenerURL, "status-listener-url", "", "Base URL of job-status-listener (e.g. https://de.example.org/job); empty disables the push-based status informer and falls back to the reconciler's polling")
 	flag.StringVar(&statusLeaseNamespace, "status-lease-namespace", "", "Namespace for the status-publisher coordination Lease (defaults to --namespace)")
 	flag.StringVar(&statusLeaseName, "status-lease-name", "vice-operator-status-publisher", "Name of the coordination Lease used to elect the status-publisher leader")
@@ -496,6 +500,8 @@ func main() {
 		GatewayProvider:         gatewayProvider,
 		ImagePullSecretName:     imagePullSecret,
 		ResourceDefaults:        resourceDefaults,
+		CABundleConfigMap:       caBundleConfigMap,
+		CABundleKey:             caBundleKey,
 		DisableSpecLaunch:       disableSpecLaunch,
 	})
 	if err != nil {

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -45,6 +45,12 @@ const (
 	PermissionsMountPath       = "/etc/vice-permissions"
 	PermissionsFileName        = "allowed-users"
 
+	// The CA bundle vice-proxy trusts when the DE's certificates chain to a
+	// private CA. Matches the mount path the DE services use.
+	CABundleVolumeName = "de-ca"
+	CABundleMountPath  = "/etc/de-ca"
+	CABundleKey        = "ca.crt"
+
 	InputPathListMountPath  = "/input-paths"
 	InputPathListFileName   = "input-path-list"
 	InputPathListVolumeName = "input-path-list"

--- a/operator/handlers.go
+++ b/operator/handlers.go
@@ -83,6 +83,8 @@ type Operator struct {
 	gatewayProvider         string
 	imagePullSecretName     string
 	resourceDefaults        vicebuild.ResourceDefaults
+	caBundleConfigMap       string // ConfigMap in namespace holding the CA vice-proxy trusts; empty leaves the image's trust store alone.
+	caBundleKey             string
 	// disableSpecLaunch turns off the operator-side spec build path: the
 	// operator advertises SpecVersion 0 (so app-exposer routes it a legacy
 	// bundle) and rejects direct spec launches. The per-operator rollback lever.
@@ -127,6 +129,8 @@ type OperatorOptions struct {
 	GatewayProvider         string
 	ImagePullSecretName     string
 	ResourceDefaults        vicebuild.ResourceDefaults
+	CABundleConfigMap       string // ConfigMap in Namespace holding the CA vice-proxy trusts; empty leaves the image's trust store alone.
+	CABundleKey             string
 	DisableSpecLaunch       bool
 }
 
@@ -197,6 +201,8 @@ func NewOperator(opts OperatorOptions) (*Operator, error) {
 		gatewayProvider:         opts.GatewayProvider,
 		imagePullSecretName:     opts.ImagePullSecretName,
 		resourceDefaults:        opts.ResourceDefaults,
+		caBundleConfigMap:       opts.CABundleConfigMap,
+		caBundleKey:             opts.CABundleKey,
 		disableSpecLaunch:       opts.DisableSpecLaunch,
 	}, nil
 }
@@ -243,6 +249,8 @@ func (o *Operator) viceBuildConfig() vicebuild.Config {
 		LoadingServicePort:      o.loadingServicePort,
 		ImageRewriter:           rewriter,
 		Resources:               o.resourceDefaults,
+		CABundleConfigMap:       o.caBundleConfigMap,
+		CABundleKey:             o.caBundleKey,
 	}
 }
 

--- a/vicebuild/config.go
+++ b/vicebuild/config.go
@@ -12,6 +12,7 @@ package vicebuild
 
 import (
 	"github.com/cyverse-de/app-exposer/common"
+	"github.com/cyverse-de/app-exposer/constants"
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
@@ -53,6 +54,14 @@ type Config struct {
 	// Secrets.
 	ImagePullSecretName     string
 	ClusterConfigSecretName string
+
+	// CABundleConfigMap names a ConfigMap in Namespace holding the CA that
+	// vice-proxy must trust to reach Keycloak — needed only where the DE's
+	// certificates chain to a private CA. Empty adds no volume and no mount,
+	// leaving clusters with publicly-trusted certificates unaffected.
+	// CABundleKey is the key within it; empty means constants.CABundleKey.
+	CABundleConfigMap string
+	CABundleKey       string
 
 	// UserSuffix is appended to the submitter username where Keycloak expects
 	// the fully-qualified form (permissions ConfigMap, CSI proxy user).
@@ -110,6 +119,15 @@ type ResourceDefaults struct {
 	DoViceProxyCPULimit bool
 	DoViceProxyMemLimit bool
 	DoViceProxyStorage  bool
+}
+
+// caBundleKey returns the configured CA bundle key, defaulting to the
+// conventional ca.crt.
+func (c *Config) caBundleKey() string {
+	if c.CABundleKey == "" {
+		return constants.CABundleKey
+	}
+	return c.CABundleKey
 }
 
 // rewriteImage applies the configured image rewriter, or returns ref unchanged

--- a/vicebuild/deployments.go
+++ b/vicebuild/deployments.go
@@ -3,6 +3,7 @@ package vicebuild
 import (
 	"fmt"
 	"net/url"
+	"path/filepath"
 
 	"github.com/cyverse-de/app-exposer/common"
 	"github.com/cyverse-de/app-exposer/constants"
@@ -145,8 +146,8 @@ func (c *Config) analysisContainer(spec *operatorclient.VICESpec) apiv1.Containe
 }
 
 // viceProxyContainer builds the vice-proxy sidecar with per-analysis args, the
-// cluster-config-secret envFrom, and the permissions mount — folding in the old
-// TransformViceProxyArgs.
+// cluster-config-secret envFrom, the permissions mount, and any configured CA
+// bundle — folding in the old TransformViceProxyArgs.
 func (c *Config) viceProxyContainer(spec *operatorclient.VICESpec) apiv1.Container {
 	backendURL := "http://localhost:60000"
 	if len(spec.Container.Ports) > 0 {
@@ -199,6 +200,21 @@ func (c *Config) viceProxyContainer(spec *operatorclient.VICESpec) apiv1.Contain
 				Optional:             &optional,
 			}},
 		}
+	}
+
+	// SSL_CERT_FILE is enough on its own: vice-proxy is a cgo-free Go binary
+	// that never sets its own RootCAs, so crypto/x509 picks this up for the
+	// back-channel token exchange with Keycloak.
+	if c.CABundleConfigMap != "" {
+		container.VolumeMounts = append(container.VolumeMounts, apiv1.VolumeMount{
+			Name:      constants.CABundleVolumeName,
+			MountPath: constants.CABundleMountPath,
+			ReadOnly:  true,
+		})
+		container.Env = append(container.Env, apiv1.EnvVar{
+			Name:  "SSL_CERT_FILE",
+			Value: filepath.Join(constants.CABundleMountPath, c.caBundleKey()),
+		})
 	}
 	return container
 }
@@ -352,19 +368,19 @@ func (c *Config) Deployment(spec *operatorclient.VICESpec) *appsv1.Deployment {
 			},
 			Template: apiv1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{Labels: labels},
-			Spec: apiv1.PodSpec{
-				Hostname:                     common.Subdomain(spec.UserID, string(spec.ExternalID)),
-				RestartPolicy:                apiv1.RestartPolicyAlways,
-				Volumes:                      c.podVolumes(spec),
-				InitContainers:               c.initContainers(spec),
-				Containers:                   c.containers(spec),
-				ImagePullSecrets:             c.imagePullSecrets(),
-				AutomountServiceAccountToken: &autoMount,
-				DNSConfig: &apiv1.PodDNSConfig{
-					Options: []apiv1.PodDNSConfigOption{
-						{Name: "ndots", Value: constants.StringPtr("1")},
+				Spec: apiv1.PodSpec{
+					Hostname:                     common.Subdomain(spec.UserID, string(spec.ExternalID)),
+					RestartPolicy:                apiv1.RestartPolicyAlways,
+					Volumes:                      c.podVolumes(spec),
+					InitContainers:               c.initContainers(spec),
+					Containers:                   c.containers(spec),
+					ImagePullSecrets:             c.imagePullSecrets(),
+					AutomountServiceAccountToken: &autoMount,
+					DNSConfig: &apiv1.PodDNSConfig{
+						Options: []apiv1.PodDNSConfigOption{
+							{Name: "ndots", Value: constants.StringPtr("1")},
+						},
 					},
-				},
 					SecurityContext: &apiv1.PodSecurityContext{
 						RunAsUser:  uidPtr(spec),
 						RunAsGroup: uidPtr(spec),

--- a/vicebuild/deployments_test.go
+++ b/vicebuild/deployments_test.go
@@ -193,6 +193,56 @@ func TestViceProxyArgsFolded(t *testing.T) {
 	assert.True(t, hasPermsMount, "permissions volume mount present")
 }
 
+// TestViceProxyCABundle confirms the CA bundle reaches vice-proxy as both a
+// volume and SSL_CERT_FILE only when configured, so clusters with
+// publicly-trusted certificates keep an unchanged pod spec.
+func TestViceProxyCABundle(t *testing.T) {
+	for _, tt := range []struct {
+		name      string
+		configMap string
+		key       string
+		wantEnv   string // empty means no volume, no mount, and no env var
+	}{
+		{name: "unset", configMap: "", wantEnv: ""},
+		{name: "default key", configMap: "local-ca", wantEnv: "/etc/de-ca/ca.crt"},
+		{name: "explicit key", configMap: "local-ca", key: "bundle.pem", wantEnv: "/etc/de-ca/bundle.pem"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := testConfig()
+			cfg.CABundleConfigMap = tt.configMap
+			cfg.CABundleKey = tt.key
+
+			dep := cfg.Deployment(testSpec())
+			proxy := findContainer(t, dep.Spec.Template.Spec.Containers, constants.VICEProxyContainerName)
+
+			var gotEnv string
+			for _, e := range proxy.Env {
+				if e.Name == "SSL_CERT_FILE" {
+					gotEnv = e.Value
+				}
+			}
+			assert.Equal(t, tt.wantEnv, gotEnv)
+
+			var mounted, volumed bool
+			for _, vm := range proxy.VolumeMounts {
+				if vm.Name == constants.CABundleVolumeName {
+					mounted = true
+					assert.True(t, vm.ReadOnly)
+				}
+			}
+			for _, v := range dep.Spec.Template.Spec.Volumes {
+				if v.Name == constants.CABundleVolumeName {
+					volumed = true
+					require.NotNil(t, v.ConfigMap)
+					assert.Equal(t, tt.configMap, v.ConfigMap.Name)
+				}
+			}
+			assert.Equal(t, tt.wantEnv != "", mounted, "CA volume mount presence")
+			assert.Equal(t, tt.wantEnv != "", volumed, "CA volume presence")
+		})
+	}
+}
+
 // TestImageRefsFolded confirms TransformImageRefs is folded in: a configured
 // rewriter is applied to every container image.
 func TestImageRefsFolded(t *testing.T) {

--- a/vicebuild/volumes.go
+++ b/vicebuild/volumes.go
@@ -314,6 +314,17 @@ func (c *Config) podVolumes(spec *operatorclient.VICESpec) []apiv1.Volume {
 		},
 	)
 
+	if c.CABundleConfigMap != "" {
+		volumes = append(volumes, apiv1.Volume{
+			Name: constants.CABundleVolumeName,
+			VolumeSource: apiv1.VolumeSource{
+				ConfigMap: &apiv1.ConfigMapVolumeSource{
+					LocalObjectReference: apiv1.LocalObjectReference{Name: c.CABundleConfigMap},
+				},
+			},
+		})
+	}
+
 	if spec.Resources.SharedMemoryBytes != nil {
 		size := resourcev1.NewQuantity(*spec.Resources.SharedMemoryBytes, resourcev1.BinarySI)
 		volumes = append(volumes, apiv1.Volume{


### PR DESCRIPTION
## Problem

vice-proxy exchanges the OAuth authorization code with Keycloak over a **back channel** — a server-side call from inside the analysis pod. On a deployment whose certificates chain to a private CA, that call fails:

```
failed to get the token from Keycloak: Post "https://keycloak.../protocol/openid-connect/token":
tls: failed to verify certificate: x509: certificate signed by unknown authority
```

The browser's trust in the certificate is irrelevant here, and there was no way to fix it from configuration. The sidecar mounts only the permissions volume, and nothing in its spec could name a CA — the ~20 DE services get theirs from templated manifests, but an analysis pod's spec is built here.

## Change

New `--ca-bundle-configmap` / `--ca-bundle-key` flags on vice-operator, threaded through `OperatorOptions` → `viceBuildConfig()` → `vicebuild.Config`. When set, `podVolumes` adds a ConfigMap volume and `viceProxyContainer` adds a read-only mount at `/etc/de-ca` plus `SSL_CERT_FILE`.

vice-proxy itself needs no change: it is a `CGO_ENABLED=0` Go binary that never sets its own `tls.Config.RootCAs`, so `crypto/x509` reads `SSL_CERT_FILE` on its own. The mount path matches what the DE services already use.

The ConfigMap must live in `--namespace`, which is where analyses already run — on a DE deployment the CA is published to both the DE and VICE namespaces already, so there is nothing new to create.

## Compatibility

Empty is the default, and it adds no volume, no mount and no variable — the pod spec is byte-identical for any cluster using publicly trusted certificates. That is why `incluster/golden_equivalence_test.go` passes untouched rather than needing new expectations.

## Testing

`TestViceProxyCABundle` is table-driven over unset / default key / explicit key, asserting the volume, the mount and the env var appear together or not at all.

Verified end to end on a local single-node cluster with a private CA: CloudShell launched, the full browser OAuth flow completed against the analysis URL, and the final response was the app's own HTML. Sidecar logs went from the x509 failure above to:

```
level=info msg="authenticated user: local-admin"
level=info msg="proxying request to http://localhost:7681/"
```

## Note for reviewers

The diff includes a reindent of the pod spec in `vicebuild/deployments.go`, which has not been gofmt-clean since 59cedd1. It is whitespace only — `git diff -w` shows nothing in that region.

The deployment side (passing the flags from `vice_operator_ca_bundle_configmap`) is a separate change in the deployments repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)