### PR TITLE
Merge timelord into app-exposer as the expiration worker

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,9 +125,13 @@ Every package does `var log = common.Log`. Caller reporting is on. Level is set 
   Never compare one against `now()` and never convert one with
   `current_setting('TimeZone')`: both resolve the value in the session zone
   (usually `Etc/UTC`), which on a US deployment terminates analyses hours early.
-  Pass a Go cutoff cast with `::timestamp` and relabel values read back — see
-  `db/timestamps.go`. `incluster/incluster.go`'s time-limit SQL still has the
-  older, broken form.
+  Pass a Go cutoff cast with `::timestamp` and relabel values read back with
+  `db.InLocalZone` — see `db/timestamps.go`. That helper is the one canonical
+  rule; don't write a second conversion.
+- **The expiration sweep's one unguarded action was `markCompleted`.** It now
+  checks `db.HasCompletedStatus` first, because the analysis only stops being
+  returned as expired once the DE acts on that status — and when the DE doesn't,
+  an unguarded publish is unbounded.
 - **The expiration worker runs in every replica.** Anything that must happen once
   per analysis takes the `notif_statuses` row with `FOR UPDATE SKIP LOCKED`
   (`db.ClaimNotifStatuses`) rather than read-then-write.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,8 +81,16 @@ Loaded via **koanf**, not a typed struct. Sources in order: file (`/etc/de/app-e
 - Template with all keys: `configs/default.yml`
 - Access pattern: `cfg.String("k8s.frontend.base")`, `cfg.Bool(...)`, etc. There is no compile-time check that a key exists, so typos are runtime errors.
 - The expiration worker adds `amqp.*`, `iplant_groups.*`, and
-  `notification_agent.base`. `iplant_groups.user` is required (startup fails
-  without it); an empty `amqp.uri` disables only the runtime backfill.
+  `notification_agent.base`. None of them can stop the worker: a missing
+  `iplant_groups.user` costs notifications their email address, an unusable
+  `iplant_groups.base` or `notification_agent.base` swaps in
+  `notifications.Disabled`, and an empty `amqp.uri` disables the runtime
+  backfill. Time-limit enforcement keeps running in every case — each of these
+  logs at error level instead.
+- `TZ` is load-bearing, not cosmetic: it decides the zone the DE's naive
+  analysis timestamps are read in. Unset, Go resolves it to UTC and every
+  analysis on a US deployment expires hours early. The worker logs the zone it
+  resolved at startup (`db.LocalZone`).
 - Kubeconfig: `~/.kube/config` by default; setting the `CLUSTER` env var switches to in-cluster config.
 - Important namespace flags: `--namespace` (default `default`, used for outcluster resources) and `--vice-namespace` (default `vice-apps`, where VICE pods run).
 - Local-dev TLS certs and a sample service listing live in `local-config/`.
@@ -135,6 +143,22 @@ Every package does `var log = common.Log`. Caller reporting is on. Level is set 
 - **The expiration worker runs in every replica.** Anything that must happen once
   per analysis takes the `notif_statuses` row with `FOR UPDATE SKIP LOCKED`
   (`db.ClaimNotifStatuses`) rather than read-then-write.
+- **The sweep terminates first and notifies second, under a budget.** Delivery
+  blocks on an HTTP POST while holding a row lock, so notifications are capped at
+  `DefaultNotificationBudget` per sweep and never sit between an expired analysis
+  and its termination. Retries are paced by `expiration/retry.go`:
+  `MaxNotificationAttempts` counts spaced attempts, so it measures hours rather
+  than the sweep interval. Anything that shortens the pacing has to shrink the
+  ceiling with it.
+- **The expiry warning windows are disjoint** (`(0, 1h]` and `(1h, 24h]`) and the
+  already-warned filter lives in SQL. Nesting them sends both warnings — the text
+  is identical — to any analysis whose time limit is under a day; dropping the
+  filter re-locks every warned analysis's row on every sweep, on every replica.
+- **vice-operator runs one replica per cluster.** Its save-and-exit dedup
+  (`saveAndExitInFlight`) is per-process, and duplicate requests arrive over the
+  operator's Service, so scaling it out needs a cluster-wide claim first — two
+  replicas would delete an analysis's resources while the other is still
+  uploading its outputs.
 - **Two Swagger doc trees**: `docs/` for app-exposer, `operatordocs/` for vice-operator (instance name `operator`); regenerate with `just docs` / `just operator-docs`.
 - **`outcluster/` is legacy HTCondor support** — avoid modernizing it unless the task asks.
 - **Files over ~300 lines** should be split by entity/feature (`launch.go`, `exit.go`, …) — follow the existing pattern in `httphandlers/`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,9 +120,14 @@ Every package does `var log = common.Log`. Caller reporting is on. Level is set 
   consumer only backfills them and logs at warn level when it has to. Always
   derive a subdomain with `common.Subdomain` — a second implementation that
   drifts makes analyses unroutable.
-- **Both timestamps are naive `timestamp` columns holding local wall-clock
-  time.** Read them through `AT TIME ZONE current_setting('TimeZone')`; reading
-  them raw shifts every duration by the local UTC offset.
+- **The analysis timestamps are naive `timestamp` columns holding wall-clock
+  time in the deployment's zone**, which is *not* the database session's zone.
+  Never compare one against `now()` and never convert one with
+  `current_setting('TimeZone')`: both resolve the value in the session zone
+  (usually `Etc/UTC`), which on a US deployment terminates analyses hours early.
+  Pass a Go cutoff cast with `::timestamp` and relabel values read back — see
+  `db/timestamps.go`. `incluster/incluster.go`'s time-limit SQL still has the
+  older, broken form.
 - **The expiration worker runs in every replica.** Anything that must happen once
   per analysis takes the `notif_statuses` row with `FOR UPDATE SKIP LOCKED`
   (`db.ClaimNotifStatuses`) rather than read-then-write.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,12 +39,18 @@ A single Docker image ships both `app-exposer` and `vice-operator`.
 - `batch/` — Argo Workflows job builder
 - `common/` — shared logger, error responses, label helpers, `FixUsername`
 - `constants/` — k8s label/annotation constants
-- `db/` — sqlx-backed DB access (operators table, analyses, …)
+- `db/` — sqlx-backed DB access (operators table, analyses, notif_statuses, …)
+- `expiration/` — background worker enforcing VICE analysis time limits (was the
+  standalone `timelord` service); also consumes `jobs.updates` from AMQP to
+  backfill an analysis's subdomain / planned end date
 - `httphandlers/` — Echo handlers, split per feature (e.g. `launch.go`, `exit.go`)
 - `imageinfo/` — Harbor image-info queries
 - `incluster/` — k8s-native VICE launch logic (Deployments, Services, Ingresses)
 - `instantlaunches/` — quick-launch saved configs
+- `iplantgroups/` — iplant-groups client, used to resolve a user's email address
 - `millicores/` — CPU quantity helpers
+- `notifications/` — notification-agent client for analysis expiry warnings,
+  periodic "still running" reminders, and termination notices
 - `operator/` — vice-operator server-side logic (capacity calc, gateway/loading pages, status informer)
 - `operatorclient/` — HTTP client app-exposer uses to talk to vice-operator
 - `outcluster/` — **legacy** HTCondor path (Services/Endpoints/Ingresses for non-k8s apps); only touch if the task explicitly calls for it
@@ -74,6 +80,9 @@ Loaded via **koanf**, not a typed struct. Sources in order: file (`/etc/de/app-e
 
 - Template with all keys: `configs/default.yml`
 - Access pattern: `cfg.String("k8s.frontend.base")`, `cfg.Bool(...)`, etc. There is no compile-time check that a key exists, so typos are runtime errors.
+- The expiration worker adds `amqp.*`, `iplant_groups.*`, and
+  `notification_agent.base`. `iplant_groups.user` is required (startup fails
+  without it); an empty `amqp.uri` disables only the runtime backfill.
 - Kubeconfig: `~/.kube/config` by default; setting the `CLUSTER` env var switches to in-cluster config.
 - Important namespace flags: `--namespace` (default `default`, used for outcluster resources) and `--vice-namespace` (default `vice-apps`, where VICE pods run).
 - Local-dev TLS certs and a sample service listing live in `local-config/`.
@@ -106,6 +115,17 @@ Every package does `var log = common.Log`. Caller reporting is on. Level is set 
 - **DB calls require a `Tx`** — never operate outside a transaction, and thread `context.Context` end-to-end (use `*Context` variants like `ExecContext`/`QueryRowContext`).
 - **Sanitize DB errors** in HTTP responses (map `sql.ErrNoRows` → 404, others → 500; log the real error server-side).
 - **No CRDs defined here** — vice-operator uses the upstream k8s Gateway API (`sigs.k8s.io/gateway-api`).
+- **`jobs.subdomain` and `jobs.planned_end_date` have one writer**: the VICE
+  launch handler, via `db.InitializeRuntime`. The `expiration` package's AMQP
+  consumer only backfills them and logs at warn level when it has to. Always
+  derive a subdomain with `common.Subdomain` — a second implementation that
+  drifts makes analyses unroutable.
+- **Both timestamps are naive `timestamp` columns holding local wall-clock
+  time.** Read them through `AT TIME ZONE current_setting('TimeZone')`; reading
+  them raw shifts every duration by the local UTC offset.
+- **The expiration worker runs in every replica.** Anything that must happen once
+  per analysis takes the `notif_statuses` row with `FOR UPDATE SKIP LOCKED`
+  (`db.ClaimNotifStatuses`) rather than read-then-write.
 - **Two Swagger doc trees**: `docs/` for app-exposer, `operatordocs/` for vice-operator (instance name `operator`); regenerate with `just docs` / `just operator-docs`.
 - **`outcluster/` is legacy HTCondor support** — avoid modernizing it unless the task asks.
 - **Files over ~300 lines** should be split by entity/feature (`launch.go`, `exit.go`, …) — follow the existing pattern in `httphandlers/`.
@@ -114,6 +134,11 @@ Every package does `var log = common.Log`. Caller reporting is on. Level is set 
 
 - `apps` (Clojure) — app catalog and job submission; calls `POST /vice/launch` and `POST /vice/{uuid}/save-and-exit`.
 - `terrain` (Clojure) — API gateway; calls app-exposer for VICE management.
+- `notification-agent` — receives the analysis notifications the `expiration`
+  worker emits.
+- `iplant-groups` — resolves a username to an email address for those notifications.
+- `job-status-listener` — receives the `Completed` status the expiration worker
+  publishes for analyses that already left every cluster.
 
 ## Pointers
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ### Build stage
-FROM golang:1.25 AS builder
+FROM golang:1.26 AS builder
 
 WORKDIR /build
 

--- a/Justfile
+++ b/Justfile
@@ -94,6 +94,18 @@ test-imageinfo:
 test-common:
     go test ./common
 
+test-db:
+    go test ./db/...
+
+test-expiration:
+    go test ./expiration/...
+
+test-iplantgroups:
+    go test ./iplantgroups/...
+
+test-notifications:
+    go test ./notifications/...
+
 test-operator:
     go test ./operator/...
 
@@ -127,7 +139,7 @@ test-vice-bundle:
 test-vice-userid:
     go test ./cmd/vice-userid/...
 
-test: test-imageinfo test-common test-operator test-operatorclient test-app-exposer test-vice-operator test-vice-operator-tool test-vice-export test-vice-import test-vice-launch test-vice-list test-vice-bundle test-vice-userid
+test: test-imageinfo test-common test-db test-expiration test-iplantgroups test-notifications test-operator test-operatorclient test-app-exposer test-vice-operator test-vice-operator-tool test-vice-export test-vice-import test-vice-launch test-vice-list test-vice-bundle test-vice-userid
 
 fmt-docs:
     swag fmt -g app.go -d cmd/app-exposer/,httphandlers/,common/,incluster/

--- a/README.md
+++ b/README.md
@@ -86,6 +86,45 @@ For configuration, use `example-config.yml` as a reference. You'll need to eithe
 
 Disables authentication in the vice-proxy sidecar containers for VICE applications. When set to `true`, the `--disable-auth` flag is passed to vice-proxy, allowing unauthenticated access to VICE applications. This is intended for development, testing, or scenarios where authentication is handled elsewhere. In production environments, this should remain `false` (the default) to enforce authentication via Keycloak.
 
+### Analysis Expiration
+
+`--expiration-sweep-interval` (default: `10s`)
+
+How often the background worker checks running analyses for expiry warnings and
+terminations. This bounds how late either can be.
+
+`--expiry-warning` (default: `1h`)
+
+How far ahead of an analysis's planned end date to send the short-notice expiry
+warning. The day-ahead warning is fixed at 24h.
+
+## Analysis expiration and notifications
+
+app-exposer enforces the time limits on VICE analyses. A background worker
+(`expiration/`) sweeps the running analyses and:
+
+- warns the owner a day and an hour before the analysis's planned end date,
+- sends a periodic "still running" reminder (default every 4h, overridable per
+  analysis via the submission's `periodic_period`),
+- asks the owning operator to save outputs and exit once the planned end date
+  passes, then tells the owner it was terminated,
+- marks an expired analysis `Completed` if it is no longer running in any
+  cluster.
+
+This work was previously the standalone `timelord` service. It needs
+`notification_agent.base`, `iplant_groups.base`, `iplant_groups.user`, and
+`amqp.*` in the config file.
+
+The worker runs in every app-exposer replica. Each notification is sent exactly
+once by claiming the analysis's `notif_statuses` row with `FOR UPDATE SKIP
+LOCKED`, so replicas never duplicate a user's email.
+
+The VICE launch handler is the canonical writer of `jobs.subdomain` and
+`jobs.planned_end_date`. The worker's AMQP consumer watches `jobs.updates` and
+backfills those columns for any interactive analysis that reaches `Running`
+without them, logging at warn level whenever it has to — in steady state it
+should never fire.
+
 ## Regenerating the Swagger docs
 
 Both `app-exposer` and `vice-operator` ship Swagger 2.0 docs generated from godoc-style annotations on the handler source. The generators are invoked via the Justfile so the source-file list and any non-default `swag` flags stay in one place:

--- a/cmd/app-exposer/app.go
+++ b/cmd/app-exposer/app.go
@@ -71,10 +71,7 @@ type ExposerAppInit struct {
 //
 // NewExposerApp creates and returns a newly instantiated *ExposerApp.
 func NewExposerApp(init *ExposerAppInit, apps *apps.Apps, c *koanf.Koanf) *ExposerApp {
-	jobStatusURL := c.String("vice.job-status.base")
-	if jobStatusURL == "" {
-		jobStatusURL = "http://job-status-listener"
-	}
+	jobStatusURL := jobStatusBase(c)
 
 	metadataBaseURL := c.String("metadata.base")
 	if metadataBaseURL == "" {

--- a/cmd/app-exposer/expiration.go
+++ b/cmd/app-exposer/expiration.go
@@ -29,9 +29,10 @@ func jobStatusBase(c *koanf.Koanf) string {
 }
 
 // startExpirationWorker builds and starts the analysis expiration worker along
-// with the runtime backfill that feeds it. Configuration problems here are
-// fatal: without them the DE would silently stop enforcing analysis time
-// limits, which is worse than failing to start.
+// with the runtime backfill that feeds it. Missing configuration degrades the
+// worker rather than stopping the process: this is secondary to app-exposer's
+// API, and taking VICE launches down over a notification setting trades a small
+// problem for a much larger one.
 func startExpirationWorker(
 	ctx context.Context,
 	c *koanf.Koanf,
@@ -47,12 +48,14 @@ func startExpirationWorker(
 
 	groupsUser := c.String("iplant_groups.user")
 	if groupsUser == "" {
-		log.Fatal("iplant_groups.user must be set in the config file; iplant-groups rejects subject lookups without it, which would leave every analysis notification without an email address")
+		log.Warn("iplant_groups.user is not set in the config file; iplant-groups rejects subject lookups without it, " +
+			"so analysis notifications will reach the DE UI but carry no email address")
 	}
 
 	subjects, err := iplantgroups.New(groupsBase, groupsUser)
 	if err != nil {
-		log.Fatal(err)
+		log.Errorf("building the iplant-groups client, so analysis time limits will not be enforced: %v", err)
+		return
 	}
 
 	notificationAgentBase := c.String("notification_agent.base")
@@ -62,7 +65,8 @@ func startExpirationWorker(
 
 	notifier, err := notifications.New(notificationAgentBase, c.String("k8s.frontend.base"), subjects)
 	if err != nil {
-		log.Fatal(err)
+		log.Errorf("building the notification client, so analysis time limits will not be enforced: %v", err)
+		return
 	}
 
 	worker := expiration.New(

--- a/cmd/app-exposer/expiration.go
+++ b/cmd/app-exposer/expiration.go
@@ -41,37 +41,9 @@ func startExpirationWorker(
 	jobStatusURL string,
 	sweepInterval, expiryWarning time.Duration,
 ) {
-	groupsBase := c.String("iplant_groups.base")
-	if groupsBase == "" {
-		groupsBase = "http://iplant-groups"
-	}
-
-	groupsUser := c.String("iplant_groups.user")
-	if groupsUser == "" {
-		log.Warn("iplant_groups.user is not set in the config file; iplant-groups rejects subject lookups without it, " +
-			"so analysis notifications will reach the DE UI but carry no email address")
-	}
-
-	subjects, err := iplantgroups.New(groupsBase, groupsUser)
-	if err != nil {
-		log.Errorf("building the iplant-groups client, so analysis time limits will not be enforced: %v", err)
-		return
-	}
-
-	notificationAgentBase := c.String("notification_agent.base")
-	if notificationAgentBase == "" {
-		notificationAgentBase = "http://notification-agent"
-	}
-
-	notifier, err := notifications.New(notificationAgentBase, c.String("k8s.frontend.base"), subjects)
-	if err != nil {
-		log.Errorf("building the notification client, so analysis time limits will not be enforced: %v", err)
-		return
-	}
-
 	worker := expiration.New(
 		dbase,
-		notifier,
+		buildNotifier(c),
 		scheduler,
 		incluster.NewJSLPublisher(jobStatusURL),
 		expiration.Init{
@@ -82,6 +54,46 @@ func startExpirationWorker(
 	go worker.Run(ctx)
 
 	startRuntimeBackfill(ctx, c, dbase)
+}
+
+// buildNotifier builds the client the expiration worker notifies users through,
+// falling back to a notifier that drops what it is given when the deployment's
+// notification settings cannot produce a working one.
+//
+// Notifications are the part of this worker the DE can do without; terminating
+// analyses at their time limit is not. Returning no worker at all over a
+// malformed URL would leave every VICE analysis running past its limit, so the
+// failure is confined to what actually depends on the setting.
+func buildNotifier(c *koanf.Koanf) notifications.AnalysisNotifier {
+	groupsBase := c.String("iplant_groups.base")
+	if groupsBase == "" {
+		groupsBase = "http://iplant-groups"
+	}
+
+	groupsUser := c.String("iplant_groups.user")
+	if groupsUser == "" {
+		log.Error("iplant_groups.user is not set in the config file; iplant-groups rejects subject lookups without it, " +
+			"so analysis notifications will reach the DE UI but carry no email address")
+	}
+
+	subjects, err := iplantgroups.New(groupsBase, groupsUser)
+	if err != nil {
+		log.Errorf("building the iplant-groups client, so analysis notifications are disabled: %v", err)
+		return notifications.Disabled{}
+	}
+
+	notificationAgentBase := c.String("notification_agent.base")
+	if notificationAgentBase == "" {
+		notificationAgentBase = "http://notification-agent"
+	}
+
+	notifier, err := notifications.New(notificationAgentBase, c.String("k8s.frontend.base"), subjects)
+	if err != nil {
+		log.Errorf("building the notification client, so analysis notifications are disabled: %v", err)
+		return notifications.Disabled{}
+	}
+
+	return notifier
 }
 
 // startRuntimeBackfill subscribes to the DE's job status updates so that any

--- a/cmd/app-exposer/expiration.go
+++ b/cmd/app-exposer/expiration.go
@@ -1,0 +1,139 @@
+package main
+
+import (
+	"context"
+	"time"
+
+	"github.com/cyverse-de/app-exposer/db"
+	"github.com/cyverse-de/app-exposer/expiration"
+	"github.com/cyverse-de/app-exposer/incluster"
+	"github.com/cyverse-de/app-exposer/iplantgroups"
+	"github.com/cyverse-de/app-exposer/notifications"
+	"github.com/cyverse-de/app-exposer/operatorclient"
+	"github.com/cyverse-de/messaging/v12"
+	"github.com/knadh/koanf"
+)
+
+// backfillPrefetch is how many job status updates the runtime backfill will
+// hold unacknowledged. Matches the prefetch the DE's other status consumers use.
+const backfillPrefetch = 100
+
+// jobStatusBase returns the job-status-listener base URL, defaulting to the
+// in-cluster service name. Shared by the launch path and the expiration worker
+// so both publish analysis status to the same place.
+func jobStatusBase(c *koanf.Koanf) string {
+	if base := c.String("vice.job-status.base"); base != "" {
+		return base
+	}
+	return "http://job-status-listener"
+}
+
+// startExpirationWorker builds and starts the analysis expiration worker along
+// with the runtime backfill that feeds it. Configuration problems here are
+// fatal: without them the DE would silently stop enforcing analysis time
+// limits, which is worse than failing to start.
+func startExpirationWorker(
+	ctx context.Context,
+	c *koanf.Koanf,
+	dbase *db.Database,
+	scheduler *operatorclient.Scheduler,
+	jobStatusURL string,
+	sweepInterval, expiryWarning time.Duration,
+) {
+	groupsBase := c.String("iplant_groups.base")
+	if groupsBase == "" {
+		groupsBase = "http://iplant-groups"
+	}
+
+	groupsUser := c.String("iplant_groups.user")
+	if groupsUser == "" {
+		log.Fatal("iplant_groups.user must be set in the config file; iplant-groups rejects subject lookups without it, which would leave every analysis notification without an email address")
+	}
+
+	subjects, err := iplantgroups.New(groupsBase, groupsUser)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	notificationAgentBase := c.String("notification_agent.base")
+	if notificationAgentBase == "" {
+		notificationAgentBase = "http://notification-agent"
+	}
+
+	notifier, err := notifications.New(notificationAgentBase, c.String("k8s.frontend.base"), subjects)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	worker := expiration.New(
+		dbase,
+		notifier,
+		scheduler,
+		incluster.NewJSLPublisher(jobStatusURL),
+		expiration.Init{
+			SweepInterval: sweepInterval,
+			ExpiryWarning: expiryWarning,
+		},
+	)
+	go worker.Run(ctx)
+
+	startRuntimeBackfill(ctx, c, dbase)
+}
+
+// startRuntimeBackfill subscribes to the DE's job status updates so that any
+// interactive analysis reaching Running without a subdomain or planned end date
+// gets one. The VICE launch handler is the canonical writer of both; this is the
+// safety net for analyses that miss that write.
+func startRuntimeBackfill(ctx context.Context, c *koanf.Koanf, dbase *db.Database) {
+	amqpURI := c.String("amqp.uri")
+	if amqpURI == "" {
+		log.Warn("amqp.uri is not set, so the analysis runtime backfill is disabled; " +
+			"the VICE launch handler still sets the subdomain and planned end date, but " +
+			"analyses that miss that write will not be repaired")
+		return
+	}
+
+	exchange := c.String("amqp.exchange.name")
+	if exchange == "" {
+		exchange = "de"
+	}
+
+	exchangeType := c.String("amqp.exchange.type")
+	if exchangeType == "" {
+		exchangeType = "topic"
+	}
+
+	backfill := expiration.NewRuntimeBackfill(dbase)
+
+	// Connect in the background: with reconnect enabled, messaging.NewClient
+	// blocks until the broker answers, and app-exposer's HTTP API has to come up
+	// whether or not RabbitMQ is reachable.
+	go func() {
+		client, err := messaging.NewClient(amqpURI, true)
+		if err != nil {
+			log.Errorf("connecting to the AMQP broker for the analysis runtime backfill: %v", err)
+			return
+		}
+		defer client.Close()
+
+		// Listen has to be running before AddConsumer: AddConsumer hands the
+		// consumer to Listen's goroutine and blocks until it is registered.
+		go client.Listen()
+
+		client.AddConsumer(
+			exchange,
+			exchangeType,
+			expiration.QueueName,
+			messaging.UpdatesKey,
+			backfill.MessageHandler(),
+			backfillPrefetch,
+		)
+
+		log.Infof(
+			"consuming %s from exchange %s on queue %s for the analysis runtime backfill",
+			messaging.UpdatesKey, exchange, expiration.QueueName,
+		)
+
+		<-ctx.Done()
+	}()
+}

--- a/cmd/app-exposer/main.go
+++ b/cmd/app-exposer/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cyverse-de/app-exposer/apps"
 	"github.com/cyverse-de/app-exposer/common"
 	"github.com/cyverse-de/app-exposer/db"
+	"github.com/cyverse-de/app-exposer/expiration"
 	"github.com/cyverse-de/app-exposer/httphandlers"
 	"github.com/cyverse-de/app-exposer/imageinfo"
 	"github.com/cyverse-de/app-exposer/millicores"
@@ -106,6 +107,8 @@ func main() {
 		batchExitHandlerImage                = flag.String("batch-exit-handler-image", "harbor.cyverse.org/de/batch-exit-handler:latest", "The image to use for the exitHandler in batch workflows")
 		clusterConfigSecret                  = flag.String("cluster-config-secret", "cluster-config-secret", "Name of a Secret to inject as env vars into the vice-proxy container via envFrom. Used to provide cluster-specific config for multi-cluster deployments.")
 		maxConcurrentLaunches                = flag.Int("max-concurrent-launches", httphandlers.DefaultMaxConcurrentLaunches, "Upper bound on in-flight VICE launches per app-exposer instance; bursts beyond this return 503 so clients can back off.")
+		expirationSweepInterval              = flag.Duration("expiration-sweep-interval", expiration.DefaultSweepInterval, "How often to check running analyses for expiry warnings and terminations.")
+		expiryWarning                        = flag.Duration("expiry-warning", expiration.DefaultExpiryWarning, "How far ahead of an analysis's planned end date to send the short-notice expiry warning.")
 	)
 
 	var tracerCtx, cancel = context.WithCancel(context.Background())
@@ -390,6 +393,11 @@ func main() {
 	// Initialize and start the status reconciliation worker.
 	reconciler := reconciler.New(dbase, app.handlers.GetScheduler(), tokenSource)
 	go reconciler.Run(context.Background())
+
+	// Initialize and start the analysis expiration worker, which warns users
+	// about analyses nearing their time limit and terminates the ones that pass
+	// it. This ran as the standalone `timelord` service before it moved here.
+	startExpirationWorker(context.Background(), c, dbase, app.handlers.GetScheduler(), jobStatusBase(c), *expirationSweepInterval, *expiryWarning)
 
 	log.Printf("listening on port %d", *listenPort)
 	log.Fatal(http.ListenAndServe(fmt.Sprintf(":%d", *listenPort), app.router))

--- a/configs/default.yml
+++ b/configs/default.yml
@@ -1,3 +1,9 @@
+amqp:
+  uri: amqp://username:password@host:5672/vhost
+  exchange:
+    name: de
+    type: topic
+
 apps:
   base: "http://localhost:31323"
 
@@ -7,6 +13,10 @@ db:
 interapps:
   proxy:
     tag: latest
+
+iplant_groups:
+  base: "http://iplant-groups"
+  user: de_grouper
 
 irods:
   zone: "cyverse"
@@ -23,6 +33,9 @@ keycloak:
 
 metadata:
   base: "http://metadata"
+
+notification_agent:
+  base: "http://notification-agent"
 
 path_list:
   file_identifier: "# application/vnd.de.multi-input-path-list+csv; version=1"

--- a/db/expiration.go
+++ b/db/expiration.go
@@ -13,11 +13,9 @@ import (
 // has reached its time limit and to describe it in a user notification.
 //
 // StartDate and PlannedEndDate are nullable: an analysis that has not started,
-// or whose planned end date has not been set yet, leaves them nil. Both are
-// selected through AT TIME ZONE current_setting('TimeZone') so the naive
-// `timestamp` columns arrive as the absolute instants they were written as —
-// the columns hold local wall-clock time, so reading them without the
-// conversion would silently shift every duration by the local UTC offset.
+// or whose planned end date has not been set yet, leaves them nil. Both come
+// from naive `timestamp` columns and are only correct instants once
+// localizeTimestamps has run — see db/timestamps.go.
 type Analysis struct {
 	ID             constants.AnalysisID `db:"id"`
 	AppID          string               `db:"app_id"`
@@ -50,8 +48,8 @@ const analysisColumns = `
 	       jobs.job_description,
 	       jobs.job_name,
 	       jobs.result_folder_path,
-	       jobs.start_date AT TIME ZONE current_setting('TimeZone') AS start_date,
-	       jobs.planned_end_date AT TIME ZONE current_setting('TimeZone') AS planned_end_date,
+	       jobs.start_date,
+	       jobs.planned_end_date,
 	       COALESCE(jobs.subdomain, '') AS subdomain,
 	       job_types.system_id,
 	       users.username,
@@ -71,30 +69,80 @@ const analysisColumns = `
 // running analyses are candidates for expiry warnings or termination.
 const runningStatus = "Running"
 
+// localizeTimestamps relabels the analysis's naive timestamps into the zone the
+// DE wrote them in, which is what makes every duration derived from them — the
+// termination grace period, the reminder pacing, the times in the notification
+// emails — measure the interval the user actually sees.
+func (a *Analysis) localizeTimestamps() {
+	a.StartDate = inLocalZone(a.StartDate)
+	a.PlannedEndDate = inLocalZone(a.PlannedEndDate)
+}
+
+// selectAnalyses runs one of the analysisColumns queries. Every multi-row
+// Analysis query goes through it so that none can return timestamps that have
+// not been relabeled.
+func (d *Database) selectAnalyses(ctx context.Context, query string, args ...any) ([]Analysis, error) {
+	analyses := []Analysis{}
+	if err := d.db.SelectContext(ctx, &analyses, query, args...); err != nil {
+		return nil, err
+	}
+
+	for i := range analyses {
+		analyses[i].localizeTimestamps()
+	}
+
+	return analyses, nil
+}
+
+// The statements that compare or write one of the naive timestamp columns are
+// package-level so the contract in db/timestamps.go can be asserted against them
+// directly — the bug they guard against is invisible at the Go type level and
+// only shows up as analyses terminating hours early.
+const (
+	expiredAnalysesQuery = analysisColumns + `
+		 WHERE jobs.status = $1
+		   AND jobs.planned_end_date <= $2::timestamp
+	`
+
+	expiringWithinQuery = analysisColumns + `
+		 WHERE jobs.status = $1
+		   AND jobs.planned_end_date > $2::timestamp
+		   AND jobs.planned_end_date <= $3::timestamp
+	`
+
+	periodicReminderQuery = analysisColumns + `
+		  LEFT JOIN notif_statuses ON jobs.id = notif_statuses.analysis_id
+		 WHERE jobs.status = $1
+		   AND jobs.start_date IS NOT NULL
+		   AND jobs.planned_end_date > $2::timestamp
+		   AND GREATEST(jobs.start_date, notif_statuses.last_periodic_warning) <
+		       $2::timestamp - COALESCE(notif_statuses.periodic_warning_period, '4 hours'::interval)
+	`
+
+	initialRuntimeStmt = `
+		UPDATE ONLY jobs
+		   SET planned_end_date = COALESCE(
+		           planned_end_date,
+		           COALESCE(start_date, $4::timestamp) + make_interval(secs => $3)
+		       ),
+		       subdomain = COALESCE(NULLIF(subdomain, ''), $2)
+		 WHERE id = $1
+		   AND (planned_end_date IS NULL OR subdomain IS NULL OR subdomain = '')
+	`
+)
+
 // ListExpiredAnalyses returns the running analyses whose planned end date has
 // passed and which are therefore due for termination.
 func (d *Database) ListExpiredAnalyses(ctx context.Context) ([]Analysis, error) {
-	const query = analysisColumns + `
-		 WHERE jobs.status = $1
-		   AND jobs.planned_end_date <= now()
-	`
-	analyses := []Analysis{}
-	err := d.db.SelectContext(ctx, &analyses, query, runningStatus)
-	return analyses, err
+	return d.selectAnalyses(ctx, expiredAnalysesQuery, runningStatus, time.Now())
 }
 
 // ListAnalysesExpiringWithin returns the running analyses whose planned end
 // date falls between now and the given window — the candidates for an advance
 // "your analysis will terminate" warning.
 func (d *Database) ListAnalysesExpiringWithin(ctx context.Context, window time.Duration) ([]Analysis, error) {
-	const query = analysisColumns + `
-		 WHERE jobs.status = $1
-		   AND jobs.planned_end_date > now()
-		   AND jobs.planned_end_date <= now() + make_interval(secs => $2)
-	`
-	analyses := []Analysis{}
-	err := d.db.SelectContext(ctx, &analyses, query, runningStatus, window.Seconds())
-	return analyses, err
+	now := time.Now()
+	return d.selectAnalyses(ctx, expiringWithinQuery, runningStatus, now, now.Add(window))
 }
 
 // ListAnalysesDueForPeriodicReminder returns the running analyses that have not
@@ -108,17 +156,7 @@ func (d *Database) ListAnalysesExpiringWithin(ctx context.Context, window time.D
 // records nothing to stop it happening again ten seconds later. GREATEST
 // ignores NULLs in Postgres, so it doubles as the has-no-reminder-yet case.
 func (d *Database) ListAnalysesDueForPeriodicReminder(ctx context.Context) ([]Analysis, error) {
-	const query = analysisColumns + `
-		  LEFT JOIN notif_statuses ON jobs.id = notif_statuses.analysis_id
-		 WHERE jobs.status = $1
-		   AND jobs.start_date IS NOT NULL
-		   AND jobs.planned_end_date > now()
-		   AND GREATEST(jobs.start_date, notif_statuses.last_periodic_warning) <
-		       now() - COALESCE(notif_statuses.periodic_warning_period, '4 hours'::interval)
-	`
-	analyses := []Analysis{}
-	err := d.db.SelectContext(ctx, &analyses, query, runningStatus)
-	return analyses, err
+	return d.selectAnalyses(ctx, periodicReminderQuery, runningStatus, time.Now())
 }
 
 // interactiveAnalysis is the predicate identifying an analysis with a VICE
@@ -147,9 +185,7 @@ func (d *Database) ListAnalysesMissingRuntime(ctx context.Context) ([]Analysis, 
 		 WHERE jobs.status = $1
 		   AND (jobs.planned_end_date IS NULL OR COALESCE(jobs.subdomain, '') = '')
 		   AND ` + interactiveAnalysis
-	analyses := []Analysis{}
-	err := d.db.SelectContext(ctx, &analyses, query, runningStatus)
-	return analyses, err
+	return d.selectAnalyses(ctx, query, runningStatus)
 }
 
 // GetAnalysisByExternalID returns the analysis owning the given external ID, or
@@ -165,6 +201,7 @@ func (d *Database) GetAnalysisByExternalID(ctx context.Context, externalID const
 	if err := d.db.GetContext(ctx, &analysis, query, externalID); err != nil {
 		return nil, err
 	}
+	analysis.localizeTimestamps()
 	return &analysis, nil
 }
 
@@ -220,17 +257,7 @@ func (d *Database) GetTimeLimitSeconds(ctx context.Context, analysisID constants
 // granted. Returns whether the statement changed anything, so callers can log
 // when the launch-time write had to be backfilled later.
 func (d *Database) SetInitialRuntime(ctx context.Context, analysisID constants.AnalysisID, subdomain string, timeLimitSeconds int64) (bool, error) {
-	const stmt = `
-		UPDATE ONLY jobs
-		   SET planned_end_date = COALESCE(
-		           planned_end_date,
-		           COALESCE(start_date, now()::timestamp) + make_interval(secs => $3)
-		       ),
-		       subdomain = COALESCE(NULLIF(subdomain, ''), $2)
-		 WHERE id = $1
-		   AND (planned_end_date IS NULL OR subdomain IS NULL OR subdomain = '')
-	`
-	result, err := d.db.ExecContext(ctx, stmt, analysisID, subdomain, timeLimitSeconds)
+	result, err := d.db.ExecContext(ctx, initialRuntimeStmt, analysisID, subdomain, timeLimitSeconds, time.Now())
 	if err != nil {
 		return false, err
 	}

--- a/db/expiration.go
+++ b/db/expiration.go
@@ -98,18 +98,55 @@ func (d *Database) ListAnalysesExpiringWithin(ctx context.Context, window time.D
 }
 
 // ListAnalysesDueForPeriodicReminder returns the running analyses that have not
-// yet expired and whose last periodic reminder is older than their configured
-// reminder period. Analyses with no notif_statuses row yet are included: their
-// first reminder is due immediately.
+// yet expired and whose reminder period has elapsed.
+//
+// The period is measured from the analysis's last reminder, or from its start
+// date when it has had none, which is what keeps a freshly launched analysis
+// from being reminded immediately. That pacing has to match the worker's
+// reminderDue check: an analysis returned here but not yet due costs a
+// tracking-row insert and a row lock on every sweep, on every replica, and
+// records nothing to stop it happening again ten seconds later. GREATEST
+// ignores NULLs in Postgres, so it doubles as the has-no-reminder-yet case.
 func (d *Database) ListAnalysesDueForPeriodicReminder(ctx context.Context) ([]Analysis, error) {
 	const query = analysisColumns + `
 		  LEFT JOIN notif_statuses ON jobs.id = notif_statuses.analysis_id
 		 WHERE jobs.status = $1
+		   AND jobs.start_date IS NOT NULL
 		   AND jobs.planned_end_date > now()
-		   AND (notif_statuses.last_periodic_warning IS NULL
-		    OR notif_statuses.last_periodic_warning <
-		       now() - COALESCE(notif_statuses.periodic_warning_period, '4 hours'::interval))
+		   AND GREATEST(jobs.start_date, notif_statuses.last_periodic_warning) <
+		       now() - COALESCE(notif_statuses.periodic_warning_period, '4 hours'::interval)
 	`
+	analyses := []Analysis{}
+	err := d.db.SelectContext(ctx, &analyses, query, runningStatus)
+	return analyses, err
+}
+
+// interactiveAnalysis is the predicate identifying an analysis with a VICE
+// step, written against jobs.id so the queries that must exclude batch analyses
+// and IsInteractive share one definition of "interactive".
+const interactiveAnalysis = `
+	EXISTS (SELECT 1
+	          FROM job_steps js
+	          JOIN job_types jt ON js.job_type_id = jt.id
+	         WHERE js.job_id = jobs.id
+	           AND jt.name = 'Interactive')
+`
+
+// ListAnalysesMissingRuntime returns the running VICE analyses that reached
+// Running without a subdomain or a planned end date.
+//
+// These are the analyses the launch-time write missed. Left alone, one is
+// unroutable — the DE cannot build its access URL without a subdomain — and
+// invisible to ListExpiredAnalyses, since a NULL planned end date never
+// compares true against now(), so it would run until an admin killed it.
+//
+// Batch analyses are excluded: they legitimately have neither field, and
+// without the filter every running HPC job would come back on every sweep.
+func (d *Database) ListAnalysesMissingRuntime(ctx context.Context) ([]Analysis, error) {
+	const query = analysisColumns + `
+		 WHERE jobs.status = $1
+		   AND (jobs.planned_end_date IS NULL OR COALESCE(jobs.subdomain, '') = '')
+		   AND ` + interactiveAnalysis
 	analyses := []Analysis{}
 	err := d.db.SelectContext(ctx, &analyses, query, runningStatus)
 	return analyses, err
@@ -132,14 +169,12 @@ func (d *Database) GetAnalysisByExternalID(ctx context.Context, externalID const
 }
 
 // IsInteractive reports whether any of the analysis's steps is a VICE
-// (Interactive) step.
+// (Interactive) step. An analysis the DE has no record of is not interactive.
 func (d *Database) IsInteractive(ctx context.Context, analysisID constants.AnalysisID) (bool, error) {
 	const query = `
-		SELECT EXISTS (SELECT 1
-		                 FROM job_steps js
-		                 JOIN job_types jt ON js.job_type_id = jt.id
-		                WHERE js.job_id = $1
-		                  AND jt.name = 'Interactive')
+		SELECT COALESCE((SELECT ` + interactiveAnalysis + `
+		                   FROM jobs
+		                  WHERE jobs.id = $1), FALSE)
 	`
 	var interactive bool
 	err := d.db.QueryRowContext(ctx, query, analysisID).Scan(&interactive)

--- a/db/expiration.go
+++ b/db/expiration.go
@@ -107,12 +107,6 @@ const (
 		   AND jobs.planned_end_date <= $2::timestamp
 	`
 
-	expiringWithinQuery = analysisColumns + `
-		 WHERE jobs.status = $1
-		   AND jobs.planned_end_date > $2::timestamp
-		   AND jobs.planned_end_date <= $3::timestamp
-	`
-
 	periodicReminderQuery = analysisColumns + `
 		  LEFT JOIN notif_statuses ON jobs.id = notif_statuses.analysis_id
 		 WHERE jobs.status = $1
@@ -134,18 +128,55 @@ const (
 	`
 )
 
+// expiringWithinQueryFor builds the expiry-warning query for one warning kind.
+// sentColumn comes from expiringWithinQueries below, so the column name is
+// always one of a closed set of constants and is never interpolated from input.
+//
+// The query does the filtering the worker would otherwise do in Go: analyses
+// already warned are excluded here, because one returned to the worker costs a
+// tracking-row insert and a row lock on every sweep, on every replica, and
+// records nothing that would stop it happening again ten seconds later. Analyses
+// with no start date are excluded for a different reason — a notification cannot
+// be rendered without one, so returning them only burns delivery attempts.
+func expiringWithinQueryFor(sentColumn string) string {
+	return analysisColumns + `
+		  LEFT JOIN notif_statuses ON jobs.id = notif_statuses.analysis_id
+		 WHERE jobs.status = $1
+		   AND jobs.start_date IS NOT NULL
+		   AND jobs.planned_end_date > $2::timestamp
+		   AND jobs.planned_end_date <= $3::timestamp
+		   AND COALESCE(notif_statuses.` + sentColumn + `, FALSE) = FALSE
+	`
+}
+
+// expiringWithinQueries holds the expiry-warning query for each warning kind
+// that has an advance window.
+var expiringWithinQueries = map[WarningKind]string{
+	DayWarning:  expiringWithinQueryFor("day_warning_sent"),
+	HourWarning: expiringWithinQueryFor("hour_warning_sent"),
+}
+
 // ListExpiredAnalyses returns the running analyses whose planned end date has
 // passed and which are therefore due for termination.
 func (d *Database) ListExpiredAnalyses(ctx context.Context) ([]Analysis, error) {
 	return d.selectAnalyses(ctx, expiredAnalysesQuery, runningStatus, time.Now())
 }
 
-// ListAnalysesExpiringWithin returns the running analyses whose planned end
-// date falls between now and the given window — the candidates for an advance
-// "your analysis will terminate" warning.
-func (d *Database) ListAnalysesExpiringWithin(ctx context.Context, window time.Duration) ([]Analysis, error) {
+// ListAnalysesExpiringWithin returns the running analyses due the given expiry
+// warning: those whose planned end date falls between now+from and now+to and
+// which have not been warned yet.
+//
+// The window is half-open at the near end so the day and hour warnings cover
+// disjoint ranges. Nesting them would send both notifications, whose text is
+// identical, in the same pass to any analysis whose whole time limit is shorter
+// than the day window.
+func (d *Database) ListAnalysesExpiringWithin(ctx context.Context, kind WarningKind, from, to time.Duration) ([]Analysis, error) {
+	query, ok := expiringWithinQueries[kind]
+	if !ok {
+		return nil, fmt.Errorf("no expiry warning query for warning kind %q", kind)
+	}
 	now := time.Now()
-	return d.selectAnalyses(ctx, expiringWithinQuery, runningStatus, now, now.Add(window))
+	return d.selectAnalyses(ctx, query, runningStatus, now.Add(from), now.Add(to))
 }
 
 // ListAnalysesDueForPeriodicReminder returns the running analyses that have not

--- a/db/expiration.go
+++ b/db/expiration.go
@@ -2,11 +2,14 @@ package db
 
 import (
 	"context"
+	"database/sql"
+	"errors"
 	"fmt"
 	"time"
 
 	"github.com/cyverse-de/app-exposer/common"
 	"github.com/cyverse-de/app-exposer/constants"
+	"github.com/cyverse-de/messaging/v12"
 )
 
 // Analysis carries the jobs-table fields needed to decide whether an analysis
@@ -74,8 +77,8 @@ const runningStatus = "Running"
 // termination grace period, the reminder pacing, the times in the notification
 // emails — measure the interval the user actually sees.
 func (a *Analysis) localizeTimestamps() {
-	a.StartDate = inLocalZone(a.StartDate)
-	a.PlannedEndDate = inLocalZone(a.PlannedEndDate)
+	a.StartDate = InLocalZone(a.StartDate)
+	a.PlannedEndDate = InLocalZone(a.PlannedEndDate)
 }
 
 // selectAnalyses runs one of the analysisColumns queries. Every multi-row
@@ -157,6 +160,37 @@ func (d *Database) ListAnalysesExpiringWithin(ctx context.Context, window time.D
 // ignores NULLs in Postgres, so it doubles as the has-no-reminder-yet case.
 func (d *Database) ListAnalysesDueForPeriodicReminder(ctx context.Context) ([]Analysis, error) {
 	return d.selectAnalyses(ctx, periodicReminderQuery, runningStatus, time.Now())
+}
+
+// HasCompletedStatus reports whether a Completed status has already been
+// recorded for the given external ID.
+//
+// The expiration worker uses this to avoid re-publishing a Completed status it
+// has already sent. It reads job_status_updates rather than jobs.status on
+// purpose: the jobs row is updated by a separate pipeline that can lag or stall,
+// and a stall is exactly the case where the worker would otherwise re-publish on
+// every sweep forever.
+func (d *Database) HasCompletedStatus(ctx context.Context, externalID constants.ExternalID) (bool, error) {
+	tx, err := d.db.BeginTxx(ctx, nil)
+	if err != nil {
+		return false, err
+	}
+	defer tx.Rollback() //nolint:errcheck // rollback after commit is a no-op
+
+	status, err := d.GetLatestStatusByExternalID(ctx, tx, externalID)
+	if err != nil {
+		// No status recorded yet means nothing has been published.
+		if errors.Is(err, sql.ErrNoRows) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	if err := tx.Commit(); err != nil {
+		return false, err
+	}
+
+	return status == messaging.SucceededState, nil
 }
 
 // interactiveAnalysis is the predicate identifying an analysis with a VICE

--- a/db/expiration.go
+++ b/db/expiration.go
@@ -1,0 +1,228 @@
+package db
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/cyverse-de/app-exposer/common"
+	"github.com/cyverse-de/app-exposer/constants"
+)
+
+// Analysis carries the jobs-table fields needed to decide whether an analysis
+// has reached its time limit and to describe it in a user notification.
+//
+// StartDate and PlannedEndDate are nullable: an analysis that has not started,
+// or whose planned end date has not been set yet, leaves them nil. Both are
+// selected through AT TIME ZONE current_setting('TimeZone') so the naive
+// `timestamp` columns arrive as the absolute instants they were written as —
+// the columns hold local wall-clock time, so reading them without the
+// conversion would silently shift every duration by the local UTC offset.
+type Analysis struct {
+	ID             constants.AnalysisID `db:"id"`
+	AppID          string               `db:"app_id"`
+	UserID         string               `db:"user_id"`
+	Status         string               `db:"status"`
+	Description    string               `db:"job_description"`
+	Name           string               `db:"job_name"`
+	ResultFolder   string               `db:"result_folder_path"`
+	StartDate      *time.Time           `db:"start_date"`
+	PlannedEndDate *time.Time           `db:"planned_end_date"`
+	Subdomain      string               `db:"subdomain"`
+	Kind           string               `db:"system_id"`
+	Username       string               `db:"username"`
+	ExternalID     constants.ExternalID `db:"external_id"`
+	NotifyPeriodic bool                 `db:"notify_periodic"`
+	PeriodicPeriod int                  `db:"periodic_period"`
+}
+
+// analysisColumns is the shared projection behind every *Analysis query.
+//
+// external_id comes from a LIMIT 1 subquery rather than a join so multi-step
+// analyses yield exactly one row. It is COALESCEd to the empty string — an
+// analysis with no job_steps row yet is skipped by callers rather than failing
+// the whole sweep.
+const analysisColumns = `
+	SELECT jobs.id,
+	       jobs.app_id,
+	       jobs.user_id,
+	       jobs.status,
+	       jobs.job_description,
+	       jobs.job_name,
+	       jobs.result_folder_path,
+	       jobs.start_date AT TIME ZONE current_setting('TimeZone') AS start_date,
+	       jobs.planned_end_date AT TIME ZONE current_setting('TimeZone') AS planned_end_date,
+	       COALESCE(jobs.subdomain, '') AS subdomain,
+	       job_types.system_id,
+	       users.username,
+	       COALESCE((SELECT js.external_id
+	                   FROM job_steps js
+	                  WHERE js.job_id = jobs.id
+	               ORDER BY js.step_number
+	                  LIMIT 1), '') AS external_id,
+	       COALESCE((jobs.submission->>'notify_periodic')::bool, TRUE) AS notify_periodic,
+	       COALESCE((jobs.submission->>'periodic_period')::int, 0) AS periodic_period
+	  FROM jobs
+	  JOIN job_types ON jobs.job_type_id = job_types.id
+	  JOIN users ON jobs.user_id = users.id
+`
+
+// runningStatus is the jobs.status value for an analysis that is still up. Only
+// running analyses are candidates for expiry warnings or termination.
+const runningStatus = "Running"
+
+// ListExpiredAnalyses returns the running analyses whose planned end date has
+// passed and which are therefore due for termination.
+func (d *Database) ListExpiredAnalyses(ctx context.Context) ([]Analysis, error) {
+	const query = analysisColumns + `
+		 WHERE jobs.status = $1
+		   AND jobs.planned_end_date <= now()
+	`
+	analyses := []Analysis{}
+	err := d.db.SelectContext(ctx, &analyses, query, runningStatus)
+	return analyses, err
+}
+
+// ListAnalysesExpiringWithin returns the running analyses whose planned end
+// date falls between now and the given window — the candidates for an advance
+// "your analysis will terminate" warning.
+func (d *Database) ListAnalysesExpiringWithin(ctx context.Context, window time.Duration) ([]Analysis, error) {
+	const query = analysisColumns + `
+		 WHERE jobs.status = $1
+		   AND jobs.planned_end_date > now()
+		   AND jobs.planned_end_date <= now() + make_interval(secs => $2)
+	`
+	analyses := []Analysis{}
+	err := d.db.SelectContext(ctx, &analyses, query, runningStatus, window.Seconds())
+	return analyses, err
+}
+
+// ListAnalysesDueForPeriodicReminder returns the running analyses that have not
+// yet expired and whose last periodic reminder is older than their configured
+// reminder period. Analyses with no notif_statuses row yet are included: their
+// first reminder is due immediately.
+func (d *Database) ListAnalysesDueForPeriodicReminder(ctx context.Context) ([]Analysis, error) {
+	const query = analysisColumns + `
+		  LEFT JOIN notif_statuses ON jobs.id = notif_statuses.analysis_id
+		 WHERE jobs.status = $1
+		   AND jobs.planned_end_date > now()
+		   AND (notif_statuses.last_periodic_warning IS NULL
+		    OR notif_statuses.last_periodic_warning <
+		       now() - COALESCE(notif_statuses.periodic_warning_period, '4 hours'::interval))
+	`
+	analyses := []Analysis{}
+	err := d.db.SelectContext(ctx, &analyses, query, runningStatus)
+	return analyses, err
+}
+
+// GetAnalysisByExternalID returns the analysis owning the given external ID, or
+// sql.ErrNoRows when no analysis has that external ID.
+func (d *Database) GetAnalysisByExternalID(ctx context.Context, externalID constants.ExternalID) (*Analysis, error) {
+	const query = analysisColumns + `
+		 WHERE EXISTS (SELECT 1
+		                 FROM job_steps js
+		                WHERE js.job_id = jobs.id
+		                  AND js.external_id = $1)
+	`
+	var analysis Analysis
+	if err := d.db.GetContext(ctx, &analysis, query, externalID); err != nil {
+		return nil, err
+	}
+	return &analysis, nil
+}
+
+// IsInteractive reports whether any of the analysis's steps is a VICE
+// (Interactive) step.
+func (d *Database) IsInteractive(ctx context.Context, analysisID constants.AnalysisID) (bool, error) {
+	const query = `
+		SELECT EXISTS (SELECT 1
+		                 FROM job_steps js
+		                 JOIN job_types jt ON js.job_type_id = jt.id
+		                WHERE js.job_id = $1
+		                  AND jt.name = 'Interactive')
+	`
+	var interactive bool
+	err := d.db.QueryRowContext(ctx, query, analysisID).Scan(&interactive)
+	return interactive, err
+}
+
+// DefaultToolTimeLimitSeconds is the runtime allowed for a tool that declares
+// no time limit of its own — 72 hours.
+const DefaultToolTimeLimitSeconds = 259200
+
+// GetTimeLimitSeconds returns how long an analysis is allowed to run. A time
+// limit requested at launch (initial_time_limit_seconds) wins; otherwise the
+// limit is the sum of the tools' limits, with DefaultToolTimeLimitSeconds
+// standing in for any tool that declares none.
+func (d *Database) GetTimeLimitSeconds(ctx context.Context, analysisID constants.AnalysisID) (int64, error) {
+	const query = `
+		SELECT COALESCE(
+		    jobs.initial_time_limit_seconds,
+		    sum(CASE WHEN tools.time_limit_seconds > 0
+		             THEN tools.time_limit_seconds
+		             ELSE $2 END)
+		)
+		  FROM tools
+		  JOIN tasks ON tools.id = tasks.tool_id
+		  JOIN app_steps ON tasks.id = app_steps.task_id
+		  JOIN jobs ON jobs.app_version_id = app_steps.app_version_id
+		 WHERE jobs.id = $1
+		 GROUP BY jobs.id
+	`
+	var seconds int64
+	err := d.db.QueryRowContext(ctx, query, analysisID, DefaultToolTimeLimitSeconds).Scan(&seconds)
+	return seconds, err
+}
+
+// SetInitialRuntime fills in the runtime fields the DE derives at launch:
+// the analysis's subdomain and its planned end date, the latter computed as
+// start_date (or now, if the analysis has no start date yet) plus
+// timeLimitSeconds.
+//
+// Both columns are only filled when currently unset, which makes this safe to
+// call more than once: it never clobbers a subdomain already in use for
+// routing, and never rolls back a time-limit extension the user has been
+// granted. Returns whether the statement changed anything, so callers can log
+// when the launch-time write had to be backfilled later.
+func (d *Database) SetInitialRuntime(ctx context.Context, analysisID constants.AnalysisID, subdomain string, timeLimitSeconds int64) (bool, error) {
+	const stmt = `
+		UPDATE ONLY jobs
+		   SET planned_end_date = COALESCE(
+		           planned_end_date,
+		           COALESCE(start_date, now()::timestamp) + make_interval(secs => $3)
+		       ),
+		       subdomain = COALESCE(NULLIF(subdomain, ''), $2)
+		 WHERE id = $1
+		   AND (planned_end_date IS NULL OR subdomain IS NULL OR subdomain = '')
+	`
+	result, err := d.db.ExecContext(ctx, stmt, analysisID, subdomain, timeLimitSeconds)
+	if err != nil {
+		return false, err
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	return rows > 0, nil
+}
+
+// InitializeRuntime derives and stores the runtime fields the DE computes once
+// per analysis: its routing subdomain and its planned end date. Safe to call
+// repeatedly — neither column is overwritten once set.
+//
+// This is the single path for that write. The VICE launch handler calls it as
+// the canonical writer; the job-status AMQP handler calls it again as a safety
+// net for analyses that reached Running without it (an analysis launched by an
+// older app-exposer, or one whose launch-time write failed). Returns whether
+// anything changed, which is what lets the safety net log that it had to
+// backfill.
+func (d *Database) InitializeRuntime(ctx context.Context, analysisID constants.AnalysisID, userID, externalID string) (bool, error) {
+	timeLimitSeconds, err := d.GetTimeLimitSeconds(ctx, analysisID)
+	if err != nil {
+		return false, fmt.Errorf("determining time limit for analysis %s: %w", analysisID, err)
+	}
+	return d.SetInitialRuntime(ctx, analysisID, common.Subdomain(userID, externalID), timeLimitSeconds)
+}
+
+// Compile-time check that *Database satisfies the expiration worker's needs.
+var _ ExpirationDB = (*Database)(nil)

--- a/db/expiration_test.go
+++ b/db/expiration_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/cyverse-de/app-exposer/common"
+	"github.com/jmoiron/sqlx"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -143,4 +144,51 @@ func TestInitializeRuntimeSurfacesATimeLimitFailure(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "determining time limit")
 	assert.False(t, changed)
+}
+
+// newRegexpTestDB matches expectations as regular expressions so a test can pin
+// the one predicate it cares about instead of restating the whole shared
+// analysis projection.
+func newRegexpTestDB(t *testing.T) (*Database, sqlmock.Sqlmock) {
+	t.Helper()
+	rawDB, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherRegexp))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = rawDB.Close() })
+	return New(sqlx.NewDb(rawDB, "postgres"), ""), mock
+}
+
+// TestListAnalysesDueForPeriodicReminderPacesFromTheLastReminder pins the
+// pacing to match the worker's reminderDue check. An analysis returned here but
+// not actually due costs a tracking-row insert and a row lock on every sweep, on
+// every replica, and records nothing that would stop it happening again ten
+// seconds later.
+func TestListAnalysesDueForPeriodicReminderPacesFromTheLastReminder(t *testing.T) {
+	database, mock := newRegexpTestDB(t)
+
+	mock.ExpectQuery(`GREATEST\(jobs\.start_date, notif_statuses\.last_periodic_warning\)\s+<\s+now\(\) - COALESCE\(notif_statuses\.periodic_warning_period`).
+		WithArgs(runningStatus).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}))
+
+	analyses, err := database.ListAnalysesDueForPeriodicReminder(context.Background())
+
+	require.NoError(t, err)
+	assert.Empty(t, analyses)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+// TestListAnalysesMissingRuntimeExcludesBatchAnalyses pins the interactive
+// filter. Batch analyses legitimately have neither a subdomain nor a planned end
+// date, so without it every running HPC job would come back on every sweep.
+func TestListAnalysesMissingRuntimeExcludesBatchAnalyses(t *testing.T) {
+	database, mock := newRegexpTestDB(t)
+
+	mock.ExpectQuery(`planned_end_date IS NULL OR COALESCE\(jobs\.subdomain, ''\) = ''[\s\S]*jt\.name = 'Interactive'`).
+		WithArgs(runningStatus).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}))
+
+	analyses, err := database.ListAnalysesMissingRuntime(context.Background())
+
+	require.NoError(t, err)
+	assert.Empty(t, analyses)
+	assert.NoError(t, mock.ExpectationsWereMet())
 }

--- a/db/expiration_test.go
+++ b/db/expiration_test.go
@@ -1,0 +1,146 @@
+package db
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/cyverse-de/app-exposer/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const timeLimitSQL = `
+		SELECT COALESCE(
+		    jobs.initial_time_limit_seconds,
+		    sum(CASE WHEN tools.time_limit_seconds > 0
+		             THEN tools.time_limit_seconds
+		             ELSE $2 END)
+		)
+		  FROM tools
+		  JOIN tasks ON tools.id = tasks.tool_id
+		  JOIN app_steps ON tasks.id = app_steps.task_id
+		  JOIN jobs ON jobs.app_version_id = app_steps.app_version_id
+		 WHERE jobs.id = $1
+		 GROUP BY jobs.id
+	`
+
+const initialRuntimeSQL = `
+		UPDATE ONLY jobs
+		   SET planned_end_date = COALESCE(
+		           planned_end_date,
+		           COALESCE(start_date, now()::timestamp) + make_interval(secs => $3)
+		       ),
+		       subdomain = COALESCE(NULLIF(subdomain, ''), $2)
+		 WHERE id = $1
+		   AND (planned_end_date IS NULL OR subdomain IS NULL OR subdomain = '')
+	`
+
+func TestGetTimeLimitSeconds(t *testing.T) {
+	database, mock := newTestDB(t)
+
+	mock.ExpectQuery(timeLimitSQL).
+		WithArgs(testAnalysisID, DefaultToolTimeLimitSeconds).
+		WillReturnRows(sqlmock.NewRows([]string{"coalesce"}).AddRow(int64(3600)))
+
+	seconds, err := database.GetTimeLimitSeconds(context.Background(), testAnalysisID)
+
+	require.NoError(t, err)
+	assert.Equal(t, int64(3600), seconds)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSetInitialRuntime(t *testing.T) {
+	tests := []struct {
+		name        string
+		rowsChanged int64
+		execErr     error
+		wantChanged bool
+		wantErr     bool
+	}{
+		{
+			name:        "reports a change when the columns were unset",
+			rowsChanged: 1,
+			wantChanged: true,
+		},
+		{
+			// Both columns were already populated, so the guarded UPDATE
+			// matched nothing. This is the steady-state result of the AMQP
+			// safety net running after the launch handler already wrote them.
+			name:        "reports no change when both columns were already set",
+			rowsChanged: 0,
+			wantChanged: false,
+		},
+		{
+			name:    "surfaces a database error",
+			execErr: errors.New("connection reset"),
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			database, mock := newTestDB(t)
+
+			expectation := mock.ExpectExec(initialRuntimeSQL).
+				WithArgs(testAnalysisID, "a1b2c3d4e", int64(3600))
+			if tt.execErr != nil {
+				expectation.WillReturnError(tt.execErr)
+			} else {
+				expectation.WillReturnResult(sqlmock.NewResult(0, tt.rowsChanged))
+			}
+
+			changed, err := database.SetInitialRuntime(context.Background(), testAnalysisID, "a1b2c3d4e", 3600)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.False(t, changed)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantChanged, changed)
+			assert.NoError(t, mock.ExpectationsWereMet())
+		})
+	}
+}
+
+// TestInitializeRuntimeUsesTheSharedSubdomain verifies that the runtime write
+// derives the subdomain with common.Subdomain — the same helper the launch path
+// uses for pod labels and gateway hostnames. If these two ever diverge, an
+// analysis becomes unroutable, so the coupling is asserted explicitly.
+func TestInitializeRuntimeUsesTheSharedSubdomain(t *testing.T) {
+	database, mock := newTestDB(t)
+
+	const userID = "user-1"
+	const externalID = "external-1"
+	wantSubdomain := common.Subdomain(userID, externalID)
+
+	mock.ExpectQuery(timeLimitSQL).
+		WithArgs(testAnalysisID, DefaultToolTimeLimitSeconds).
+		WillReturnRows(sqlmock.NewRows([]string{"coalesce"}).AddRow(int64(259200)))
+	mock.ExpectExec(initialRuntimeSQL).
+		WithArgs(testAnalysisID, wantSubdomain, int64(259200)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	changed, err := database.InitializeRuntime(context.Background(), testAnalysisID, userID, externalID)
+
+	require.NoError(t, err)
+	assert.True(t, changed)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestInitializeRuntimeSurfacesATimeLimitFailure(t *testing.T) {
+	database, mock := newTestDB(t)
+
+	mock.ExpectQuery(timeLimitSQL).
+		WithArgs(testAnalysisID, DefaultToolTimeLimitSeconds).
+		WillReturnError(errors.New("no such analysis"))
+
+	changed, err := database.InitializeRuntime(context.Background(), testAnalysisID, "user-1", "external-1")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "determining time limit")
+	assert.False(t, changed)
+}

--- a/db/expiration_test.go
+++ b/db/expiration_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/cyverse-de/app-exposer/common"
@@ -174,6 +175,58 @@ func TestListAnalysesDueForPeriodicReminderPacesFromTheLastReminder(t *testing.T
 	require.NoError(t, err)
 	assert.Empty(t, analyses)
 	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+// TestListAnalysesExpiringWithinFiltersInSQL pins the two predicates that keep
+// the warning pass from doing work it cannot use. An analysis already warned
+// costs a tracking-row insert and a row lock on every sweep, on every replica;
+// one with no start date cannot have a notification rendered for it at all, so
+// returning it only spends delivery attempts.
+func TestListAnalysesExpiringWithinFiltersInSQL(t *testing.T) {
+	tests := []struct {
+		name        string
+		kind        WarningKind
+		wantPattern string
+	}{
+		{
+			name:        "the hour warning excludes analyses already warned",
+			kind:        HourWarning,
+			wantPattern: `jobs\.start_date IS NOT NULL[\s\S]*COALESCE\(notif_statuses\.hour_warning_sent, FALSE\) = FALSE`,
+		},
+		{
+			name:        "the day warning excludes analyses already warned",
+			kind:        DayWarning,
+			wantPattern: `jobs\.start_date IS NOT NULL[\s\S]*COALESCE\(notif_statuses\.day_warning_sent, FALSE\) = FALSE`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			database, mock := newRegexpTestDB(t)
+
+			mock.ExpectQuery(tt.wantPattern).
+				WithArgs(runningStatus, sqlmock.AnyArg(), sqlmock.AnyArg()).
+				WillReturnRows(sqlmock.NewRows([]string{"id"}))
+
+			analyses, err := database.ListAnalysesExpiringWithin(context.Background(), tt.kind, time.Hour, 24*time.Hour)
+
+			require.NoError(t, err)
+			assert.Empty(t, analyses)
+			assert.NoError(t, mock.ExpectationsWereMet())
+		})
+	}
+}
+
+// TestListAnalysesExpiringWithinRejectsKindsWithNoWindow guards the map lookup:
+// the kill notification has no advance window, so asking for one is a
+// programming error rather than an empty result.
+func TestListAnalysesExpiringWithinRejectsKindsWithNoWindow(t *testing.T) {
+	database, _ := newRegexpTestDB(t)
+
+	analyses, err := database.ListAnalysesExpiringWithin(context.Background(), KillWarning, 0, time.Hour)
+
+	require.Error(t, err)
+	assert.Nil(t, analyses)
 }
 
 // TestListAnalysesMissingRuntimeExcludesBatchAnalyses pins the interactive

--- a/db/expiration_test.go
+++ b/db/expiration_test.go
@@ -31,7 +31,7 @@ const initialRuntimeSQL = `
 		UPDATE ONLY jobs
 		   SET planned_end_date = COALESCE(
 		           planned_end_date,
-		           COALESCE(start_date, now()::timestamp) + make_interval(secs => $3)
+		           COALESCE(start_date, $4::timestamp) + make_interval(secs => $3)
 		       ),
 		       subdomain = COALESCE(NULLIF(subdomain, ''), $2)
 		 WHERE id = $1
@@ -85,7 +85,7 @@ func TestSetInitialRuntime(t *testing.T) {
 			database, mock := newTestDB(t)
 
 			expectation := mock.ExpectExec(initialRuntimeSQL).
-				WithArgs(testAnalysisID, "a1b2c3d4e", int64(3600))
+				WithArgs(testAnalysisID, "a1b2c3d4e", int64(3600), sqlmock.AnyArg())
 			if tt.execErr != nil {
 				expectation.WillReturnError(tt.execErr)
 			} else {
@@ -122,7 +122,7 @@ func TestInitializeRuntimeUsesTheSharedSubdomain(t *testing.T) {
 		WithArgs(testAnalysisID, DefaultToolTimeLimitSeconds).
 		WillReturnRows(sqlmock.NewRows([]string{"coalesce"}).AddRow(int64(259200)))
 	mock.ExpectExec(initialRuntimeSQL).
-		WithArgs(testAnalysisID, wantSubdomain, int64(259200)).
+		WithArgs(testAnalysisID, wantSubdomain, int64(259200), sqlmock.AnyArg()).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 
 	changed, err := database.InitializeRuntime(context.Background(), testAnalysisID, userID, externalID)
@@ -165,8 +165,8 @@ func newRegexpTestDB(t *testing.T) (*Database, sqlmock.Sqlmock) {
 func TestListAnalysesDueForPeriodicReminderPacesFromTheLastReminder(t *testing.T) {
 	database, mock := newRegexpTestDB(t)
 
-	mock.ExpectQuery(`GREATEST\(jobs\.start_date, notif_statuses\.last_periodic_warning\)\s+<\s+now\(\) - COALESCE\(notif_statuses\.periodic_warning_period`).
-		WithArgs(runningStatus).
+	mock.ExpectQuery(`GREATEST\(jobs\.start_date, notif_statuses\.last_periodic_warning\)\s+<\s+\$2::timestamp - COALESCE\(notif_statuses\.periodic_warning_period`).
+		WithArgs(runningStatus, sqlmock.AnyArg()).
 		WillReturnRows(sqlmock.NewRows([]string{"id"}))
 
 	analyses, err := database.ListAnalysesDueForPeriodicReminder(context.Background())

--- a/db/interfaces.go
+++ b/db/interfaces.go
@@ -36,6 +36,10 @@ type ExpirationDB interface {
 	// IsInteractive reports whether the analysis has a VICE step.
 	IsInteractive(ctx context.Context, analysisID constants.AnalysisID) (bool, error)
 
+	// HasCompletedStatus reports whether a Completed status has already been
+	// recorded for the given external ID.
+	HasCompletedStatus(ctx context.Context, externalID constants.ExternalID) (bool, error)
+
 	// InitializeRuntime fills in the analysis's subdomain and planned end date
 	// when they are not already set, reporting whether it changed anything.
 	InitializeRuntime(ctx context.Context, analysisID constants.AnalysisID, userID, externalID string) (bool, error)

--- a/db/interfaces.go
+++ b/db/interfaces.go
@@ -25,6 +25,10 @@ type ExpirationDB interface {
 	// periodic reminder is older than their configured reminder period.
 	ListAnalysesDueForPeriodicReminder(ctx context.Context) ([]Analysis, error)
 
+	// ListAnalysesMissingRuntime returns the running VICE analyses that have no
+	// subdomain or no planned end date.
+	ListAnalysesMissingRuntime(ctx context.Context) ([]Analysis, error)
+
 	// GetAnalysisByExternalID returns the analysis owning an external ID, or
 	// sql.ErrNoRows when there is none.
 	GetAnalysisByExternalID(ctx context.Context, externalID constants.ExternalID) (*Analysis, error)
@@ -50,8 +54,8 @@ type ExpirationDB interface {
 	// SetWarningFailureCount records the failed-attempt count for a notification.
 	SetWarningFailureCount(ctx context.Context, tx *sqlx.Tx, kind WarningKind, analysisID constants.AnalysisID, count int) error
 
-	// SetLastPeriodicWarning records when the last periodic reminder was sent.
-	SetLastPeriodicWarning(ctx context.Context, tx *sqlx.Tx, analysisID constants.AnalysisID, sentAt time.Time) error
+	// SetLastPeriodicWarning records that a periodic reminder has just been sent.
+	SetLastPeriodicWarning(ctx context.Context, tx *sqlx.Tx, analysisID constants.AnalysisID) error
 }
 
 // ReconcilerDB is the narrow subset of *Database operations used by the

--- a/db/interfaces.go
+++ b/db/interfaces.go
@@ -17,9 +17,10 @@ type ExpirationDB interface {
 	// ListExpiredAnalyses returns running analyses past their planned end date.
 	ListExpiredAnalyses(ctx context.Context) ([]Analysis, error)
 
-	// ListAnalysesExpiringWithin returns running analyses whose planned end
-	// date falls inside the given window.
-	ListAnalysesExpiringWithin(ctx context.Context, window time.Duration) ([]Analysis, error)
+	// ListAnalysesExpiringWithin returns the running analyses due the given
+	// expiry warning: those expiring between now+from and now+to that have not
+	// been warned yet.
+	ListAnalysesExpiringWithin(ctx context.Context, kind WarningKind, from, to time.Duration) ([]Analysis, error)
 
 	// ListAnalysesDueForPeriodicReminder returns running analyses whose last
 	// periodic reminder is older than their configured reminder period.

--- a/db/interfaces.go
+++ b/db/interfaces.go
@@ -9,6 +9,51 @@ import (
 	"github.com/jmoiron/sqlx"
 )
 
+// ExpirationDB is the narrow subset of *Database operations used by the
+// background analysis-expiration worker. As with ReconcilerDB it exists so the
+// worker can be unit-tested against a fake; the production *Database satisfies
+// it structurally.
+type ExpirationDB interface {
+	// ListExpiredAnalyses returns running analyses past their planned end date.
+	ListExpiredAnalyses(ctx context.Context) ([]Analysis, error)
+
+	// ListAnalysesExpiringWithin returns running analyses whose planned end
+	// date falls inside the given window.
+	ListAnalysesExpiringWithin(ctx context.Context, window time.Duration) ([]Analysis, error)
+
+	// ListAnalysesDueForPeriodicReminder returns running analyses whose last
+	// periodic reminder is older than their configured reminder period.
+	ListAnalysesDueForPeriodicReminder(ctx context.Context) ([]Analysis, error)
+
+	// GetAnalysisByExternalID returns the analysis owning an external ID, or
+	// sql.ErrNoRows when there is none.
+	GetAnalysisByExternalID(ctx context.Context, externalID constants.ExternalID) (*Analysis, error)
+
+	// IsInteractive reports whether the analysis has a VICE step.
+	IsInteractive(ctx context.Context, analysisID constants.AnalysisID) (bool, error)
+
+	// InitializeRuntime fills in the analysis's subdomain and planned end date
+	// when they are not already set, reporting whether it changed anything.
+	InitializeRuntime(ctx context.Context, analysisID constants.AnalysisID, userID, externalID string) (bool, error)
+
+	// EnsureNotifStatuses creates the analysis's notification-tracking row if
+	// it is missing.
+	EnsureNotifStatuses(ctx context.Context, analysisID constants.AnalysisID, externalID constants.ExternalID, periodicPeriodSeconds int) error
+
+	// ClaimNotifStatuses locks the analysis's notification-tracking row and
+	// runs fn against it, returning ErrNotClaimed if another replica holds it.
+	ClaimNotifStatuses(ctx context.Context, analysisID constants.AnalysisID, fn func(tx *sqlx.Tx, statuses *NotifStatuses) error) error
+
+	// SetWarningSent records delivery (or abandonment) of a notification.
+	SetWarningSent(ctx context.Context, tx *sqlx.Tx, kind WarningKind, analysisID constants.AnalysisID, sent bool) error
+
+	// SetWarningFailureCount records the failed-attempt count for a notification.
+	SetWarningFailureCount(ctx context.Context, tx *sqlx.Tx, kind WarningKind, analysisID constants.AnalysisID, count int) error
+
+	// SetLastPeriodicWarning records when the last periodic reminder was sent.
+	SetLastPeriodicWarning(ctx context.Context, tx *sqlx.Tx, analysisID constants.AnalysisID, sentAt time.Time) error
+}
+
 // ReconcilerDB is the narrow subset of *Database operations used by the
 // background reconciliation worker. It exists so the reconciler can be
 // unit-tested against a fake without pulling in a real Postgres. The

--- a/db/notifstatuses.go
+++ b/db/notifstatuses.go
@@ -33,10 +33,9 @@ const (
 
 // NotifStatuses records which notifications have already been delivered for an
 // analysis, and how many delivery attempts have failed. LastPeriodicWarning is
-// nil when no periodic reminder has been sent yet, and is read through
-// AT TIME ZONE current_setting('TimeZone') for the same reason as the timestamps
-// on Analysis: the column is naive and holds local wall-clock time, so reading
-// it raw would put every comparison off by the local UTC offset.
+// nil when no periodic reminder has been sent yet, and like the timestamps on
+// Analysis it comes from a naive `timestamp` column, so it is only a correct
+// instant once relabeled — see db/timestamps.go.
 type NotifStatuses struct {
 	AnalysisID              constants.AnalysisID `db:"analysis_id"`
 	ExternalID              constants.ExternalID `db:"external_id"`
@@ -96,6 +95,11 @@ var warningStatements = map[WarningKind]struct{ setSent, setFailureCount string 
 	},
 }
 
+// lastPeriodicWarningStmt is package-level for the same reason as the statements
+// in db/expiration.go: it writes one of the naive timestamp columns, so the
+// contract in db/timestamps.go is asserted against it directly.
+const lastPeriodicWarningStmt = `UPDATE notif_statuses SET last_periodic_warning = $2::timestamp WHERE analysis_id = $1`
+
 // EnsureNotifStatuses creates the analysis's notif_statuses row if it does not
 // exist. periodicPeriodSeconds is the reminder interval requested at launch; a
 // non-positive value stores the DE's four-hour default.
@@ -147,7 +151,7 @@ func (d *Database) ClaimNotifStatuses(ctx context.Context, analysisID constants.
 		       day_warning_failure_count,
 		       kill_warning_sent,
 		       kill_warning_failure_count,
-		       last_periodic_warning AT TIME ZONE current_setting('TimeZone') AS last_periodic_warning,
+		       last_periodic_warning,
 		       COALESCE(EXTRACT(EPOCH FROM periodic_warning_period), 0)::bigint AS periodic_warning_seconds
 		  FROM notif_statuses
 		 WHERE analysis_id = $1
@@ -170,6 +174,8 @@ func (d *Database) ClaimNotifStatuses(ctx context.Context, analysisID constants.
 		}
 		return sql.ErrNoRows
 	}
+
+	statuses.LastPeriodicWarning = inLocalZone(statuses.LastPeriodicWarning)
 
 	if err := fn(tx, &statuses); err != nil {
 		return err
@@ -213,12 +219,12 @@ func (d *Database) SetWarningFailureCount(ctx context.Context, tx *sqlx.Tx, kind
 // SetLastPeriodicWarning records that a periodic reminder has just gone out,
 // which is what paces the next one.
 //
-// The time comes from the database rather than from Go: last_periodic_warning
-// is a naive `timestamp` holding local wall-clock time, so a Go instant written
-// into it lands shifted by the difference between the process's zone and the
-// database's, throwing off every comparison that paces the reminders.
+// The time comes from Go rather than from the database. Postgres drops the
+// offset when it parses the value into the naive column, storing the
+// deployment's wall clock — whereas now()::timestamp would store the wall clock
+// of the database session's zone, which is not the zone anything reads this
+// column back in.
 func (d *Database) SetLastPeriodicWarning(ctx context.Context, tx *sqlx.Tx, analysisID constants.AnalysisID) error {
-	const stmt = `UPDATE notif_statuses SET last_periodic_warning = now()::timestamp WHERE analysis_id = $1`
-	_, err := tx.ExecContext(ctx, stmt, analysisID)
+	_, err := tx.ExecContext(ctx, lastPeriodicWarningStmt, analysisID, time.Now())
 	return err
 }

--- a/db/notifstatuses.go
+++ b/db/notifstatuses.go
@@ -1,0 +1,219 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/cyverse-de/app-exposer/constants"
+	"github.com/jmoiron/sqlx"
+)
+
+// ErrNotClaimed is returned by ClaimNotifStatuses when another replica already
+// holds the analysis's notif_statuses row. It is an expected outcome, not a
+// fault: the holder is sending the notification, so this replica skips the
+// analysis for this pass.
+var ErrNotClaimed = errors.New("notif_statuses row claimed by another process")
+
+// WarningKind identifies one of the three expiry-related notifications whose
+// delivery is tracked per analysis.
+type WarningKind string
+
+const (
+	// DayWarning is the notification sent a day before an analysis expires.
+	DayWarning WarningKind = "day"
+	// HourWarning is the notification sent shortly before an analysis expires.
+	HourWarning WarningKind = "hour"
+	// KillWarning is the notification sent when an analysis has been
+	// terminated for exceeding its time limit.
+	KillWarning WarningKind = "kill"
+)
+
+// NotifStatuses records which notifications have already been delivered for an
+// analysis, and how many delivery attempts have failed. LastPeriodicWarning is
+// nil when no periodic reminder has been sent yet, and is read through
+// AT TIME ZONE current_setting('TimeZone') for the same reason as the timestamps
+// on Analysis: the column is naive and holds local wall-clock time, so reading
+// it raw would put every comparison off by the local UTC offset.
+type NotifStatuses struct {
+	AnalysisID              constants.AnalysisID `db:"analysis_id"`
+	ExternalID              constants.ExternalID `db:"external_id"`
+	HourWarningSent         bool                 `db:"hour_warning_sent"`
+	HourWarningFailureCount int                  `db:"hour_warning_failure_count"`
+	DayWarningSent          bool                 `db:"day_warning_sent"`
+	DayWarningFailureCount  int                  `db:"day_warning_failure_count"`
+	KillWarningSent         bool                 `db:"kill_warning_sent"`
+	KillWarningFailureCount int                  `db:"kill_warning_failure_count"`
+	LastPeriodicWarning     *time.Time           `db:"last_periodic_warning"`
+	PeriodicWarningSeconds  int64                `db:"periodic_warning_seconds"`
+}
+
+// Sent reports whether the given notification has already been delivered (or
+// abandoned after too many failures).
+func (n *NotifStatuses) Sent(kind WarningKind) bool {
+	switch kind {
+	case DayWarning:
+		return n.DayWarningSent
+	case HourWarning:
+		return n.HourWarningSent
+	case KillWarning:
+		return n.KillWarningSent
+	}
+	return false
+}
+
+// FailureCount returns how many delivery attempts for the given notification
+// have failed so far.
+func (n *NotifStatuses) FailureCount(kind WarningKind) int {
+	switch kind {
+	case DayWarning:
+		return n.DayWarningFailureCount
+	case HourWarning:
+		return n.HourWarningFailureCount
+	case KillWarning:
+		return n.KillWarningFailureCount
+	}
+	return 0
+}
+
+// warningStatements pairs each notification kind with the statements that
+// update its columns. The statements are constants selected by a closed set of
+// WarningKind values, so no column name is ever interpolated from input.
+var warningStatements = map[WarningKind]struct{ setSent, setFailureCount string }{
+	DayWarning: {
+		setSent:         `UPDATE notif_statuses SET day_warning_sent = $2 WHERE analysis_id = $1`,
+		setFailureCount: `UPDATE notif_statuses SET day_warning_failure_count = $2 WHERE analysis_id = $1`,
+	},
+	HourWarning: {
+		setSent:         `UPDATE notif_statuses SET hour_warning_sent = $2 WHERE analysis_id = $1`,
+		setFailureCount: `UPDATE notif_statuses SET hour_warning_failure_count = $2 WHERE analysis_id = $1`,
+	},
+	KillWarning: {
+		setSent:         `UPDATE notif_statuses SET kill_warning_sent = $2 WHERE analysis_id = $1`,
+		setFailureCount: `UPDATE notif_statuses SET kill_warning_failure_count = $2 WHERE analysis_id = $1`,
+	},
+}
+
+// EnsureNotifStatuses creates the analysis's notif_statuses row if it does not
+// exist. periodicPeriodSeconds is the reminder interval requested at launch; a
+// non-positive value stores the DE's four-hour default.
+//
+// Idempotent by way of the unique constraint on analysis_id, so concurrent
+// replicas racing to create the same row both succeed.
+func (d *Database) EnsureNotifStatuses(ctx context.Context, analysisID constants.AnalysisID, externalID constants.ExternalID, periodicPeriodSeconds int) error {
+	period := fmt.Sprintf("%d seconds", periodicPeriodSeconds)
+	if periodicPeriodSeconds <= 0 {
+		period = "4 hours"
+	}
+
+	const stmt = `
+		INSERT INTO notif_statuses (analysis_id, external_id, periodic_warning_period)
+		VALUES ($1, $2, CAST($3 AS interval))
+		ON CONFLICT (analysis_id) DO NOTHING
+	`
+	_, err := d.db.ExecContext(ctx, stmt, analysisID, externalID, period)
+	return err
+}
+
+// ClaimNotifStatuses locks the analysis's notif_statuses row and runs fn with
+// the loaded statuses and the owning transaction. The transaction commits when
+// fn returns nil and rolls back otherwise, so a notification whose delivery
+// fails leaves no partial bookkeeping behind.
+//
+// The lock is taken FOR UPDATE SKIP LOCKED, which is what keeps concurrent
+// app-exposer replicas from both sending the same notification: the replica
+// that loses the race gets ErrNotClaimed and moves on. Callers must have
+// created the row (see EnsureNotifStatuses) first; sql.ErrNoRows means the row
+// genuinely does not exist rather than that it was locked elsewhere.
+//
+// fn runs while the row lock is held and is expected to make a notification
+// call out to the network, matching ClaimAndReconcile's existing tradeoff:
+// the lock is held for one analysis's notification, not for a whole sweep.
+func (d *Database) ClaimNotifStatuses(ctx context.Context, analysisID constants.AnalysisID, fn func(tx *sqlx.Tx, statuses *NotifStatuses) error) error {
+	tx, err := d.db.BeginTxx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback() //nolint:errcheck // rollback after commit is a no-op
+
+	const claimQuery = `
+		SELECT analysis_id,
+		       external_id,
+		       hour_warning_sent,
+		       hour_warning_failure_count,
+		       day_warning_sent,
+		       day_warning_failure_count,
+		       kill_warning_sent,
+		       kill_warning_failure_count,
+		       last_periodic_warning AT TIME ZONE current_setting('TimeZone') AS last_periodic_warning,
+		       COALESCE(EXTRACT(EPOCH FROM periodic_warning_period), 0)::bigint AS periodic_warning_seconds
+		  FROM notif_statuses
+		 WHERE analysis_id = $1
+		   FOR UPDATE SKIP LOCKED
+	`
+	var statuses NotifStatuses
+	if err := tx.GetContext(ctx, &statuses, claimQuery, analysisID); err != nil {
+		if !errors.Is(err, sql.ErrNoRows) {
+			return err
+		}
+		// SKIP LOCKED returns no rows both when the row is locked and when
+		// it is absent. Distinguish the two so a missing row surfaces as a
+		// real error instead of being silently skipped forever.
+		claimed, existsErr := d.notifStatusesExists(ctx, analysisID)
+		if existsErr != nil {
+			return existsErr
+		}
+		if claimed {
+			return ErrNotClaimed
+		}
+		return sql.ErrNoRows
+	}
+
+	if err := fn(tx, &statuses); err != nil {
+		return err
+	}
+
+	return tx.Commit()
+}
+
+// notifStatusesExists reports whether the analysis has a notif_statuses row.
+// Deliberately runs outside the claiming transaction: inside it, the row would
+// be invisible to the same SKIP LOCKED semantics that just missed it.
+func (d *Database) notifStatusesExists(ctx context.Context, analysisID constants.AnalysisID) (bool, error) {
+	const query = `SELECT EXISTS (SELECT 1 FROM notif_statuses WHERE analysis_id = $1)`
+	var exists bool
+	err := d.db.QueryRowContext(ctx, query, analysisID).Scan(&exists)
+	return exists, err
+}
+
+// SetWarningSent records that the given notification has been delivered, or has
+// failed often enough that the DE stops retrying it.
+func (d *Database) SetWarningSent(ctx context.Context, tx *sqlx.Tx, kind WarningKind, analysisID constants.AnalysisID, sent bool) error {
+	stmts, ok := warningStatements[kind]
+	if !ok {
+		return fmt.Errorf("unknown warning kind %q", kind)
+	}
+	_, err := tx.ExecContext(ctx, stmts.setSent, analysisID, sent)
+	return err
+}
+
+// SetWarningFailureCount records how many delivery attempts for the given
+// notification have failed.
+func (d *Database) SetWarningFailureCount(ctx context.Context, tx *sqlx.Tx, kind WarningKind, analysisID constants.AnalysisID, count int) error {
+	stmts, ok := warningStatements[kind]
+	if !ok {
+		return fmt.Errorf("unknown warning kind %q", kind)
+	}
+	_, err := tx.ExecContext(ctx, stmts.setFailureCount, analysisID, count)
+	return err
+}
+
+// SetLastPeriodicWarning records when the most recent periodic reminder went
+// out, which is what paces the next one.
+func (d *Database) SetLastPeriodicWarning(ctx context.Context, tx *sqlx.Tx, analysisID constants.AnalysisID, sentAt time.Time) error {
+	const stmt = `UPDATE notif_statuses SET last_periodic_warning = $2 WHERE analysis_id = $1`
+	_, err := tx.ExecContext(ctx, stmt, analysisID, sentAt)
+	return err
+}

--- a/db/notifstatuses.go
+++ b/db/notifstatuses.go
@@ -210,10 +210,15 @@ func (d *Database) SetWarningFailureCount(ctx context.Context, tx *sqlx.Tx, kind
 	return err
 }
 
-// SetLastPeriodicWarning records when the most recent periodic reminder went
-// out, which is what paces the next one.
-func (d *Database) SetLastPeriodicWarning(ctx context.Context, tx *sqlx.Tx, analysisID constants.AnalysisID, sentAt time.Time) error {
-	const stmt = `UPDATE notif_statuses SET last_periodic_warning = $2 WHERE analysis_id = $1`
-	_, err := tx.ExecContext(ctx, stmt, analysisID, sentAt)
+// SetLastPeriodicWarning records that a periodic reminder has just gone out,
+// which is what paces the next one.
+//
+// The time comes from the database rather than from Go: last_periodic_warning
+// is a naive `timestamp` holding local wall-clock time, so a Go instant written
+// into it lands shifted by the difference between the process's zone and the
+// database's, throwing off every comparison that paces the reminders.
+func (d *Database) SetLastPeriodicWarning(ctx context.Context, tx *sqlx.Tx, analysisID constants.AnalysisID) error {
+	const stmt = `UPDATE notif_statuses SET last_periodic_warning = now()::timestamp WHERE analysis_id = $1`
+	_, err := tx.ExecContext(ctx, stmt, analysisID)
 	return err
 }

--- a/db/notifstatuses.go
+++ b/db/notifstatuses.go
@@ -175,7 +175,7 @@ func (d *Database) ClaimNotifStatuses(ctx context.Context, analysisID constants.
 		return sql.ErrNoRows
 	}
 
-	statuses.LastPeriodicWarning = inLocalZone(statuses.LastPeriodicWarning)
+	statuses.LastPeriodicWarning = InLocalZone(statuses.LastPeriodicWarning)
 
 	if err := fn(tx, &statuses); err != nil {
 		return err

--- a/db/notifstatuses_test.go
+++ b/db/notifstatuses_test.go
@@ -1,0 +1,294 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/cyverse-de/app-exposer/constants"
+	"github.com/jmoiron/sqlx"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testAnalysisID = constants.AnalysisID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+
+// claimSQL and existsSQL mirror the statements in ClaimNotifStatuses. They are
+// restated here so an unintended change to either statement fails the test
+// rather than silently altering the locking behavior.
+const claimSQL = `
+		SELECT analysis_id,
+		       external_id,
+		       hour_warning_sent,
+		       hour_warning_failure_count,
+		       day_warning_sent,
+		       day_warning_failure_count,
+		       kill_warning_sent,
+		       kill_warning_failure_count,
+		       last_periodic_warning AT TIME ZONE current_setting('TimeZone') AS last_periodic_warning,
+		       COALESCE(EXTRACT(EPOCH FROM periodic_warning_period), 0)::bigint AS periodic_warning_seconds
+		  FROM notif_statuses
+		 WHERE analysis_id = $1
+		   FOR UPDATE SKIP LOCKED
+	`
+
+const existsSQL = `SELECT EXISTS (SELECT 1 FROM notif_statuses WHERE analysis_id = $1)`
+
+func claimColumns() []string {
+	return []string{
+		"analysis_id", "external_id",
+		"hour_warning_sent", "hour_warning_failure_count",
+		"day_warning_sent", "day_warning_failure_count",
+		"kill_warning_sent", "kill_warning_failure_count",
+		"last_periodic_warning", "periodic_warning_seconds",
+	}
+}
+
+// TestClaimNotifStatuses covers the concurrency contract that keeps two
+// app-exposer replicas from sending the same notification twice.
+func TestClaimNotifStatuses(t *testing.T) {
+	t.Run("runs the callback and commits when the row is claimed", func(t *testing.T) {
+		database, mock := newTestDB(t)
+
+		mock.ExpectBegin()
+		mock.ExpectQuery(claimSQL).
+			WithArgs(testAnalysisID).
+			WillReturnRows(sqlmock.NewRows(claimColumns()).
+				AddRow(string(testAnalysisID), "external-1", true, 2, false, 0, false, 0, nil, int64(7200)))
+		mock.ExpectCommit()
+
+		var seen *NotifStatuses
+		err := database.ClaimNotifStatuses(context.Background(), testAnalysisID, func(_ *sqlx.Tx, statuses *NotifStatuses) error {
+			seen = statuses
+			return nil
+		})
+
+		require.NoError(t, err)
+		require.NotNil(t, seen)
+		assert.True(t, seen.HourWarningSent)
+		assert.Equal(t, 2, seen.HourWarningFailureCount)
+		assert.Equal(t, int64(7200), seen.PeriodicWarningSeconds)
+		assert.Nil(t, seen.LastPeriodicWarning)
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("returns ErrNotClaimed when another replica holds the row", func(t *testing.T) {
+		database, mock := newTestDB(t)
+
+		mock.ExpectBegin()
+		mock.ExpectQuery(claimSQL).
+			WithArgs(testAnalysisID).
+			WillReturnRows(sqlmock.NewRows(claimColumns()))
+		// The row exists, so the empty result means it was locked elsewhere.
+		mock.ExpectQuery(existsSQL).
+			WithArgs(testAnalysisID).
+			WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(true))
+		mock.ExpectRollback()
+
+		called := false
+		err := database.ClaimNotifStatuses(context.Background(), testAnalysisID, func(*sqlx.Tx, *NotifStatuses) error {
+			called = true
+			return nil
+		})
+
+		require.ErrorIs(t, err, ErrNotClaimed)
+		assert.False(t, called, "the callback must not run when the claim is lost")
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("returns ErrNoRows when the row genuinely does not exist", func(t *testing.T) {
+		database, mock := newTestDB(t)
+
+		mock.ExpectBegin()
+		mock.ExpectQuery(claimSQL).
+			WithArgs(testAnalysisID).
+			WillReturnRows(sqlmock.NewRows(claimColumns()))
+		mock.ExpectQuery(existsSQL).
+			WithArgs(testAnalysisID).
+			WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(false))
+		mock.ExpectRollback()
+
+		err := database.ClaimNotifStatuses(context.Background(), testAnalysisID, func(*sqlx.Tx, *NotifStatuses) error {
+			return nil
+		})
+
+		require.ErrorIs(t, err, sql.ErrNoRows,
+			"a missing row must surface as an error rather than being skipped forever")
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("rolls back when the callback fails", func(t *testing.T) {
+		database, mock := newTestDB(t)
+		sentinel := errors.New("notification-agent is down")
+
+		mock.ExpectBegin()
+		mock.ExpectQuery(claimSQL).
+			WithArgs(testAnalysisID).
+			WillReturnRows(sqlmock.NewRows(claimColumns()).
+				AddRow(string(testAnalysisID), "external-1", false, 0, false, 0, false, 0, nil, int64(0)))
+		mock.ExpectRollback()
+
+		err := database.ClaimNotifStatuses(context.Background(), testAnalysisID, func(*sqlx.Tx, *NotifStatuses) error {
+			return sentinel
+		})
+
+		require.ErrorIs(t, err, sentinel)
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+}
+
+func TestEnsureNotifStatuses(t *testing.T) {
+	const expectedSQL = `
+		INSERT INTO notif_statuses (analysis_id, external_id, periodic_warning_period)
+		VALUES ($1, $2, CAST($3 AS interval))
+		ON CONFLICT (analysis_id) DO NOTHING
+	`
+
+	tests := []struct {
+		name        string
+		periodSecs  int
+		wantsPeriod string
+	}{
+		{name: "a requested period is stored as seconds", periodSecs: 900, wantsPeriod: "900 seconds"},
+		{name: "zero selects the four-hour default", periodSecs: 0, wantsPeriod: "4 hours"},
+		{name: "a negative period selects the default", periodSecs: -5, wantsPeriod: "4 hours"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			database, mock := newTestDB(t)
+
+			mock.ExpectExec(expectedSQL).
+				WithArgs(testAnalysisID, constants.ExternalID("external-1"), tt.wantsPeriod).
+				WillReturnResult(sqlmock.NewResult(0, 1))
+
+			err := database.EnsureNotifStatuses(context.Background(), testAnalysisID, "external-1", tt.periodSecs)
+
+			require.NoError(t, err)
+			assert.NoError(t, mock.ExpectationsWereMet())
+		})
+	}
+}
+
+func TestSetWarningSentAndFailureCount(t *testing.T) {
+	tests := []struct {
+		name         string
+		kind         WarningKind
+		wantSentSQL  string
+		wantCountSQL string
+	}{
+		{
+			name:         "day",
+			kind:         DayWarning,
+			wantSentSQL:  `UPDATE notif_statuses SET day_warning_sent = $2 WHERE analysis_id = $1`,
+			wantCountSQL: `UPDATE notif_statuses SET day_warning_failure_count = $2 WHERE analysis_id = $1`,
+		},
+		{
+			name:         "hour",
+			kind:         HourWarning,
+			wantSentSQL:  `UPDATE notif_statuses SET hour_warning_sent = $2 WHERE analysis_id = $1`,
+			wantCountSQL: `UPDATE notif_statuses SET hour_warning_failure_count = $2 WHERE analysis_id = $1`,
+		},
+		{
+			name:         "kill",
+			kind:         KillWarning,
+			wantSentSQL:  `UPDATE notif_statuses SET kill_warning_sent = $2 WHERE analysis_id = $1`,
+			wantCountSQL: `UPDATE notif_statuses SET kill_warning_failure_count = $2 WHERE analysis_id = $1`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			database, mock := newTestDB(t)
+
+			mock.ExpectBegin()
+			mock.ExpectExec(tt.wantSentSQL).
+				WithArgs(testAnalysisID, true).
+				WillReturnResult(sqlmock.NewResult(0, 1))
+			mock.ExpectExec(tt.wantCountSQL).
+				WithArgs(testAnalysisID, 3).
+				WillReturnResult(sqlmock.NewResult(0, 1))
+			mock.ExpectCommit()
+
+			tx, err := database.db.BeginTxx(context.Background(), nil)
+			require.NoError(t, err)
+
+			require.NoError(t, database.SetWarningSent(context.Background(), tx, tt.kind, testAnalysisID, true))
+			require.NoError(t, database.SetWarningFailureCount(context.Background(), tx, tt.kind, testAnalysisID, 3))
+			require.NoError(t, tx.Commit())
+
+			assert.NoError(t, mock.ExpectationsWereMet())
+		})
+	}
+}
+
+func TestWarningStatementsRejectAnUnknownKind(t *testing.T) {
+	database, mock := newTestDB(t)
+
+	mock.ExpectBegin()
+	mock.ExpectRollback()
+
+	tx, err := database.db.BeginTxx(context.Background(), nil)
+	require.NoError(t, err)
+	defer func() { _ = tx.Rollback() }()
+
+	err = database.SetWarningSent(context.Background(), tx, WarningKind("bogus"), testAnalysisID, true)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown warning kind")
+
+	err = database.SetWarningFailureCount(context.Background(), tx, WarningKind("bogus"), testAnalysisID, 1)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown warning kind")
+}
+
+func TestSetLastPeriodicWarning(t *testing.T) {
+	database, mock := newTestDB(t)
+	sentAt := time.Date(2026, 8, 10, 12, 0, 0, 0, time.UTC)
+
+	mock.ExpectBegin()
+	mock.ExpectExec(`UPDATE notif_statuses SET last_periodic_warning = $2 WHERE analysis_id = $1`).
+		WithArgs(testAnalysisID, sentAt).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectCommit()
+
+	tx, err := database.db.BeginTxx(context.Background(), nil)
+	require.NoError(t, err)
+
+	require.NoError(t, database.SetLastPeriodicWarning(context.Background(), tx, testAnalysisID, sentAt))
+	require.NoError(t, tx.Commit())
+
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestNotifStatusesAccessors(t *testing.T) {
+	statuses := &NotifStatuses{
+		HourWarningSent:         true,
+		HourWarningFailureCount: 1,
+		DayWarningSent:          false,
+		DayWarningFailureCount:  2,
+		KillWarningSent:         true,
+		KillWarningFailureCount: 3,
+	}
+
+	tests := []struct {
+		name         string
+		kind         WarningKind
+		wantSent     bool
+		wantFailures int
+	}{
+		{name: "hour", kind: HourWarning, wantSent: true, wantFailures: 1},
+		{name: "day", kind: DayWarning, wantSent: false, wantFailures: 2},
+		{name: "kill", kind: KillWarning, wantSent: true, wantFailures: 3},
+		{name: "unknown kinds read as unsent", kind: WarningKind("bogus"), wantSent: false, wantFailures: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.wantSent, statuses.Sent(tt.kind))
+			assert.Equal(t, tt.wantFailures, statuses.FailureCount(tt.kind))
+		})
+	}
+}

--- a/db/notifstatuses_test.go
+++ b/db/notifstatuses_test.go
@@ -27,7 +27,7 @@ const claimSQL = `
 		       day_warning_failure_count,
 		       kill_warning_sent,
 		       kill_warning_failure_count,
-		       last_periodic_warning AT TIME ZONE current_setting('TimeZone') AS last_periodic_warning,
+		       last_periodic_warning,
 		       COALESCE(EXTRACT(EPOCH FROM periodic_warning_period), 0)::bigint AS periodic_warning_seconds
 		  FROM notif_statuses
 		 WHERE analysis_id = $1
@@ -246,11 +246,11 @@ func TestWarningStatementsRejectAnUnknownKind(t *testing.T) {
 func TestSetLastPeriodicWarning(t *testing.T) {
 	database, mock := newTestDB(t)
 
-	// The timestamp comes from the database, not from Go: the column is naive
-	// and holds local wall-clock time.
+	// The timestamp comes from Go and is cast to a naive timestamp, which stores
+	// the deployment's wall clock rather than the database session zone's.
 	mock.ExpectBegin()
-	mock.ExpectExec(`UPDATE notif_statuses SET last_periodic_warning = now()::timestamp WHERE analysis_id = $1`).
-		WithArgs(testAnalysisID).
+	mock.ExpectExec(`UPDATE notif_statuses SET last_periodic_warning = $2::timestamp WHERE analysis_id = $1`).
+		WithArgs(testAnalysisID, sqlmock.AnyArg()).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 	mock.ExpectCommit()
 

--- a/db/notifstatuses_test.go
+++ b/db/notifstatuses_test.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"errors"
 	"testing"
-	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/cyverse-de/app-exposer/constants"
@@ -246,18 +245,19 @@ func TestWarningStatementsRejectAnUnknownKind(t *testing.T) {
 
 func TestSetLastPeriodicWarning(t *testing.T) {
 	database, mock := newTestDB(t)
-	sentAt := time.Date(2026, 8, 10, 12, 0, 0, 0, time.UTC)
 
+	// The timestamp comes from the database, not from Go: the column is naive
+	// and holds local wall-clock time.
 	mock.ExpectBegin()
-	mock.ExpectExec(`UPDATE notif_statuses SET last_periodic_warning = $2 WHERE analysis_id = $1`).
-		WithArgs(testAnalysisID, sentAt).
+	mock.ExpectExec(`UPDATE notif_statuses SET last_periodic_warning = now()::timestamp WHERE analysis_id = $1`).
+		WithArgs(testAnalysisID).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 	mock.ExpectCommit()
 
 	tx, err := database.db.BeginTxx(context.Background(), nil)
 	require.NoError(t, err)
 
-	require.NoError(t, database.SetLastPeriodicWarning(context.Background(), tx, testAnalysisID, sentAt))
+	require.NoError(t, database.SetLastPeriodicWarning(context.Background(), tx, testAnalysisID))
 	require.NoError(t, tx.Commit())
 
 	assert.NoError(t, mock.ExpectationsWereMet())

--- a/db/timestamps.go
+++ b/db/timestamps.go
@@ -20,11 +20,13 @@ import "time"
 // pass a Go instant and cast the parameter with ::timestamp — never
 // ::timestamptz — so Postgres drops the offset and both sides of the comparison
 // are the deployment's wall clock. Values read back are relabeled by
-// inLocalZone.
+// InLocalZone.
 
-// inLocalZone reinterprets a naive timestamp's wall-clock fields as local time,
-// which is the zone the DE wrote them in.
-func inLocalZone(t *time.Time) *time.Time {
+// InLocalZone reinterprets a naive timestamp's wall-clock fields as local time,
+// which is the zone the DE wrote them in. Exported for the callers outside this
+// package that read one of these columns directly — there is one rule here, and
+// a second implementation of it would drift.
+func InLocalZone(t *time.Time) *time.Time {
 	return inZone(t, time.Local)
 }
 

--- a/db/timestamps.go
+++ b/db/timestamps.go
@@ -1,0 +1,44 @@
+package db
+
+import "time"
+
+// The DE stores analysis timestamps — jobs.start_date, jobs.planned_end_date,
+// notif_statuses.last_periodic_warning — in `timestamp without time zone`
+// columns holding wall-clock time in the deployment's zone. Every service that
+// writes them takes its zone from the same TZ setting, so the columns are
+// consistent with each other but carry no offset of their own.
+//
+// That makes the database session's TimeZone a trap. Comparing one of these
+// columns against now() converts it using the session zone, which is whatever
+// the server happens to be configured for (Etc/UTC, typically) rather than the
+// zone the value was written in, and reading one back through lib/pq yields a
+// time.Time labeled UTC for the same reason. Either way every instant lands off
+// by the local UTC offset — enough, on a US deployment against a UTC database,
+// to terminate an analysis hours before its time limit.
+//
+// This package therefore keeps the session zone out of it entirely. Comparisons
+// pass a Go instant and cast the parameter with ::timestamp — never
+// ::timestamptz — so Postgres drops the offset and both sides of the comparison
+// are the deployment's wall clock. Values read back are relabeled by
+// inLocalZone.
+
+// inLocalZone reinterprets a naive timestamp's wall-clock fields as local time,
+// which is the zone the DE wrote them in.
+func inLocalZone(t *time.Time) *time.Time {
+	return inZone(t, time.Local)
+}
+
+// inZone relabels a naive timestamp's wall-clock fields as being in loc, without
+// shifting them. nil passes through, since these columns are nullable.
+func inZone(t *time.Time, loc *time.Location) *time.Time {
+	if t == nil {
+		return nil
+	}
+
+	relabeled := time.Date(
+		t.Year(), t.Month(), t.Day(),
+		t.Hour(), t.Minute(), t.Second(), t.Nanosecond(),
+		loc,
+	)
+	return &relabeled
+}

--- a/db/timestamps.go
+++ b/db/timestamps.go
@@ -1,6 +1,9 @@
 package db
 
-import "time"
+import (
+	"os"
+	"time"
+)
 
 // The DE stores analysis timestamps — jobs.start_date, jobs.planned_end_date,
 // notif_statuses.last_periodic_warning — in `timestamp without time zone`
@@ -28,6 +31,21 @@ import "time"
 // a second implementation of it would drift.
 func InLocalZone(t *time.Time) *time.Time {
 	return inZone(t, time.Local)
+}
+
+// LocalZone describes the zone InLocalZone relabels into: its abbreviation, its
+// current offset from UTC, and whether the process was told which zone to use.
+//
+// Go falls back to UTC when TZ is unset or names a zone the image cannot
+// resolve, and that fallback is silent. On a deployment whose analyses were
+// written in a western zone it makes every planned end date look hours earlier
+// than it is, which terminates live analyses — the failure this whole file
+// exists to prevent. Callers log it at startup so the resolved zone is visible
+// before it matters.
+func LocalZone() (name string, offset time.Duration, configured bool) {
+	zone, seconds := time.Now().Zone()
+	_, configured = os.LookupEnv("TZ")
+	return zone, time.Duration(seconds) * time.Second, configured
 }
 
 // inZone relabels a naive timestamp's wall-clock fields as being in loc, without

--- a/db/timestamps_test.go
+++ b/db/timestamps_test.go
@@ -1,0 +1,90 @@
+package db
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func timePtr(t time.Time) *time.Time { return &t }
+
+// TestInZonePreservesTheWallClock covers the relabeling that makes the DE's
+// naive timestamp columns usable as instants. lib/pq hands these values back
+// labeled UTC whatever zone they were written in, so the wall clock has to be
+// kept and the label replaced — not converted, which would move the wall clock
+// and leave the instant just as wrong.
+func TestInZonePreservesTheWallClock(t *testing.T) {
+	phoenix, err := time.LoadLocation("America/Phoenix")
+	require.NoError(t, err)
+
+	tests := []struct {
+		name string
+		in   *time.Time
+		loc  *time.Location
+		// wantOffsetHours is the difference between the relabeled instant and
+		// the same wall clock read as UTC.
+		wantOffsetHours int
+	}{
+		{
+			name:            "a naive value relabeled into a western zone moves the instant later",
+			in:              timePtr(time.Date(2026, 8, 11, 15, 31, 44, 0, time.UTC)),
+			loc:             phoenix,
+			wantOffsetHours: 7,
+		},
+		{
+			name:            "relabeling into UTC is a no-op",
+			in:              timePtr(time.Date(2026, 8, 11, 15, 31, 44, 0, time.UTC)),
+			loc:             time.UTC,
+			wantOffsetHours: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := inZone(tt.in, tt.loc)
+			require.NotNil(t, got)
+
+			assert.Equal(t, tt.in.Format("2006-01-02T15:04:05"), got.Format("2006-01-02T15:04:05"),
+				"the wall clock must be preserved exactly")
+			assert.Equal(t, tt.loc, got.Location())
+			assert.Equal(t, time.Duration(tt.wantOffsetHours)*time.Hour, got.Sub(*tt.in),
+				"the instant must move by the zone's offset")
+		})
+	}
+}
+
+func TestInZonePassesNilThrough(t *testing.T) {
+	assert.Nil(t, inZone(nil, time.UTC))
+	assert.Nil(t, inLocalZone(nil))
+}
+
+// TestNaiveTimestampsAreNeverComparedAgainstNow is a regression guard on the bug
+// that terminated live analyses: comparing one of these naive columns against
+// SQL now() makes Postgres resolve it in the database session's zone rather than
+// the deployment's, so on a UTC session every analysis looked hours older than
+// it was. The cutoffs must come from Go and be cast with ::timestamp.
+func TestNaiveTimestampsAreNeverComparedAgainstNow(t *testing.T) {
+	tests := []struct {
+		name  string
+		query string
+	}{
+		{name: "expired", query: expiredAnalysesQuery},
+		{name: "expiring within a window", query: expiringWithinQuery},
+		{name: "due for a periodic reminder", query: periodicReminderQuery},
+		{name: "initial runtime write", query: initialRuntimeStmt},
+		{name: "last periodic warning write", query: lastPeriodicWarningStmt},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.NotContains(t, tt.query, "now()",
+				"the database clock resolves naive columns in the session zone")
+			assert.NotContains(t, tt.query, "current_setting('TimeZone')",
+				"the session zone is not the zone these columns were written in")
+			assert.Contains(t, tt.query, "::timestamp",
+				"the Go-supplied cutoff must be cast to a naive timestamp")
+		})
+	}
+}

--- a/db/timestamps_test.go
+++ b/db/timestamps_test.go
@@ -57,7 +57,7 @@ func TestInZonePreservesTheWallClock(t *testing.T) {
 
 func TestInZonePassesNilThrough(t *testing.T) {
 	assert.Nil(t, inZone(nil, time.UTC))
-	assert.Nil(t, inLocalZone(nil))
+	assert.Nil(t, InLocalZone(nil))
 }
 
 // TestNaiveTimestampsAreNeverComparedAgainstNow is a regression guard on the bug

--- a/db/timestamps_test.go
+++ b/db/timestamps_test.go
@@ -71,7 +71,8 @@ func TestNaiveTimestampsAreNeverComparedAgainstNow(t *testing.T) {
 		query string
 	}{
 		{name: "expired", query: expiredAnalysesQuery},
-		{name: "expiring within a window", query: expiringWithinQuery},
+		{name: "expiring within the day window", query: expiringWithinQueries[DayWarning]},
+		{name: "expiring within the hour window", query: expiringWithinQueries[HourWarning]},
 		{name: "due for a periodic reminder", query: periodicReminderQuery},
 		{name: "initial runtime write", query: initialRuntimeStmt},
 		{name: "last periodic warning write", query: lastPeriodicWarningStmt},

--- a/expiration/expiration.go
+++ b/expiration/expiration.go
@@ -139,10 +139,39 @@ func (w *Worker) sweep(ctx context.Context) {
 		}
 	}()
 
+	w.repairRuntime(ctx)
 	w.warnExpiring(ctx, w.expiryWarning, db.HourWarning)
 	w.warnExpiring(ctx, DayExpiryWarning, db.DayWarning)
 	w.remindStillRunning(ctx)
 	w.terminateExpired(ctx)
+}
+
+// repairRuntime fills in the subdomain and planned end date of any running VICE
+// analysis that is missing them. It runs first so an analysis repaired this
+// sweep is a candidate for the passes that follow.
+//
+// The AMQP consumer in this package does the same repair as job status updates
+// arrive, but it only exists when amqp.uri is configured. This pass is the one
+// that is always present: without it, an analysis whose launch-time write
+// failed would be unroutable and would never expire, with nothing to notice.
+func (w *Worker) repairRuntime(ctx context.Context) {
+	analyses, err := w.db.ListAnalysesMissingRuntime(ctx)
+	if err != nil {
+		log.Errorf("listing analyses missing a subdomain or planned end date: %v", err)
+		return
+	}
+
+	for i := range analyses {
+		analysis := &analyses[i]
+		if analysis.ExternalID == "" {
+			// No job_steps row yet, so there is no external ID to derive the
+			// subdomain from. The next sweep picks it up.
+			continue
+		}
+		initializeRuntime(ctx, w.db, analysis, analysis.ExternalID, log.WithFields(logrus.Fields{
+			"analysisID": analysis.ID,
+		}))
+	}
 }
 
 // warnExpiring warns the owners of analyses expiring inside the given window.
@@ -188,7 +217,7 @@ func (w *Worker) remindStillRunning(ctx context.Context) {
 				// harmless and the reminder period paces the retries.
 				return err
 			}
-			return w.db.SetLastPeriodicWarning(ctx, tx, analysis.ID, time.Now())
+			return w.db.SetLastPeriodicWarning(ctx, tx, analysis.ID)
 		})
 		w.logClaimResult(analysis, "periodic reminder", claimErr)
 	}

--- a/expiration/expiration.go
+++ b/expiration/expiration.go
@@ -1,0 +1,305 @@
+// Package expiration enforces the time limits on VICE analyses. A background
+// worker periodically warns users whose analyses are about to expire, sends the
+// periodic "still running" reminder, and terminates analyses that have run past
+// their planned end date. It also backfills the runtime fields an analysis
+// needs (subdomain, planned end date) if they were not set at launch.
+//
+// This work moved here from the standalone `timelord` service. Running it
+// inside app-exposer removes the HTTP hop it used to make back into app-exposer
+// to terminate an analysis, and lets it share the operator scheduler.
+package expiration
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/cyverse-de/app-exposer/common"
+	"github.com/cyverse-de/app-exposer/db"
+	"github.com/cyverse-de/app-exposer/incluster"
+	"github.com/cyverse-de/app-exposer/notifications"
+	"github.com/cyverse-de/app-exposer/operatorclient"
+	"github.com/jmoiron/sqlx"
+	"github.com/sirupsen/logrus"
+)
+
+var log = common.Log.WithFields(logrus.Fields{"package": "expiration"})
+
+const (
+	// DefaultSweepInterval is how often the worker re-examines running
+	// analyses. Warnings and terminations are both driven off planned end
+	// dates, so the cadence bounds how late either can be.
+	DefaultSweepInterval = 10 * time.Second
+
+	// DefaultExpiryWarning is how far ahead of expiry the short-notice
+	// warning goes out.
+	DefaultExpiryWarning = time.Hour
+
+	// DayExpiryWarning is how far ahead of expiry the day-notice warning
+	// goes out.
+	DayExpiryWarning = 24 * time.Hour
+
+	// DefaultPeriodicReminderPeriod is how often a long-running analysis's
+	// "still running" reminder repeats when the analysis did not request an
+	// interval of its own.
+	DefaultPeriodicReminderPeriod = 4 * time.Hour
+
+	// MaxNotificationAttempts bounds how many times delivery of a single
+	// notification is retried before the DE gives up and stops trying. Without
+	// it a persistently unreachable recipient would be retried on every sweep
+	// for the life of the analysis.
+	MaxNotificationAttempts = 3
+)
+
+// completedMessage is recorded against an analysis that the DE marks Completed
+// because it is no longer running anywhere. It lands in the job status history,
+// so it names the reason rather than just the new state.
+const completedMessage = "analysis is past its planned end date and is not running in any cluster; marking it Completed"
+
+// Init configures a Worker.
+type Init struct {
+	// SweepInterval is how often to examine running analyses. Zero selects
+	// DefaultSweepInterval.
+	SweepInterval time.Duration
+
+	// ExpiryWarning is how far ahead of expiry to send the short-notice
+	// warning. Zero selects DefaultExpiryWarning.
+	ExpiryWarning time.Duration
+}
+
+// Worker runs the periodic expiration sweep.
+type Worker struct {
+	db            db.ExpirationDB
+	notifier      notifications.AnalysisNotifier
+	scheduler     *operatorclient.Scheduler
+	status        incluster.AnalysisStatusPublisher
+	sweepInterval time.Duration
+	expiryWarning time.Duration
+}
+
+// New creates a Worker. The scheduler is used both to find which cluster is
+// running an analysis and to terminate it there; status publishes to
+// job-status-listener for analyses that have already vanished from every
+// cluster.
+func New(
+	database db.ExpirationDB,
+	notifier notifications.AnalysisNotifier,
+	scheduler *operatorclient.Scheduler,
+	status incluster.AnalysisStatusPublisher,
+	init Init,
+) *Worker {
+	w := &Worker{
+		db:            database,
+		notifier:      notifier,
+		scheduler:     scheduler,
+		status:        status,
+		sweepInterval: init.SweepInterval,
+		expiryWarning: init.ExpiryWarning,
+	}
+	if w.sweepInterval <= 0 {
+		w.sweepInterval = DefaultSweepInterval
+	}
+	if w.expiryWarning <= 0 {
+		w.expiryWarning = DefaultExpiryWarning
+	}
+	return w
+}
+
+// Run sweeps until the context is canceled. The first sweep happens
+// immediately so a restart doesn't delay an overdue termination.
+func (w *Worker) Run(ctx context.Context) {
+	log.Infof(
+		"starting analysis expiration worker (sweep every %s, expiry warning %s ahead)",
+		w.sweepInterval, w.expiryWarning,
+	)
+
+	ticker := time.NewTicker(w.sweepInterval)
+	defer ticker.Stop()
+
+	w.sweep(ctx)
+
+	for {
+		select {
+		case <-ctx.Done():
+			log.Info("stopping analysis expiration worker")
+			return
+		case <-ticker.C:
+			w.sweep(ctx)
+		}
+	}
+}
+
+// sweep runs one pass of all four responsibilities. Each pass is guarded
+// against panics: this worker is secondary to app-exposer's API, and a panic
+// here would otherwise take the VICE launch path down with it.
+func (w *Worker) sweep(ctx context.Context) {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Errorf("panic in analysis expiration sweep, skipping this pass: %v", r)
+		}
+	}()
+
+	w.warnExpiring(ctx, w.expiryWarning, db.HourWarning)
+	w.warnExpiring(ctx, DayExpiryWarning, db.DayWarning)
+	w.remindStillRunning(ctx)
+	w.terminateExpired(ctx)
+}
+
+// warnExpiring warns the owners of analyses expiring inside the given window.
+func (w *Worker) warnExpiring(ctx context.Context, window time.Duration, kind db.WarningKind) {
+	analyses, err := w.db.ListAnalysesExpiringWithin(ctx, window)
+	if err != nil {
+		log.Errorf("listing analyses expiring within %s: %v", window, err)
+		return
+	}
+
+	for i := range analyses {
+		analysis := &analyses[i]
+		if !w.trackNotifications(ctx, analysis) {
+			continue
+		}
+		w.deliver(ctx, analysis, kind)
+	}
+}
+
+// remindStillRunning sends the periodic "your analysis is still running"
+// reminder to the owners of analyses whose reminder period has elapsed.
+func (w *Worker) remindStillRunning(ctx context.Context) {
+	analyses, err := w.db.ListAnalysesDueForPeriodicReminder(ctx)
+	if err != nil {
+		log.Errorf("listing analyses due for a periodic reminder: %v", err)
+		return
+	}
+
+	for i := range analyses {
+		analysis := &analyses[i]
+		if !w.trackNotifications(ctx, analysis) {
+			continue
+		}
+
+		claimErr := w.db.ClaimNotifStatuses(ctx, analysis.ID, func(tx *sqlx.Tx, statuses *db.NotifStatuses) error {
+			if !reminderDue(analysis, statuses, time.Now()) {
+				return nil
+			}
+			if err := w.notifier.NotifyStillRunning(ctx, analysis); err != nil {
+				// Roll back rather than record a send that didn't happen;
+				// the next sweep retries. Unlike the expiry warnings there
+				// is no attempt ceiling here, because a missed reminder is
+				// harmless and the reminder period paces the retries.
+				return err
+			}
+			return w.db.SetLastPeriodicWarning(ctx, tx, analysis.ID, time.Now())
+		})
+		w.logClaimResult(analysis, "periodic reminder", claimErr)
+	}
+}
+
+// reminderDue reports whether an analysis's periodic reminder is due. The
+// reminder is paced from the later of the analysis's start and its last
+// reminder, so a freshly started analysis waits a full period before its first
+// one rather than being reminded immediately.
+func reminderDue(analysis *db.Analysis, statuses *db.NotifStatuses, now time.Time) bool {
+	if analysis.StartDate == nil {
+		return false
+	}
+
+	period := DefaultPeriodicReminderPeriod
+	if statuses.PeriodicWarningSeconds > 0 {
+		period = time.Duration(statuses.PeriodicWarningSeconds) * time.Second
+	}
+
+	since := *analysis.StartDate
+	if statuses.LastPeriodicWarning != nil && statuses.LastPeriodicWarning.After(since) {
+		since = *statuses.LastPeriodicWarning
+	}
+
+	return since.Add(period).Before(now)
+}
+
+// deliver sends one of the expiry notifications for an analysis, exactly once
+// across all replicas, and records the outcome.
+//
+// Delivery failures are counted rather than retried immediately; after
+// MaxNotificationAttempts the notification is marked sent so the DE stops
+// trying. The counter is committed even on failure, which is why fn returns nil
+// on the failure path.
+func (w *Worker) deliver(ctx context.Context, analysis *db.Analysis, kind db.WarningKind) {
+	claimErr := w.db.ClaimNotifStatuses(ctx, analysis.ID, func(tx *sqlx.Tx, statuses *db.NotifStatuses) error {
+		if statuses.Sent(kind) {
+			return nil
+		}
+
+		sendErr := w.notify(ctx, analysis, kind)
+		if sendErr == nil {
+			return w.db.SetWarningSent(ctx, tx, kind, analysis.ID, true)
+		}
+
+		failures := statuses.FailureCount(kind) + 1
+		log.Errorf(
+			"delivering %s notification for analysis %s failed (attempt %d of %d); "+
+				"this usually means notification-agent or iplant-groups is unreachable: %v",
+			kind, analysis.ID, failures, MaxNotificationAttempts, sendErr,
+		)
+
+		if err := w.db.SetWarningFailureCount(ctx, tx, kind, analysis.ID, failures); err != nil {
+			return err
+		}
+
+		if failures >= MaxNotificationAttempts {
+			log.Warnf(
+				"giving up on the %s notification for analysis %s after %d failed attempts",
+				kind, analysis.ID, failures,
+			)
+			return w.db.SetWarningSent(ctx, tx, kind, analysis.ID, true)
+		}
+
+		return nil
+	})
+	w.logClaimResult(analysis, string(kind)+" notification", claimErr)
+}
+
+// notify dispatches to the notification matching the warning kind.
+func (w *Worker) notify(ctx context.Context, analysis *db.Analysis, kind db.WarningKind) error {
+	switch kind {
+	case db.KillWarning:
+		return w.notifier.NotifyTerminated(ctx, analysis)
+	case db.DayWarning, db.HourWarning:
+		return w.notifier.NotifyExpiringSoon(ctx, analysis)
+	}
+	return errors.New("unknown warning kind " + string(kind))
+}
+
+// trackNotifications makes sure the analysis has a notification-tracking row,
+// reporting whether it is safe to go on and notify. Analyses with no external
+// ID yet are skipped: they have no job_steps row, so nothing can be tracked or
+// terminated for them.
+func (w *Worker) trackNotifications(ctx context.Context, analysis *db.Analysis) bool {
+	if analysis.ExternalID == "" {
+		log.Warnf(
+			"analysis %s has no external ID; skipping it this pass. "+
+				"This usually means its job_steps row hasn't been written yet",
+			analysis.ID,
+		)
+		return false
+	}
+
+	if err := w.db.EnsureNotifStatuses(ctx, analysis.ID, analysis.ExternalID, analysis.PeriodicPeriod); err != nil {
+		log.Errorf("creating the notification-tracking row for analysis %s: %v", analysis.ID, err)
+		return false
+	}
+
+	return true
+}
+
+// logClaimResult reports the outcome of a claimed notification attempt. Losing
+// the claim is the expected outcome on every replica but one, so it is logged
+// at debug level.
+func (w *Worker) logClaimResult(analysis *db.Analysis, what string, err error) {
+	switch {
+	case err == nil:
+	case errors.Is(err, db.ErrNotClaimed):
+		log.Debugf("another replica is handling the %s for analysis %s", what, analysis.ID)
+	default:
+		log.Errorf("handling the %s for analysis %s: %v", what, analysis.ID, err)
+	}
+}

--- a/expiration/expiration.go
+++ b/expiration/expiration.go
@@ -11,7 +11,6 @@ package expiration
 
 import (
 	"context"
-	"errors"
 	"time"
 
 	"github.com/cyverse-de/app-exposer/common"
@@ -19,7 +18,6 @@ import (
 	"github.com/cyverse-de/app-exposer/incluster"
 	"github.com/cyverse-de/app-exposer/notifications"
 	"github.com/cyverse-de/app-exposer/operatorclient"
-	"github.com/jmoiron/sqlx"
 	"github.com/sirupsen/logrus"
 )
 
@@ -46,9 +44,22 @@ const (
 
 	// MaxNotificationAttempts bounds how many times delivery of a single
 	// notification is retried before the DE gives up and stops trying. Without
-	// it a persistently unreachable recipient would be retried on every sweep
-	// for the life of the analysis.
-	MaxNotificationAttempts = 3
+	// it a persistently unreachable recipient would be retried for the life of
+	// the analysis.
+	//
+	// Attempts are spaced by an exponential backoff (see retry.go), so the
+	// ceiling is reached after a couple of hours of failures rather than after a
+	// couple of sweeps. Both numbers have to be read together: raising the
+	// ceiling without the pacing is what let a brief restart of
+	// notification-agent abandon every notification in flight.
+	MaxNotificationAttempts = 10
+
+	// DefaultNotificationBudget bounds how long one sweep may spend sending
+	// notifications. Terminations run first and notifications second, so the
+	// budget is what keeps a notification-agent that hangs rather than refuses
+	// from pushing the next sweep — and with it the next round of terminations —
+	// arbitrarily far out.
+	DefaultNotificationBudget = 2 * time.Minute
 )
 
 // completedMessage is recorded against an analysis that the DE marks Completed
@@ -65,16 +76,23 @@ type Init struct {
 	// ExpiryWarning is how far ahead of expiry to send the short-notice
 	// warning. Zero selects DefaultExpiryWarning.
 	ExpiryWarning time.Duration
+
+	// NotificationBudget is how long one sweep may spend on notifications
+	// before deferring the rest to the next sweep. Zero selects
+	// DefaultNotificationBudget.
+	NotificationBudget time.Duration
 }
 
 // Worker runs the periodic expiration sweep.
 type Worker struct {
-	db            db.ExpirationDB
-	notifier      notifications.AnalysisNotifier
-	scheduler     *operatorclient.Scheduler
-	status        incluster.AnalysisStatusPublisher
-	sweepInterval time.Duration
-	expiryWarning time.Duration
+	db                 db.ExpirationDB
+	notifier           notifications.AnalysisNotifier
+	scheduler          *operatorclient.Scheduler
+	status             incluster.AnalysisStatusPublisher
+	sweepInterval      time.Duration
+	expiryWarning      time.Duration
+	notificationBudget time.Duration
+	retries            *retryTracker
 }
 
 // New creates a Worker. The scheduler is used both to find which cluster is
@@ -89,18 +107,23 @@ func New(
 	init Init,
 ) *Worker {
 	w := &Worker{
-		db:            database,
-		notifier:      notifier,
-		scheduler:     scheduler,
-		status:        status,
-		sweepInterval: init.SweepInterval,
-		expiryWarning: init.ExpiryWarning,
+		db:                 database,
+		notifier:           notifier,
+		scheduler:          scheduler,
+		status:             status,
+		sweepInterval:      init.SweepInterval,
+		expiryWarning:      init.ExpiryWarning,
+		notificationBudget: init.NotificationBudget,
+		retries:            newRetryTracker(),
 	}
 	if w.sweepInterval <= 0 {
 		w.sweepInterval = DefaultSweepInterval
 	}
 	if w.expiryWarning <= 0 {
 		w.expiryWarning = DefaultExpiryWarning
+	}
+	if w.notificationBudget <= 0 {
+		w.notificationBudget = DefaultNotificationBudget
 	}
 	return w
 }
@@ -112,6 +135,7 @@ func (w *Worker) Run(ctx context.Context) {
 		"starting analysis expiration worker (sweep every %s, expiry warning %s ahead)",
 		w.sweepInterval, w.expiryWarning,
 	)
+	logLocalZone()
 
 	ticker := time.NewTicker(w.sweepInterval)
 	defer ticker.Stop()
@@ -129,9 +153,31 @@ func (w *Worker) Run(ctx context.Context) {
 	}
 }
 
+// logLocalZone reports the zone the DE's naive analysis timestamps are read and
+// written in. It is resolved from the process environment rather than from
+// configuration, so this is the only place the deployment gets to see what it
+// actually resolved to before an analysis is terminated on the strength of it.
+func logLocalZone() {
+	name, offset, configured := db.LocalZone()
+	log.Infof("analysis timestamps are interpreted as wall-clock time in %s (UTC%+.0fh)", name, offset.Hours())
+	if !configured {
+		log.Warnf(
+			"TZ is not set, so analysis timestamps are being interpreted in %s. If the DE writes them in "+
+				"another zone, every analysis expires early by the difference; set TZ to the deployment's zone",
+			name,
+		)
+	}
+}
+
 // sweep runs one pass of all four responsibilities. Each pass is guarded
 // against panics: this worker is secondary to app-exposer's API, and a panic
 // here would otherwise take the VICE launch path down with it.
+//
+// Terminations run before notifications, under their own unbounded context,
+// because they are the pass with a deadline the DE cannot make up later: an
+// analysis left running past its time limit holds a node and the user's quota.
+// The notification passes share one budget, so a notification-agent that hangs
+// delays warnings rather than terminations.
 func (w *Worker) sweep(ctx context.Context) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -140,10 +186,17 @@ func (w *Worker) sweep(ctx context.Context) {
 	}()
 
 	w.repairRuntime(ctx)
-	w.warnExpiring(ctx, w.expiryWarning, db.HourWarning)
-	w.warnExpiring(ctx, DayExpiryWarning, db.DayWarning)
-	w.remindStillRunning(ctx)
-	w.terminateExpired(ctx)
+	terminated := w.terminateExpired(ctx)
+
+	notifyCtx, cancel := context.WithTimeout(ctx, w.notificationBudget)
+	defer cancel()
+
+	w.notifyTerminated(notifyCtx, terminated)
+	w.warnExpiring(notifyCtx, 0, w.expiryWarning, db.HourWarning)
+	w.warnExpiring(notifyCtx, w.expiryWarning, DayExpiryWarning, db.DayWarning)
+	w.remindStillRunning(notifyCtx)
+
+	w.retries.prune(time.Now())
 }
 
 // repairRuntime fills in the subdomain and planned end date of any running VICE
@@ -171,164 +224,5 @@ func (w *Worker) repairRuntime(ctx context.Context) {
 		initializeRuntime(ctx, w.db, analysis, analysis.ExternalID, log.WithFields(logrus.Fields{
 			"analysisID": analysis.ID,
 		}))
-	}
-}
-
-// warnExpiring warns the owners of analyses expiring inside the given window.
-func (w *Worker) warnExpiring(ctx context.Context, window time.Duration, kind db.WarningKind) {
-	analyses, err := w.db.ListAnalysesExpiringWithin(ctx, window)
-	if err != nil {
-		log.Errorf("listing analyses expiring within %s: %v", window, err)
-		return
-	}
-
-	for i := range analyses {
-		analysis := &analyses[i]
-		if !w.trackNotifications(ctx, analysis) {
-			continue
-		}
-		w.deliver(ctx, analysis, kind)
-	}
-}
-
-// remindStillRunning sends the periodic "your analysis is still running"
-// reminder to the owners of analyses whose reminder period has elapsed.
-func (w *Worker) remindStillRunning(ctx context.Context) {
-	analyses, err := w.db.ListAnalysesDueForPeriodicReminder(ctx)
-	if err != nil {
-		log.Errorf("listing analyses due for a periodic reminder: %v", err)
-		return
-	}
-
-	for i := range analyses {
-		analysis := &analyses[i]
-		if !w.trackNotifications(ctx, analysis) {
-			continue
-		}
-
-		claimErr := w.db.ClaimNotifStatuses(ctx, analysis.ID, func(tx *sqlx.Tx, statuses *db.NotifStatuses) error {
-			if !reminderDue(analysis, statuses, time.Now()) {
-				return nil
-			}
-			if err := w.notifier.NotifyStillRunning(ctx, analysis); err != nil {
-				// Roll back rather than record a send that didn't happen;
-				// the next sweep retries. Unlike the expiry warnings there
-				// is no attempt ceiling here, because a missed reminder is
-				// harmless and the reminder period paces the retries.
-				return err
-			}
-			return w.db.SetLastPeriodicWarning(ctx, tx, analysis.ID)
-		})
-		w.logClaimResult(analysis, "periodic reminder", claimErr)
-	}
-}
-
-// reminderDue reports whether an analysis's periodic reminder is due. The
-// reminder is paced from the later of the analysis's start and its last
-// reminder, so a freshly started analysis waits a full period before its first
-// one rather than being reminded immediately.
-func reminderDue(analysis *db.Analysis, statuses *db.NotifStatuses, now time.Time) bool {
-	if analysis.StartDate == nil {
-		return false
-	}
-
-	period := DefaultPeriodicReminderPeriod
-	if statuses.PeriodicWarningSeconds > 0 {
-		period = time.Duration(statuses.PeriodicWarningSeconds) * time.Second
-	}
-
-	since := *analysis.StartDate
-	if statuses.LastPeriodicWarning != nil && statuses.LastPeriodicWarning.After(since) {
-		since = *statuses.LastPeriodicWarning
-	}
-
-	return since.Add(period).Before(now)
-}
-
-// deliver sends one of the expiry notifications for an analysis, exactly once
-// across all replicas, and records the outcome.
-//
-// Delivery failures are counted rather than retried immediately; after
-// MaxNotificationAttempts the notification is marked sent so the DE stops
-// trying. The counter is committed even on failure, which is why fn returns nil
-// on the failure path.
-func (w *Worker) deliver(ctx context.Context, analysis *db.Analysis, kind db.WarningKind) {
-	claimErr := w.db.ClaimNotifStatuses(ctx, analysis.ID, func(tx *sqlx.Tx, statuses *db.NotifStatuses) error {
-		if statuses.Sent(kind) {
-			return nil
-		}
-
-		sendErr := w.notify(ctx, analysis, kind)
-		if sendErr == nil {
-			return w.db.SetWarningSent(ctx, tx, kind, analysis.ID, true)
-		}
-
-		failures := statuses.FailureCount(kind) + 1
-		log.Errorf(
-			"delivering %s notification for analysis %s failed (attempt %d of %d); "+
-				"this usually means notification-agent or iplant-groups is unreachable: %v",
-			kind, analysis.ID, failures, MaxNotificationAttempts, sendErr,
-		)
-
-		if err := w.db.SetWarningFailureCount(ctx, tx, kind, analysis.ID, failures); err != nil {
-			return err
-		}
-
-		if failures >= MaxNotificationAttempts {
-			log.Warnf(
-				"giving up on the %s notification for analysis %s after %d failed attempts",
-				kind, analysis.ID, failures,
-			)
-			return w.db.SetWarningSent(ctx, tx, kind, analysis.ID, true)
-		}
-
-		return nil
-	})
-	w.logClaimResult(analysis, string(kind)+" notification", claimErr)
-}
-
-// notify dispatches to the notification matching the warning kind.
-func (w *Worker) notify(ctx context.Context, analysis *db.Analysis, kind db.WarningKind) error {
-	switch kind {
-	case db.KillWarning:
-		return w.notifier.NotifyTerminated(ctx, analysis)
-	case db.DayWarning, db.HourWarning:
-		return w.notifier.NotifyExpiringSoon(ctx, analysis)
-	}
-	return errors.New("unknown warning kind " + string(kind))
-}
-
-// trackNotifications makes sure the analysis has a notification-tracking row,
-// reporting whether it is safe to go on and notify. Analyses with no external
-// ID yet are skipped: they have no job_steps row, so nothing can be tracked or
-// terminated for them.
-func (w *Worker) trackNotifications(ctx context.Context, analysis *db.Analysis) bool {
-	if analysis.ExternalID == "" {
-		log.Warnf(
-			"analysis %s has no external ID; skipping it this pass. "+
-				"This usually means its job_steps row hasn't been written yet",
-			analysis.ID,
-		)
-		return false
-	}
-
-	if err := w.db.EnsureNotifStatuses(ctx, analysis.ID, analysis.ExternalID, analysis.PeriodicPeriod); err != nil {
-		log.Errorf("creating the notification-tracking row for analysis %s: %v", analysis.ID, err)
-		return false
-	}
-
-	return true
-}
-
-// logClaimResult reports the outcome of a claimed notification attempt. Losing
-// the claim is the expected outcome on every replica but one, so it is logged
-// at debug level.
-func (w *Worker) logClaimResult(analysis *db.Analysis, what string, err error) {
-	switch {
-	case err == nil:
-	case errors.Is(err, db.ErrNotClaimed):
-		log.Debugf("another replica is handling the %s for analysis %s", what, analysis.ID)
-	default:
-		log.Errorf("handling the %s for analysis %s: %v", what, analysis.ID, err)
 	}
 }

--- a/expiration/expiration_test.go
+++ b/expiration/expiration_test.go
@@ -30,13 +30,17 @@ type fakeExpirationDB struct {
 
 	interactive bool
 
+	// completedStatusFor records the external IDs already reported Completed.
+	completedStatusFor map[constants.ExternalID]bool
+
 	// Injected errors (nil by default).
-	expiringErr       error
-	expiredErr        error
-	periodicErr       error
-	missingRuntimeErr error
-	ensureErr         error
-	initErr           error
+	expiringErr        error
+	expiredErr         error
+	periodicErr        error
+	missingRuntimeErr  error
+	ensureErr          error
+	initErr            error
+	completedStatusErr error
 
 	// Recorded side effects.
 	ensured        []constants.AnalysisID
@@ -56,6 +60,8 @@ func newFakeDB() *fakeExpirationDB {
 		sentFlags:     map[string]bool{},
 		failureCounts: map[string]int{},
 		lastPeriodic:  map[constants.AnalysisID]time.Time{},
+
+		completedStatusFor: map[constants.ExternalID]bool{},
 	}
 }
 
@@ -89,6 +95,13 @@ func (f *fakeExpirationDB) GetAnalysisByExternalID(_ context.Context, externalID
 
 func (f *fakeExpirationDB) IsInteractive(context.Context, constants.AnalysisID) (bool, error) {
 	return f.interactive, nil
+}
+
+func (f *fakeExpirationDB) HasCompletedStatus(_ context.Context, externalID constants.ExternalID) (bool, error) {
+	if f.completedStatusErr != nil {
+		return false, f.completedStatusErr
+	}
+	return f.completedStatusFor[externalID], nil
 }
 
 func (f *fakeExpirationDB) InitializeRuntime(_ context.Context, analysisID constants.AnalysisID, _, _ string) (bool, error) {
@@ -545,6 +558,82 @@ func TestHandleIndeterminate(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestMarkCompletedPublishesOnlyOnce covers the guard on the one action in the
+// sweep that is not claim-guarded. An expired analysis that has left every
+// cluster is reconciled by publishing a Completed status, after which the DE
+// transitions it and it stops being returned as expired. When that transition
+// does not happen — a stalled job-status pipeline, a jobs row pinned by someone
+// else's long-running transaction — the analysis stays expired forever, and an
+// unguarded publish becomes one status update per sweep per replica without end.
+func TestMarkCompletedPublishesOnlyOnce(t *testing.T) {
+	const id = constants.AnalysisID("analysis-1")
+
+	tests := []struct {
+		name            string
+		alreadyReported bool
+		lookupErr       error
+		wantPublished   bool
+	}{
+		{
+			name:          "publishes when nothing has been reported yet",
+			wantPublished: true,
+		},
+		{
+			name:            "does not re-publish once a Completed status is recorded",
+			alreadyReported: true,
+		},
+		{
+			name:      "skips the analysis when the check itself fails",
+			lookupErr: errors.New("connection reset"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			database := newFakeDB()
+			status := &fakeStatusPublisher{}
+			w := New(database, &fakeNotifier{}, nil, status, Init{})
+
+			analysis := testAnalysis(id)
+			database.completedStatusFor[analysis.ExternalID] = tt.alreadyReported
+			database.completedStatusErr = tt.lookupErr
+
+			w.markCompleted(context.Background(), &analysis)
+
+			if tt.wantPublished {
+				assert.Equal(t, []string{string(analysis.ExternalID)}, status.succeeded)
+			} else {
+				assert.Empty(t, status.succeeded)
+			}
+		})
+	}
+}
+
+// TestMarkCompletedStopsRepublishingAcrossSweeps is the regression the guard
+// exists for: a durable record is what makes repeated sweeps converge, so this
+// asserts the behavior over several passes rather than a single call.
+func TestMarkCompletedStopsRepublishingAcrossSweeps(t *testing.T) {
+	const id = constants.AnalysisID("analysis-1")
+
+	database := newFakeDB()
+	status := &fakeStatusPublisher{}
+	w := New(database, &fakeNotifier{}, nil, status, Init{})
+
+	analysis := testAnalysis(id)
+
+	for range 5 {
+		w.markCompleted(context.Background(), &analysis)
+		// Stands in for the status update the publish records, which is what a
+		// later sweep — on this replica or any other — reads back.
+		if len(status.succeeded) > 0 {
+			database.completedStatusFor[analysis.ExternalID] = true
+		}
+	}
+
+	assert.Equal(t, []string{string(analysis.ExternalID)}, status.succeeded,
+		"five sweeps of the same stuck analysis must publish exactly one status update")
 }
 
 // TestRepairRuntime covers the sweep-driven repair of the runtime fields. It is

--- a/expiration/expiration_test.go
+++ b/expiration/expiration_test.go
@@ -15,6 +15,15 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// expiringWindow records one ListAnalysesExpiringWithin call, so tests can
+// assert on the windows the sweep asks for as well as on what it does with the
+// answers.
+type expiringWindow struct {
+	kind db.WarningKind
+	from time.Duration
+	to   time.Duration
+}
+
 // fakeExpirationDB implements db.ExpirationDB for unit tests. It records the
 // bookkeeping the worker performs so assertions can be made against it, and
 // per-method errors can be injected to exercise the failure paths.
@@ -43,13 +52,15 @@ type fakeExpirationDB struct {
 	completedStatusErr error
 
 	// Recorded side effects.
-	ensured        []constants.AnalysisID
-	sentFlags      map[string]bool
-	failureCounts  map[string]int
-	lastPeriodic   map[constants.AnalysisID]time.Time
-	initRuntimeFor []constants.AnalysisID
-	initChanged    bool
-	commits        int
+	calls           []string
+	expiringWindows []expiringWindow
+	ensured         []constants.AnalysisID
+	sentFlags       map[string]bool
+	failureCounts   map[string]int
+	lastPeriodic    map[constants.AnalysisID]time.Time
+	initRuntimeFor  []constants.AnalysisID
+	initChanged     bool
+	commits         int
 }
 
 func newFakeDB() *fakeExpirationDB {
@@ -70,14 +81,18 @@ func flagKey(kind db.WarningKind, id constants.AnalysisID) string {
 }
 
 func (f *fakeExpirationDB) ListExpiredAnalyses(context.Context) ([]db.Analysis, error) {
+	f.calls = append(f.calls, "expired")
 	return f.expired, f.expiredErr
 }
 
-func (f *fakeExpirationDB) ListAnalysesExpiringWithin(context.Context, time.Duration) ([]db.Analysis, error) {
+func (f *fakeExpirationDB) ListAnalysesExpiringWithin(_ context.Context, kind db.WarningKind, from, to time.Duration) ([]db.Analysis, error) {
+	f.calls = append(f.calls, "expiring:"+string(kind))
+	f.expiringWindows = append(f.expiringWindows, expiringWindow{kind: kind, from: from, to: to})
 	return f.expiring, f.expiringErr
 }
 
 func (f *fakeExpirationDB) ListAnalysesDueForPeriodicReminder(context.Context) ([]db.Analysis, error) {
+	f.calls = append(f.calls, "periodic")
 	return f.periodic, f.periodicErr
 }
 
@@ -340,7 +355,7 @@ func TestWarnExpiring(t *testing.T) {
 			notifier := &fakeNotifier{err: tt.notifyErr}
 			w := newTestWorker(database, notifier)
 
-			w.warnExpiring(context.Background(), time.Hour, db.HourWarning)
+			w.warnExpiring(context.Background(), 0, time.Hour, db.HourWarning)
 
 			if tt.wantNotified {
 				assert.Equal(t, []constants.AnalysisID{id}, notifier.expiringSoon)
@@ -371,13 +386,138 @@ func TestWarnExpiringUsesTheRequestedKind(t *testing.T) {
 	notifier := &fakeNotifier{}
 	w := newTestWorker(database, notifier)
 
-	w.warnExpiring(context.Background(), DayExpiryWarning, db.DayWarning)
+	w.warnExpiring(context.Background(), DefaultExpiryWarning, DayExpiryWarning, db.DayWarning)
 
 	assert.Equal(t, []constants.AnalysisID{id}, notifier.expiringSoon,
 		"the day warning should still go out when only the hour warning was sent")
 	assert.True(t, database.sentFlags[flagKey(db.DayWarning, id)])
 	_, hourWritten := database.sentFlags[flagKey(db.HourWarning, id)]
 	assert.False(t, hourWritten, "the hour warning's flag should be left alone")
+}
+
+// TestDeliverPacesRetries covers the pacing between delivery attempts. The
+// attempt ceiling is the DE's only protection against retrying an undeliverable
+// notification forever, and the sweep runs every ten seconds — so without a
+// backoff between attempts, a notification-agent that is down for the length of
+// a rolling restart abandons every notification in flight.
+func TestDeliverPacesRetries(t *testing.T) {
+	const id = constants.AnalysisID("analysis-1")
+
+	database := newFakeDB()
+	analysis := testAnalysis(id)
+	database.statuses[id] = &db.NotifStatuses{AnalysisID: id}
+
+	notifier := &fakeNotifier{err: errors.New("notification-agent is down")}
+	w := newTestWorker(database, notifier)
+
+	// Stands in for consecutive sweeps: the interval between them is far
+	// shorter than the backoff the first failure schedules.
+	for range 5 {
+		w.deliver(context.Background(), &analysis, db.HourWarning)
+	}
+
+	assert.Len(t, notifier.expiringSoon, 1,
+		"only the first attempt should have been made; the rest fall inside the backoff")
+	assert.Equal(t, 1, database.failureCounts[flagKey(db.HourWarning, id)])
+	assert.NotContains(t, database.sentFlags, flagKey(db.HourWarning, id),
+		"a notification must not be abandoned while its retries are still pending")
+}
+
+// TestDeliverSkipsAnalysesWithNoStartDate covers a row the notification cannot
+// be rendered from at all. Counting those as delivery failures spends the
+// attempt ceiling on a condition no retry fixes, and logs a cause —
+// notification-agent being unreachable — that is not the real one.
+func TestDeliverSkipsAnalysesWithNoStartDate(t *testing.T) {
+	const id = constants.AnalysisID("analysis-1")
+
+	database := newFakeDB()
+	analysis := testAnalysis(id)
+	analysis.StartDate = nil
+	database.statuses[id] = &db.NotifStatuses{AnalysisID: id}
+
+	notifier := &fakeNotifier{}
+	newTestWorker(database, notifier).deliver(context.Background(), &analysis, db.KillWarning)
+
+	assert.Empty(t, notifier.terminated)
+	assert.Empty(t, database.failureCounts)
+	assert.Empty(t, database.sentFlags)
+}
+
+// TestNotificationPassesStopWhenTheBudgetIsSpent covers the bound on how long a
+// sweep spends notifying. Delivery holds a row lock and blocks on an HTTP POST,
+// so an unbounded notification pass delays the next sweep — and with it the next
+// round of terminations — for as long as notification-agent stays slow.
+func TestNotificationPassesStopWhenTheBudgetIsSpent(t *testing.T) {
+	const id = constants.AnalysisID("analysis-1")
+
+	spent, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	t.Run("expiry warnings", func(t *testing.T) {
+		database := newFakeDB()
+		database.expiring = []db.Analysis{testAnalysis(id)}
+		notifier := &fakeNotifier{}
+
+		newTestWorker(database, notifier).warnExpiring(spent, 0, time.Hour, db.HourWarning)
+
+		assert.Empty(t, notifier.expiringSoon)
+		assert.Empty(t, database.ensured, "no tracking row should be written for a pass that was cut short")
+	})
+
+	t.Run("termination notices", func(t *testing.T) {
+		database := newFakeDB()
+		analysis := testAnalysis(id)
+		notifier := &fakeNotifier{}
+
+		newTestWorker(database, notifier).notifyTerminated(spent, []*db.Analysis{&analysis})
+
+		assert.Empty(t, notifier.terminated)
+	})
+
+	t.Run("periodic reminders", func(t *testing.T) {
+		database := newFakeDB()
+		database.periodic = []db.Analysis{testAnalysis(id)}
+		notifier := &fakeNotifier{}
+
+		newTestWorker(database, notifier).remindStillRunning(spent)
+
+		assert.Empty(t, notifier.stillRunning)
+	})
+}
+
+// TestSweepTerminatesBeforeNotifying pins the order of the passes. Terminations
+// are the one pass with a deadline the DE cannot make up later — an analysis
+// past its time limit holds a node and the user's quota — so they must not queue
+// behind notification delivery.
+func TestSweepTerminatesBeforeNotifying(t *testing.T) {
+	database := newFakeDB()
+	w := newTestWorker(database, &fakeNotifier{})
+
+	w.sweep(context.Background())
+
+	assert.Equal(t,
+		[]string{"expired", "expiring:hour", "expiring:day", "periodic"},
+		database.calls,
+	)
+}
+
+// TestSweepWarnsOverDisjointWindows covers the windows the two expiry warnings
+// cover. A day window that contains the hour window sends both notifications —
+// whose text is identical — in the same pass to any analysis whose whole time
+// limit is shorter than a day.
+func TestSweepWarnsOverDisjointWindows(t *testing.T) {
+	database := newFakeDB()
+	w := New(database, &fakeNotifier{}, nil, nil, Init{})
+
+	w.sweep(context.Background())
+
+	assert.Equal(t,
+		[]expiringWindow{
+			{kind: db.HourWarning, from: 0, to: DefaultExpiryWarning},
+			{kind: db.DayWarning, from: DefaultExpiryWarning, to: DayExpiryWarning},
+		},
+		database.expiringWindows,
+	)
 }
 
 func TestReminderDue(t *testing.T) {

--- a/expiration/expiration_test.go
+++ b/expiration/expiration_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/cyverse-de/app-exposer/constants"
 	"github.com/cyverse-de/app-exposer/db"
+	"github.com/cyverse-de/app-exposer/operatorclient"
 	"github.com/jmoiron/sqlx"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -18,9 +19,11 @@ import (
 // bookkeeping the worker performs so assertions can be made against it, and
 // per-method errors can be injected to exercise the failure paths.
 type fakeExpirationDB struct {
-	expiring  []db.Analysis
-	expired   []db.Analysis
-	periodic  []db.Analysis
+	expiring       []db.Analysis
+	expired        []db.Analysis
+	periodic       []db.Analysis
+	missingRuntime []db.Analysis
+
 	byExtID   map[constants.ExternalID]*db.Analysis
 	statuses  map[constants.AnalysisID]*db.NotifStatuses
 	claimedBy map[constants.AnalysisID]bool // true => another replica holds the row
@@ -28,11 +31,12 @@ type fakeExpirationDB struct {
 	interactive bool
 
 	// Injected errors (nil by default).
-	expiringErr error
-	expiredErr  error
-	periodicErr error
-	ensureErr   error
-	initErr     error
+	expiringErr       error
+	expiredErr        error
+	periodicErr       error
+	missingRuntimeErr error
+	ensureErr         error
+	initErr           error
 
 	// Recorded side effects.
 	ensured        []constants.AnalysisID
@@ -69,6 +73,10 @@ func (f *fakeExpirationDB) ListAnalysesExpiringWithin(context.Context, time.Dura
 
 func (f *fakeExpirationDB) ListAnalysesDueForPeriodicReminder(context.Context) ([]db.Analysis, error) {
 	return f.periodic, f.periodicErr
+}
+
+func (f *fakeExpirationDB) ListAnalysesMissingRuntime(context.Context) ([]db.Analysis, error) {
+	return f.missingRuntime, f.missingRuntimeErr
 }
 
 func (f *fakeExpirationDB) GetAnalysisByExternalID(_ context.Context, externalID constants.ExternalID) (*db.Analysis, error) {
@@ -129,8 +137,8 @@ func (f *fakeExpirationDB) SetWarningFailureCount(_ context.Context, _ *sqlx.Tx,
 	return nil
 }
 
-func (f *fakeExpirationDB) SetLastPeriodicWarning(_ context.Context, _ *sqlx.Tx, analysisID constants.AnalysisID, sentAt time.Time) error {
-	f.lastPeriodic[analysisID] = sentAt
+func (f *fakeExpirationDB) SetLastPeriodicWarning(_ context.Context, _ *sqlx.Tx, analysisID constants.AnalysisID) error {
+	f.lastPeriodic[analysisID] = time.Now()
 	return nil
 }
 
@@ -158,6 +166,21 @@ func (f *fakeNotifier) NotifyStillRunning(_ context.Context, a *db.Analysis) err
 	f.stillRunning = append(f.stillRunning, a.ID)
 	return f.err
 }
+
+// fakeStatusPublisher records the analysis status updates the worker publishes
+// for analyses it reconciles without terminating.
+type fakeStatusPublisher struct {
+	succeeded []string
+}
+
+func (f *fakeStatusPublisher) Fail(context.Context, string, string) error { return nil }
+
+func (f *fakeStatusPublisher) Success(_ context.Context, jobID, _ string) error {
+	f.succeeded = append(f.succeeded, jobID)
+	return nil
+}
+
+func (f *fakeStatusPublisher) Running(context.Context, string, string) error { return nil }
 
 func timePtr(t time.Time) *time.Time { return &t }
 
@@ -460,4 +483,105 @@ func TestSweepSurvivesAPanic(t *testing.T) {
 
 	require.NotPanics(t, func() { w.sweep(context.Background()) },
 		"a panic in the sweep must not escape and take app-exposer's API down with it")
+}
+
+// TestHandleIndeterminate covers what happens to an expired analysis the worker
+// cannot locate. Marking one Completed ends it in the DE without saving its
+// outputs, so the bar for doing that on an inconclusive answer is high — but
+// never doing it strands the analysis in Running and holds the user's quota.
+func TestHandleIndeterminate(t *testing.T) {
+	const id = constants.AnalysisID("analysis-1")
+
+	pastEnd := func(d time.Duration) *time.Time { return timePtr(time.Now().Add(-d)) }
+
+	tests := []struct {
+		name          string
+		err           error
+		plannedEnd    *time.Time
+		wantCompleted bool
+	}{
+		{
+			name:       "an empty scheduler is never authoritative",
+			err:        operatorclient.ErrNoOperators,
+			plannedEnd: pastEnd(time.Minute),
+		},
+		{
+			name:       "an empty scheduler stays inconclusive past the grace period",
+			err:        operatorclient.ErrNoOperators,
+			plannedEnd: pastEnd(terminationGracePeriod + time.Hour),
+		},
+		{
+			name:       "an unreachable operator is retried inside the grace period",
+			err:        errors.New("operator unreachable"),
+			plannedEnd: pastEnd(time.Minute),
+		},
+		{
+			name:          "an unreachable operator is given up on past the grace period",
+			err:           errors.New("operator unreachable"),
+			plannedEnd:    pastEnd(terminationGracePeriod + time.Hour),
+			wantCompleted: true,
+		},
+		{
+			name:       "an analysis with no planned end date is never given up on",
+			err:        errors.New("operator unreachable"),
+			plannedEnd: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			status := &fakeStatusPublisher{}
+			w := New(newFakeDB(), &fakeNotifier{}, nil, status, Init{})
+
+			analysis := testAnalysis(id)
+			analysis.PlannedEndDate = tt.plannedEnd
+
+			w.handleIndeterminate(context.Background(), &analysis, tt.err)
+
+			if tt.wantCompleted {
+				assert.Equal(t, []string{string(analysis.ExternalID)}, status.succeeded)
+			} else {
+				assert.Empty(t, status.succeeded)
+			}
+		})
+	}
+}
+
+// TestRepairRuntime covers the sweep-driven repair of the runtime fields. It is
+// the safety net that is always present: the AMQP consumer that does the same
+// job only exists when amqp.uri is configured.
+func TestRepairRuntime(t *testing.T) {
+	t.Run("analyses missing runtime fields are initialized", func(t *testing.T) {
+		database := newFakeDB()
+		database.missingRuntime = []db.Analysis{testAnalysis("analysis-1"), testAnalysis("analysis-2")}
+
+		newTestWorker(database, &fakeNotifier{}).repairRuntime(context.Background())
+
+		assert.Equal(t,
+			[]constants.AnalysisID{"analysis-1", "analysis-2"},
+			database.initRuntimeFor,
+		)
+	})
+
+	t.Run("an analysis with no external ID is skipped", func(t *testing.T) {
+		database := newFakeDB()
+		analysis := testAnalysis("analysis-1")
+		analysis.ExternalID = ""
+		database.missingRuntime = []db.Analysis{analysis}
+
+		newTestWorker(database, &fakeNotifier{}).repairRuntime(context.Background())
+
+		assert.Empty(t, database.initRuntimeFor,
+			"there is no external ID to derive a subdomain from yet")
+	})
+
+	t.Run("a listing failure does not stop the sweep", func(t *testing.T) {
+		database := newFakeDB()
+		database.missingRuntimeErr = assert.AnError
+
+		require.NotPanics(t, func() {
+			newTestWorker(database, &fakeNotifier{}).repairRuntime(context.Background())
+		})
+		assert.Empty(t, database.initRuntimeFor)
+	})
 }

--- a/expiration/expiration_test.go
+++ b/expiration/expiration_test.go
@@ -1,0 +1,463 @@
+package expiration
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/cyverse-de/app-exposer/constants"
+	"github.com/cyverse-de/app-exposer/db"
+	"github.com/jmoiron/sqlx"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeExpirationDB implements db.ExpirationDB for unit tests. It records the
+// bookkeeping the worker performs so assertions can be made against it, and
+// per-method errors can be injected to exercise the failure paths.
+type fakeExpirationDB struct {
+	expiring  []db.Analysis
+	expired   []db.Analysis
+	periodic  []db.Analysis
+	byExtID   map[constants.ExternalID]*db.Analysis
+	statuses  map[constants.AnalysisID]*db.NotifStatuses
+	claimedBy map[constants.AnalysisID]bool // true => another replica holds the row
+
+	interactive bool
+
+	// Injected errors (nil by default).
+	expiringErr error
+	expiredErr  error
+	periodicErr error
+	ensureErr   error
+	initErr     error
+
+	// Recorded side effects.
+	ensured        []constants.AnalysisID
+	sentFlags      map[string]bool
+	failureCounts  map[string]int
+	lastPeriodic   map[constants.AnalysisID]time.Time
+	initRuntimeFor []constants.AnalysisID
+	initChanged    bool
+	commits        int
+}
+
+func newFakeDB() *fakeExpirationDB {
+	return &fakeExpirationDB{
+		byExtID:       map[constants.ExternalID]*db.Analysis{},
+		statuses:      map[constants.AnalysisID]*db.NotifStatuses{},
+		claimedBy:     map[constants.AnalysisID]bool{},
+		sentFlags:     map[string]bool{},
+		failureCounts: map[string]int{},
+		lastPeriodic:  map[constants.AnalysisID]time.Time{},
+	}
+}
+
+func flagKey(kind db.WarningKind, id constants.AnalysisID) string {
+	return string(kind) + ":" + string(id)
+}
+
+func (f *fakeExpirationDB) ListExpiredAnalyses(context.Context) ([]db.Analysis, error) {
+	return f.expired, f.expiredErr
+}
+
+func (f *fakeExpirationDB) ListAnalysesExpiringWithin(context.Context, time.Duration) ([]db.Analysis, error) {
+	return f.expiring, f.expiringErr
+}
+
+func (f *fakeExpirationDB) ListAnalysesDueForPeriodicReminder(context.Context) ([]db.Analysis, error) {
+	return f.periodic, f.periodicErr
+}
+
+func (f *fakeExpirationDB) GetAnalysisByExternalID(_ context.Context, externalID constants.ExternalID) (*db.Analysis, error) {
+	analysis, ok := f.byExtID[externalID]
+	if !ok {
+		return nil, sql.ErrNoRows
+	}
+	return analysis, nil
+}
+
+func (f *fakeExpirationDB) IsInteractive(context.Context, constants.AnalysisID) (bool, error) {
+	return f.interactive, nil
+}
+
+func (f *fakeExpirationDB) InitializeRuntime(_ context.Context, analysisID constants.AnalysisID, _, _ string) (bool, error) {
+	f.initRuntimeFor = append(f.initRuntimeFor, analysisID)
+	return f.initChanged, f.initErr
+}
+
+func (f *fakeExpirationDB) EnsureNotifStatuses(_ context.Context, analysisID constants.AnalysisID, externalID constants.ExternalID, _ int) error {
+	if f.ensureErr != nil {
+		return f.ensureErr
+	}
+	f.ensured = append(f.ensured, analysisID)
+	if _, ok := f.statuses[analysisID]; !ok {
+		f.statuses[analysisID] = &db.NotifStatuses{AnalysisID: analysisID, ExternalID: externalID}
+	}
+	return nil
+}
+
+// ClaimNotifStatuses mimics the FOR UPDATE SKIP LOCKED claim: a row marked as
+// held by another replica yields ErrNotClaimed, a missing row yields
+// sql.ErrNoRows, and the callback otherwise runs against the stored statuses.
+// The fake passes a nil transaction, which the worker only ever forwards back
+// into this same fake.
+func (f *fakeExpirationDB) ClaimNotifStatuses(_ context.Context, analysisID constants.AnalysisID, fn func(*sqlx.Tx, *db.NotifStatuses) error) error {
+	if f.claimedBy[analysisID] {
+		return db.ErrNotClaimed
+	}
+	statuses, ok := f.statuses[analysisID]
+	if !ok {
+		return sql.ErrNoRows
+	}
+	if err := fn(nil, statuses); err != nil {
+		return err
+	}
+	f.commits++
+	return nil
+}
+
+func (f *fakeExpirationDB) SetWarningSent(_ context.Context, _ *sqlx.Tx, kind db.WarningKind, analysisID constants.AnalysisID, sent bool) error {
+	f.sentFlags[flagKey(kind, analysisID)] = sent
+	return nil
+}
+
+func (f *fakeExpirationDB) SetWarningFailureCount(_ context.Context, _ *sqlx.Tx, kind db.WarningKind, analysisID constants.AnalysisID, count int) error {
+	f.failureCounts[flagKey(kind, analysisID)] = count
+	return nil
+}
+
+func (f *fakeExpirationDB) SetLastPeriodicWarning(_ context.Context, _ *sqlx.Tx, analysisID constants.AnalysisID, sentAt time.Time) error {
+	f.lastPeriodic[analysisID] = sentAt
+	return nil
+}
+
+// fakeNotifier records which notifications were requested and can be made to
+// fail.
+type fakeNotifier struct {
+	err error
+
+	terminated   []constants.AnalysisID
+	expiringSoon []constants.AnalysisID
+	stillRunning []constants.AnalysisID
+}
+
+func (f *fakeNotifier) NotifyTerminated(_ context.Context, a *db.Analysis) error {
+	f.terminated = append(f.terminated, a.ID)
+	return f.err
+}
+
+func (f *fakeNotifier) NotifyExpiringSoon(_ context.Context, a *db.Analysis) error {
+	f.expiringSoon = append(f.expiringSoon, a.ID)
+	return f.err
+}
+
+func (f *fakeNotifier) NotifyStillRunning(_ context.Context, a *db.Analysis) error {
+	f.stillRunning = append(f.stillRunning, a.ID)
+	return f.err
+}
+
+func timePtr(t time.Time) *time.Time { return &t }
+
+// testAnalysis returns a running analysis that expires in an hour.
+func testAnalysis(id constants.AnalysisID) db.Analysis {
+	return db.Analysis{
+		ID:             id,
+		ExternalID:     constants.ExternalID("ext-" + string(id)),
+		Name:           "test analysis",
+		Status:         "Running",
+		UserID:         "user-1",
+		Username:       "someone@example.org",
+		ResultFolder:   "/iplant/home/someone/analyses/test",
+		StartDate:      timePtr(time.Now().Add(-2 * time.Hour)),
+		PlannedEndDate: timePtr(time.Now().Add(time.Hour)),
+		NotifyPeriodic: true,
+	}
+}
+
+func newTestWorker(database db.ExpirationDB, notifier *fakeNotifier) *Worker {
+	return New(database, notifier, nil, nil, Init{})
+}
+
+func TestNewAppliesDefaults(t *testing.T) {
+	tests := []struct {
+		name              string
+		init              Init
+		wantSweep         time.Duration
+		wantExpiryWarning time.Duration
+	}{
+		{
+			name:              "zero values select the defaults",
+			init:              Init{},
+			wantSweep:         DefaultSweepInterval,
+			wantExpiryWarning: DefaultExpiryWarning,
+		},
+		{
+			name:              "negative values select the defaults",
+			init:              Init{SweepInterval: -time.Second, ExpiryWarning: -time.Hour},
+			wantSweep:         DefaultSweepInterval,
+			wantExpiryWarning: DefaultExpiryWarning,
+		},
+		{
+			name:              "explicit values are kept",
+			init:              Init{SweepInterval: 30 * time.Second, ExpiryWarning: 2 * time.Hour},
+			wantSweep:         30 * time.Second,
+			wantExpiryWarning: 2 * time.Hour,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := New(newFakeDB(), &fakeNotifier{}, nil, nil, tt.init)
+			assert.Equal(t, tt.wantSweep, w.sweepInterval)
+			assert.Equal(t, tt.wantExpiryWarning, w.expiryWarning)
+		})
+	}
+}
+
+func TestWarnExpiring(t *testing.T) {
+	const id = constants.AnalysisID("analysis-1")
+
+	tests := []struct {
+		name string
+		// setup mutates the fake DB before the sweep runs.
+		setup func(*fakeExpirationDB)
+		// notifyErr is injected into the notifier.
+		notifyErr error
+
+		wantNotified     bool
+		wantSentFlag     bool
+		wantSentFlagSet  bool
+		wantFailureCount int
+	}{
+		{
+			name:            "sends the warning and records it",
+			wantNotified:    true,
+			wantSentFlag:    true,
+			wantSentFlagSet: true,
+		},
+		{
+			name: "does not resend a warning already sent",
+			setup: func(f *fakeExpirationDB) {
+				f.statuses[id] = &db.NotifStatuses{AnalysisID: id, HourWarningSent: true}
+			},
+			wantNotified:    false,
+			wantSentFlagSet: false,
+		},
+		{
+			name: "another replica holding the row is skipped",
+			setup: func(f *fakeExpirationDB) {
+				f.claimedBy[id] = true
+			},
+			wantNotified:    false,
+			wantSentFlagSet: false,
+		},
+		{
+			name:             "a delivery failure is counted and retried later",
+			notifyErr:        errors.New("notification-agent is down"),
+			wantNotified:     true,
+			wantSentFlagSet:  false,
+			wantFailureCount: 1,
+		},
+		{
+			name:      "delivery is abandoned once the attempt ceiling is reached",
+			notifyErr: errors.New("notification-agent is down"),
+			setup: func(f *fakeExpirationDB) {
+				f.statuses[id] = &db.NotifStatuses{
+					AnalysisID:              id,
+					HourWarningFailureCount: MaxNotificationAttempts - 1,
+				}
+			},
+			wantNotified:     true,
+			wantSentFlag:     true,
+			wantSentFlagSet:  true,
+			wantFailureCount: MaxNotificationAttempts,
+		},
+		{
+			name: "an analysis with no external ID is skipped entirely",
+			setup: func(f *fakeExpirationDB) {
+				f.expiring[0].ExternalID = ""
+			},
+			wantNotified:    false,
+			wantSentFlagSet: false,
+		},
+		{
+			name: "a listing failure is not fatal",
+			setup: func(f *fakeExpirationDB) {
+				f.expiringErr = errors.New("database is down")
+			},
+			wantNotified:    false,
+			wantSentFlagSet: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			database := newFakeDB()
+			database.expiring = []db.Analysis{testAnalysis(id)}
+			if tt.setup != nil {
+				tt.setup(database)
+			}
+
+			notifier := &fakeNotifier{err: tt.notifyErr}
+			w := newTestWorker(database, notifier)
+
+			w.warnExpiring(context.Background(), time.Hour, db.HourWarning)
+
+			if tt.wantNotified {
+				assert.Equal(t, []constants.AnalysisID{id}, notifier.expiringSoon)
+			} else {
+				assert.Empty(t, notifier.expiringSoon)
+			}
+
+			sent, ok := database.sentFlags[flagKey(db.HourWarning, id)]
+			assert.Equal(t, tt.wantSentFlagSet, ok, "sent flag written")
+			if tt.wantSentFlagSet {
+				assert.Equal(t, tt.wantSentFlag, sent)
+			}
+
+			assert.Equal(t, tt.wantFailureCount, database.failureCounts[flagKey(db.HourWarning, id)])
+		})
+	}
+}
+
+// TestWarnExpiringUsesTheRequestedKind verifies that the day and hour warnings
+// are tracked independently, so sending one doesn't suppress the other.
+func TestWarnExpiringUsesTheRequestedKind(t *testing.T) {
+	const id = constants.AnalysisID("analysis-1")
+
+	database := newFakeDB()
+	database.expiring = []db.Analysis{testAnalysis(id)}
+	database.statuses[id] = &db.NotifStatuses{AnalysisID: id, HourWarningSent: true}
+
+	notifier := &fakeNotifier{}
+	w := newTestWorker(database, notifier)
+
+	w.warnExpiring(context.Background(), DayExpiryWarning, db.DayWarning)
+
+	assert.Equal(t, []constants.AnalysisID{id}, notifier.expiringSoon,
+		"the day warning should still go out when only the hour warning was sent")
+	assert.True(t, database.sentFlags[flagKey(db.DayWarning, id)])
+	_, hourWritten := database.sentFlags[flagKey(db.HourWarning, id)]
+	assert.False(t, hourWritten, "the hour warning's flag should be left alone")
+}
+
+func TestReminderDue(t *testing.T) {
+	now := time.Now()
+
+	tests := []struct {
+		name     string
+		analysis db.Analysis
+		statuses db.NotifStatuses
+		want     bool
+	}{
+		{
+			name:     "not due before the default period has elapsed since start",
+			analysis: db.Analysis{StartDate: timePtr(now.Add(-time.Hour))},
+			statuses: db.NotifStatuses{},
+			want:     false,
+		},
+		{
+			name:     "due once the default period has elapsed since start",
+			analysis: db.Analysis{StartDate: timePtr(now.Add(-DefaultPeriodicReminderPeriod - time.Minute))},
+			statuses: db.NotifStatuses{},
+			want:     true,
+		},
+		{
+			name:     "paced from the last reminder rather than the start",
+			analysis: db.Analysis{StartDate: timePtr(now.Add(-24 * time.Hour))},
+			statuses: db.NotifStatuses{LastPeriodicWarning: timePtr(now.Add(-time.Minute))},
+			want:     false,
+		},
+		{
+			name:     "due again once the period has elapsed since the last reminder",
+			analysis: db.Analysis{StartDate: timePtr(now.Add(-24 * time.Hour))},
+			statuses: db.NotifStatuses{LastPeriodicWarning: timePtr(now.Add(-DefaultPeriodicReminderPeriod - time.Minute))},
+			want:     true,
+		},
+		{
+			name:     "a per-analysis period overrides the default",
+			analysis: db.Analysis{StartDate: timePtr(now.Add(-2 * time.Hour))},
+			statuses: db.NotifStatuses{PeriodicWarningSeconds: int64(time.Hour.Seconds())},
+			want:     true,
+		},
+		{
+			name:     "a non-positive stored period falls back to the default",
+			analysis: db.Analysis{StartDate: timePtr(now.Add(-time.Hour))},
+			statuses: db.NotifStatuses{PeriodicWarningSeconds: 0},
+			want:     false,
+		},
+		{
+			name:     "an analysis with no start date is never due",
+			analysis: db.Analysis{},
+			statuses: db.NotifStatuses{},
+			want:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, reminderDue(&tt.analysis, &tt.statuses, now))
+		})
+	}
+}
+
+func TestRemindStillRunning(t *testing.T) {
+	const id = constants.AnalysisID("analysis-1")
+
+	dueAnalysis := func() db.Analysis {
+		a := testAnalysis(id)
+		a.StartDate = timePtr(time.Now().Add(-DefaultPeriodicReminderPeriod - time.Minute))
+		return a
+	}
+
+	t.Run("sends the reminder and records when it went out", func(t *testing.T) {
+		database := newFakeDB()
+		database.periodic = []db.Analysis{dueAnalysis()}
+		notifier := &fakeNotifier{}
+
+		newTestWorker(database, notifier).remindStillRunning(context.Background())
+
+		assert.Equal(t, []constants.AnalysisID{id}, notifier.stillRunning)
+		assert.Contains(t, database.lastPeriodic, id)
+	})
+
+	t.Run("does not record a reminder that failed to send", func(t *testing.T) {
+		database := newFakeDB()
+		database.periodic = []db.Analysis{dueAnalysis()}
+		notifier := &fakeNotifier{err: errors.New("notification-agent is down")}
+
+		newTestWorker(database, notifier).remindStillRunning(context.Background())
+
+		assert.Equal(t, []constants.AnalysisID{id}, notifier.stillRunning)
+		assert.NotContains(t, database.lastPeriodic, id,
+			"a failed reminder must not advance the timestamp, or the retry would be delayed a full period")
+	})
+
+	t.Run("does not send a reminder that is not due yet", func(t *testing.T) {
+		database := newFakeDB()
+		notDue := testAnalysis(id)
+		notDue.StartDate = timePtr(time.Now().Add(-time.Minute))
+		database.periodic = []db.Analysis{notDue}
+		notifier := &fakeNotifier{}
+
+		newTestWorker(database, notifier).remindStillRunning(context.Background())
+
+		assert.Empty(t, notifier.stillRunning)
+		assert.NotContains(t, database.lastPeriodic, id)
+	})
+}
+
+func TestSweepSurvivesAPanic(t *testing.T) {
+	database := newFakeDB()
+	// A nil scheduler makes terminateExpired panic when it has an expired
+	// analysis to look up, which stands in for any unexpected fault.
+	database.expired = []db.Analysis{testAnalysis("analysis-1")}
+
+	w := newTestWorker(database, &fakeNotifier{})
+
+	require.NotPanics(t, func() { w.sweep(context.Background()) },
+		"a panic in the sweep must not escape and take app-exposer's API down with it")
+}

--- a/expiration/notify.go
+++ b/expiration/notify.go
@@ -1,0 +1,237 @@
+package expiration
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/cyverse-de/app-exposer/db"
+	"github.com/jmoiron/sqlx"
+)
+
+// warnExpiring warns the owners of the analyses expiring between now+from and
+// now+to. The two windows the sweep uses are adjacent rather than nested, so an
+// analysis whose whole time limit is shorter than a day gets one warning rather
+// than the day and hour warnings — whose text is identical — at the same moment.
+func (w *Worker) warnExpiring(ctx context.Context, from, to time.Duration, kind db.WarningKind) {
+	analyses, err := w.db.ListAnalysesExpiringWithin(ctx, kind, from, to)
+	if err != nil {
+		log.Errorf("listing analyses expiring between %s and %s from now: %v", from, to, err)
+		return
+	}
+
+	for i := range analyses {
+		if w.notificationBudgetSpent(ctx, string(kind)+" warnings") {
+			return
+		}
+		analysis := &analyses[i]
+		if !w.trackNotifications(ctx, analysis) {
+			continue
+		}
+		w.deliver(ctx, analysis, kind)
+	}
+}
+
+// notifyTerminated tells the owners of the analyses terminated this sweep that
+// their analysis hit its time limit. It is a separate pass from the termination
+// itself so that one user's slow notification cannot delay another user's
+// termination.
+func (w *Worker) notifyTerminated(ctx context.Context, analyses []*db.Analysis) {
+	for _, analysis := range analyses {
+		if w.notificationBudgetSpent(ctx, "termination notices") {
+			return
+		}
+		if !w.trackNotifications(ctx, analysis) {
+			continue
+		}
+		w.deliver(ctx, analysis, db.KillWarning)
+	}
+}
+
+// notificationBudgetSpent reports whether this sweep's notification budget is
+// gone, logging the pass that was cut short. The remaining analyses keep their
+// unsent state, so the next sweep picks them up where this one stopped.
+func (w *Worker) notificationBudgetSpent(ctx context.Context, pass string) bool {
+	if ctx.Err() == nil {
+		return false
+	}
+	log.Warnf(
+		"this sweep's notification budget of %s is spent, so the remaining %s wait for the next sweep. "+
+			"This usually means notification-agent is responding slowly",
+		w.notificationBudget, pass,
+	)
+	return true
+}
+
+// remindStillRunning sends the periodic "your analysis is still running"
+// reminder to the owners of analyses whose reminder period has elapsed.
+func (w *Worker) remindStillRunning(ctx context.Context) {
+	analyses, err := w.db.ListAnalysesDueForPeriodicReminder(ctx)
+	if err != nil {
+		log.Errorf("listing analyses due for a periodic reminder: %v", err)
+		return
+	}
+
+	for i := range analyses {
+		if w.notificationBudgetSpent(ctx, "periodic reminders") {
+			return
+		}
+		analysis := &analyses[i]
+		if !w.trackNotifications(ctx, analysis) {
+			continue
+		}
+
+		claimErr := w.db.ClaimNotifStatuses(ctx, analysis.ID, func(tx *sqlx.Tx, statuses *db.NotifStatuses) error {
+			if !reminderDue(analysis, statuses, time.Now()) {
+				return nil
+			}
+			if err := w.notifier.NotifyStillRunning(ctx, analysis); err != nil {
+				// Roll back rather than record a send that didn't happen;
+				// the next sweep retries. Unlike the expiry warnings there
+				// is no attempt ceiling here, because a missed reminder is
+				// harmless and the reminder period paces the retries.
+				return err
+			}
+			return w.db.SetLastPeriodicWarning(ctx, tx, analysis.ID)
+		})
+		w.logClaimResult(analysis, "periodic reminder", claimErr)
+	}
+}
+
+// reminderDue reports whether an analysis's periodic reminder is due. The
+// reminder is paced from the later of the analysis's start and its last
+// reminder, so a freshly started analysis waits a full period before its first
+// one rather than being reminded immediately.
+func reminderDue(analysis *db.Analysis, statuses *db.NotifStatuses, now time.Time) bool {
+	if analysis.StartDate == nil {
+		return false
+	}
+
+	period := DefaultPeriodicReminderPeriod
+	if statuses.PeriodicWarningSeconds > 0 {
+		period = time.Duration(statuses.PeriodicWarningSeconds) * time.Second
+	}
+
+	since := *analysis.StartDate
+	if statuses.LastPeriodicWarning != nil && statuses.LastPeriodicWarning.After(since) {
+		since = *statuses.LastPeriodicWarning
+	}
+
+	return since.Add(period).Before(now)
+}
+
+// deliver sends one of the expiry notifications for an analysis, exactly once
+// across all replicas, and records the outcome.
+//
+// Delivery failures are counted rather than retried immediately: the next
+// attempt waits out a backoff that widens with the failure count, and after
+// MaxNotificationAttempts spaced attempts the notification is marked sent so the
+// DE stops trying. The counter is committed even on failure, which is why fn
+// returns nil on the failure path.
+func (w *Worker) deliver(ctx context.Context, analysis *db.Analysis, kind db.WarningKind) {
+	key := retryKey{analysisID: analysis.ID, kind: kind}
+	if !w.retries.due(key, time.Now()) {
+		return
+	}
+
+	if analysis.StartDate == nil {
+		// Every notification renders the analysis's elapsed runtime, so there
+		// is nothing to send. Retrying would only spend the attempt ceiling on
+		// a condition no retry fixes.
+		log.Warnf(
+			"analysis %s has no start date, so its %s notification cannot be built; skipping it. "+
+				"This usually means the jobs row was never fully populated",
+			analysis.ID, kind,
+		)
+		return
+	}
+
+	claimErr := w.db.ClaimNotifStatuses(ctx, analysis.ID, func(tx *sqlx.Tx, statuses *db.NotifStatuses) error {
+		if statuses.Sent(kind) {
+			return nil
+		}
+
+		sendErr := w.notify(ctx, analysis, kind)
+		if sendErr == nil {
+			w.retries.clear(key)
+			return w.db.SetWarningSent(ctx, tx, kind, analysis.ID, true)
+		}
+
+		if ctx.Err() != nil {
+			// The sweep's own notification budget cut the attempt short, so
+			// nothing was learned about the recipient. Roll back rather than
+			// spend an attempt on it.
+			return sendErr
+		}
+
+		failures := statuses.FailureCount(kind) + 1
+		log.Errorf(
+			"delivering %s notification for analysis %s failed (attempt %d of %d, next retry in %s); "+
+				"this usually means notification-agent or iplant-groups is unreachable: %v",
+			kind, analysis.ID, failures, MaxNotificationAttempts, retryBackoff(failures), sendErr,
+		)
+
+		if err := w.db.SetWarningFailureCount(ctx, tx, kind, analysis.ID, failures); err != nil {
+			return err
+		}
+
+		if failures >= MaxNotificationAttempts {
+			log.Warnf(
+				"giving up on the %s notification for analysis %s after %d failed attempts",
+				kind, analysis.ID, failures,
+			)
+			w.retries.clear(key)
+			return w.db.SetWarningSent(ctx, tx, kind, analysis.ID, true)
+		}
+
+		w.retries.schedule(key, failures, time.Now())
+		return nil
+	})
+	w.logClaimResult(analysis, string(kind)+" notification", claimErr)
+}
+
+// notify dispatches to the notification matching the warning kind.
+func (w *Worker) notify(ctx context.Context, analysis *db.Analysis, kind db.WarningKind) error {
+	switch kind {
+	case db.KillWarning:
+		return w.notifier.NotifyTerminated(ctx, analysis)
+	case db.DayWarning, db.HourWarning:
+		return w.notifier.NotifyExpiringSoon(ctx, analysis)
+	}
+	return errors.New("unknown warning kind " + string(kind))
+}
+
+// trackNotifications makes sure the analysis has a notification-tracking row,
+// reporting whether it is safe to go on and notify. Analyses with no external
+// ID yet are skipped: they have no job_steps row, so nothing can be tracked or
+// terminated for them.
+func (w *Worker) trackNotifications(ctx context.Context, analysis *db.Analysis) bool {
+	if analysis.ExternalID == "" {
+		log.Warnf(
+			"analysis %s has no external ID; skipping it this pass. "+
+				"This usually means its job_steps row hasn't been written yet",
+			analysis.ID,
+		)
+		return false
+	}
+
+	if err := w.db.EnsureNotifStatuses(ctx, analysis.ID, analysis.ExternalID, analysis.PeriodicPeriod); err != nil {
+		log.Errorf("creating the notification-tracking row for analysis %s: %v", analysis.ID, err)
+		return false
+	}
+
+	return true
+}
+
+// logClaimResult reports the outcome of a claimed notification attempt. Losing
+// the claim is the expected outcome on every replica but one, so it is logged
+// at debug level.
+func (w *Worker) logClaimResult(analysis *db.Analysis, what string, err error) {
+	switch {
+	case err == nil:
+	case errors.Is(err, db.ErrNotClaimed):
+		log.Debugf("another replica is handling the %s for analysis %s", what, analysis.ID)
+	default:
+		log.Errorf("handling the %s for analysis %s: %v", what, analysis.ID, err)
+	}
+}

--- a/expiration/retry.go
+++ b/expiration/retry.go
@@ -1,0 +1,111 @@
+package expiration
+
+import (
+	"sync"
+	"time"
+
+	"github.com/cyverse-de/app-exposer/constants"
+	"github.com/cyverse-de/app-exposer/db"
+)
+
+// Notification retries are paced so that the attempt ceiling measures elapsed
+// time rather than sweep count. The sweep runs every ten seconds, so an
+// unpaced ceiling of three attempts is spent by a notification-agent restart —
+// half a minute of unavailability would permanently abandon every warning and
+// termination notice in flight at the time.
+//
+// The delay doubles with each failure, up to retryBackoffMax, which puts the
+// ceiling roughly two and a half hours out. Pacing is per replica: the attempt
+// count is shared through notif_statuses, but when each attempt happens is not,
+// so N replicas can spend the ceiling up to N times faster. That is a bounded
+// loss of patience, not the cliff the sweep cadence created.
+const (
+	retryBackoffBase = time.Minute
+	retryBackoffMax  = 30 * time.Minute
+
+	// retryEntryTTL bounds how long a pending retry is remembered for an
+	// analysis nothing asks about again — one whose analysis was deleted, say.
+	// Well past retryBackoffMax, so it never discards a live backoff.
+	retryEntryTTL = 2 * time.Hour
+)
+
+// retryKey identifies one notification: the same analysis can have a day
+// warning in backoff while its hour warning is still on its first attempt.
+type retryKey struct {
+	analysisID constants.AnalysisID
+	kind       db.WarningKind
+}
+
+// retryTracker holds the earliest time each failed notification may be tried
+// again. It is in-memory on purpose: the durable state that matters — how many
+// attempts have failed and whether the notification was ever delivered — lives
+// in notif_statuses, and losing the pacing on a restart costs one early retry.
+type retryTracker struct {
+	mu       sync.Mutex
+	nextTime map[retryKey]time.Time
+}
+
+func newRetryTracker() *retryTracker {
+	return &retryTracker{nextTime: map[retryKey]time.Time{}}
+}
+
+// due reports whether the notification may be attempted now.
+func (r *retryTracker) due(key retryKey, now time.Time) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	next, pending := r.nextTime[key]
+	if !pending {
+		return true
+	}
+	if now.Before(next) {
+		return false
+	}
+	delete(r.nextTime, key)
+	return true
+}
+
+// schedule holds the notification back until the backoff for the given number
+// of consecutive failures has elapsed.
+func (r *retryTracker) schedule(key retryKey, failures int, now time.Time) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.nextTime[key] = now.Add(retryBackoff(failures))
+}
+
+// clear forgets any pending backoff, which is what a delivered — or abandoned —
+// notification leaves behind.
+func (r *retryTracker) clear(key retryKey) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	delete(r.nextTime, key)
+}
+
+// prune drops entries whose analyses stopped coming back from the sweep, so the
+// tracker can't grow without bound over the process's lifetime.
+func (r *retryTracker) prune(now time.Time) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for key, next := range r.nextTime {
+		if now.Sub(next) > retryEntryTTL {
+			delete(r.nextTime, key)
+		}
+	}
+}
+
+// retryBackoff returns how long to wait after the given number of consecutive
+// delivery failures.
+func retryBackoff(failures int) time.Duration {
+	if failures < 1 {
+		return retryBackoffBase
+	}
+
+	backoff := retryBackoffBase
+	for range failures - 1 {
+		backoff *= 2
+		if backoff >= retryBackoffMax {
+			return retryBackoffMax
+		}
+	}
+	return backoff
+}

--- a/expiration/retry_test.go
+++ b/expiration/retry_test.go
@@ -1,0 +1,90 @@
+package expiration
+
+import (
+	"testing"
+	"time"
+
+	"github.com/cyverse-de/app-exposer/db"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestRetryBackoffWidensWithFailures covers the pacing that makes
+// MaxNotificationAttempts a measure of elapsed time rather than of sweep count.
+// The sweep runs every ten seconds, so without this an unreachable
+// notification-agent spends the whole attempt ceiling in half a minute.
+func TestRetryBackoffWidensWithFailures(t *testing.T) {
+	tests := []struct {
+		name     string
+		failures int
+		want     time.Duration
+	}{
+		{name: "a count below the first attempt still waits the base delay", failures: 0, want: retryBackoffBase},
+		{name: "the first failure waits the base delay", failures: 1, want: retryBackoffBase},
+		{name: "the second failure waits twice as long", failures: 2, want: 2 * retryBackoffBase},
+		{name: "the fourth failure waits eight times as long", failures: 4, want: 8 * retryBackoffBase},
+		{name: "the delay is capped", failures: 12, want: retryBackoffMax},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, retryBackoff(tt.failures))
+		})
+	}
+}
+
+// TestRetryBackoffReachesTheCeilingSlowly pins the property the ceiling depends
+// on: spending every attempt must take hours, not the seconds it takes to run
+// MaxNotificationAttempts sweeps.
+func TestRetryBackoffReachesTheCeilingSlowly(t *testing.T) {
+	var total time.Duration
+	for failures := 1; failures < MaxNotificationAttempts; failures++ {
+		total += retryBackoff(failures)
+	}
+
+	assert.Greater(t, total, time.Hour,
+		"a brief notification-agent restart must not be able to spend the attempt ceiling")
+}
+
+func TestRetryTracker(t *testing.T) {
+	key := retryKey{analysisID: "analysis-1", kind: db.HourWarning}
+	now := time.Now()
+
+	t.Run("a notification with no recorded failure is due", func(t *testing.T) {
+		assert.True(t, newRetryTracker().due(key, now))
+	})
+
+	t.Run("a scheduled retry is held back until its backoff elapses", func(t *testing.T) {
+		r := newRetryTracker()
+		r.schedule(key, 1, now)
+
+		assert.False(t, r.due(key, now.Add(retryBackoffBase/2)))
+		assert.True(t, r.due(key, now.Add(retryBackoffBase)))
+	})
+
+	t.Run("the two warning kinds are paced independently", func(t *testing.T) {
+		r := newRetryTracker()
+		r.schedule(key, 1, now)
+
+		dayKey := retryKey{analysisID: key.analysisID, kind: db.DayWarning}
+		assert.True(t, r.due(dayKey, now))
+	})
+
+	t.Run("clearing a retry makes the notification due again", func(t *testing.T) {
+		r := newRetryTracker()
+		r.schedule(key, 1, now)
+		r.clear(key)
+
+		assert.True(t, r.due(key, now))
+	})
+
+	t.Run("pruning drops entries long past their retry time", func(t *testing.T) {
+		r := newRetryTracker()
+		r.schedule(key, 1, now)
+
+		r.prune(now.Add(retryEntryTTL / 2))
+		assert.Len(t, r.nextTime, 1, "a pending backoff must survive pruning")
+
+		r.prune(now.Add(retryEntryTTL * 2))
+		assert.Empty(t, r.nextTime, "an entry nothing came back for must not be kept forever")
+	})
+}

--- a/expiration/runtime.go
+++ b/expiration/runtime.go
@@ -98,14 +98,23 @@ func (r *RuntimeBackfill) backfill(ctx context.Context, externalID constants.Ext
 		return
 	}
 
-	changed, err := r.db.InitializeRuntime(ctx, analysis.ID, analysis.UserID, string(externalID))
+	initializeRuntime(ctx, r.db, analysis, externalID, msgLog)
+}
+
+// initializeRuntime fills in an interactive analysis's subdomain and planned end
+// date if they are missing, logging at warn level when it had to: in steady
+// state the launch handler has already written both, so anything repaired here
+// means an analysis was launched by an older app-exposer or its launch-time
+// write failed.
+func initializeRuntime(ctx context.Context, database db.ExpirationDB, analysis *db.Analysis, externalID constants.ExternalID, entry *logrus.Entry) {
+	changed, err := database.InitializeRuntime(ctx, analysis.ID, analysis.UserID, string(externalID))
 	if err != nil {
-		msgLog.Errorf("backfilling the subdomain and planned end date: %v", err)
+		entry.Errorf("backfilling the subdomain and planned end date: %v", err)
 		return
 	}
 
 	if changed {
-		msgLog.Warnf(
+		entry.Warnf(
 			"backfilled the subdomain and/or planned end date for analysis %s; "+
 				"the launch handler should have set these, so this analysis was "+
 				"either launched by an older app-exposer or its launch-time write failed",

--- a/expiration/runtime.go
+++ b/expiration/runtime.go
@@ -1,0 +1,115 @@
+package expiration
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+
+	"github.com/cyverse-de/app-exposer/constants"
+	"github.com/cyverse-de/app-exposer/db"
+	"github.com/cyverse-de/messaging/v12"
+	amqp "github.com/rabbitmq/amqp091-go"
+	"github.com/sirupsen/logrus"
+)
+
+// QueueName is the AMQP queue the runtime backfill consumes job status updates
+// from. It is deliberately unchanged from the standalone timelord service so
+// the existing queue and its bindings carry over on deploy rather than a new
+// one being declared alongside it.
+const QueueName = "timelord"
+
+// RuntimeBackfill is the safety net for the runtime fields an analysis needs:
+// its routing subdomain and its planned end date.
+//
+// The VICE launch handler is the canonical writer of both. This consumer
+// watches job status updates and fills them in for any interactive analysis
+// that reaches Running without them — an analysis launched by an app-exposer
+// that predates the launch-time write, or one whose write failed. Every
+// backfill is logged at warn level, because in steady state this should never
+// fire.
+type RuntimeBackfill struct {
+	db db.ExpirationDB
+}
+
+// NewRuntimeBackfill returns a RuntimeBackfill backed by the given database.
+func NewRuntimeBackfill(database db.ExpirationDB) *RuntimeBackfill {
+	return &RuntimeBackfill{db: database}
+}
+
+// MessageHandler returns the AMQP handler for job status update messages.
+func (r *RuntimeBackfill) MessageHandler() messaging.MessageHandler {
+	return func(ctx context.Context, delivery amqp.Delivery) {
+		// Acknowledge up front: this is a backfill for something the launch
+		// handler already does, so dropping a message on a crash costs nothing
+		// that the next Running update won't also cover.
+		if err := delivery.Ack(false); err != nil {
+			log.Errorf("acknowledging job status update: %v", err)
+		}
+
+		update := &messaging.UpdateMessage{}
+		if err := json.Unmarshal(delivery.Body, update); err != nil {
+			log.Errorf("unmarshaling job status update: %v", err)
+			return
+		}
+
+		// Only a Running analysis has the start date the planned end date is
+		// derived from. Checked before any query so the vast majority of
+		// status updates cost nothing.
+		if update.State != messaging.RunningState {
+			return
+		}
+
+		if update.Job == nil || update.Job.InvocationID == "" {
+			log.Error("job status update carries no invocation ID; ignoring it")
+			return
+		}
+
+		r.backfill(ctx, constants.ExternalID(update.Job.InvocationID))
+	}
+}
+
+// backfill fills in the runtime fields of the interactive analysis owning the
+// given external ID.
+func (r *RuntimeBackfill) backfill(ctx context.Context, externalID constants.ExternalID) {
+	msgLog := log.WithFields(logrus.Fields{"externalID": externalID})
+
+	analysis, err := r.db.GetAnalysisByExternalID(ctx, externalID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			// A status update for an analysis the DE has no record of. Not
+			// actionable here; job-status-listener owns that complaint.
+			msgLog.Debug("no analysis found for external ID; ignoring the update")
+			return
+		}
+		msgLog.Errorf("looking up the analysis for external ID: %v", err)
+		return
+	}
+
+	msgLog = msgLog.WithFields(logrus.Fields{"analysisID": analysis.ID})
+
+	interactive, err := r.db.IsInteractive(ctx, analysis.ID)
+	if err != nil {
+		msgLog.Errorf("determining whether the analysis is interactive: %v", err)
+		return
+	}
+	if !interactive {
+		// Only VICE analyses get a subdomain and a planned end date.
+		return
+	}
+
+	changed, err := r.db.InitializeRuntime(ctx, analysis.ID, analysis.UserID, string(externalID))
+	if err != nil {
+		msgLog.Errorf("backfilling the subdomain and planned end date: %v", err)
+		return
+	}
+
+	if changed {
+		msgLog.Warnf(
+			"backfilled the subdomain and/or planned end date for analysis %s; "+
+				"the launch handler should have set these, so this analysis was "+
+				"either launched by an older app-exposer or its launch-time write failed",
+			analysis.ID,
+		)
+	}
+}

--- a/expiration/termination.go
+++ b/expiration/termination.go
@@ -2,10 +2,20 @@ package expiration
 
 import (
 	"context"
+	"errors"
+	"time"
 
 	"github.com/cyverse-de/app-exposer/db"
 	"github.com/cyverse-de/app-exposer/operatorclient"
 )
+
+// terminationGracePeriod bounds how long an expired analysis stays in limbo
+// while the worker cannot tell whether it is still running. Waiting is the safe
+// default, but waiting forever is its own failure: one permanently unreachable
+// operator would otherwise pin every expired analysis in Running, holding the
+// users' quota and leaving their listings wrong with no recovery short of an
+// admin deleting the operator row.
+const terminationGracePeriod = 24 * time.Hour
 
 // terminateExpired terminates the analyses that have run past their planned end
 // date, and reconciles the ones that are already gone.
@@ -34,14 +44,7 @@ func (w *Worker) terminateExpired(ctx context.Context) {
 		// nothing or marks a live analysis Completed.
 		client, err := w.scheduler.FindAnalysis(ctx, analysis.ID)
 		if err != nil {
-			// An operator was unreachable, so "not found" can't be trusted.
-			// Leave the analysis alone: it will be reconsidered next sweep.
-			// Marking it Completed here would end a possibly-live analysis on
-			// the strength of an outage.
-			log.Errorf(
-				"cannot determine whether expired analysis %s is still running, leaving it as-is: %v",
-				analysis.ID, err,
-			)
+			w.handleIndeterminate(ctx, analysis, err)
 			continue
 		}
 
@@ -52,6 +55,43 @@ func (w *Worker) terminateExpired(ctx context.Context) {
 
 		w.terminate(ctx, analysis, client)
 	}
+}
+
+// handleIndeterminate decides what to do with an expired analysis whose
+// whereabouts could not be established. The default is to wait for the next
+// sweep: marking it Completed on the strength of an outage would end an
+// analysis that may still be live, without saving its outputs. Past
+// terminationGracePeriod the DE reconciles it anyway rather than leaving the
+// row stuck in Running forever.
+func (w *Worker) handleIndeterminate(ctx context.Context, analysis *db.Analysis, err error) {
+	// No operator was asked at all, so nothing was learned and there is no
+	// unreachable cluster to give up on. Never escalate this one: a scheduler
+	// that has not synced yet would otherwise complete every expired analysis
+	// in the DE once the grace period elapsed.
+	if errors.Is(err, operatorclient.ErrNoOperators) {
+		log.Warnf(
+			"cannot determine whether expired analysis %s is still running: no operators are registered. "+
+				"This usually means the reconciler has not synced the operators table yet",
+			analysis.ID,
+		)
+		return
+	}
+
+	if analysis.PlannedEndDate != nil && time.Since(*analysis.PlannedEndDate) > terminationGracePeriod {
+		log.Warnf(
+			"expired analysis %s has been undeterminable for more than %s, so the DE is reconciling it anyway. "+
+				"This usually means an operator in the operators table is permanently unreachable "+
+				"(a decommissioned cluster, an expired certificate) and should be removed: %v",
+			analysis.ID, terminationGracePeriod, err,
+		)
+		w.markCompleted(ctx, analysis)
+		return
+	}
+
+	log.Errorf(
+		"cannot determine whether expired analysis %s is still running, leaving it as-is: %v",
+		analysis.ID, err,
+	)
 }
 
 // markCompleted records an analysis as Completed because it is past its planned
@@ -73,8 +113,10 @@ func (w *Worker) markCompleted(ctx context.Context, analysis *db.Analysis) {
 // then tells the user it was terminated.
 //
 // The termination request is re-sent on every sweep until the analysis leaves
-// the cluster; the operator's save-and-exit is expected to tolerate that. The
-// notification, by contrast, goes out exactly once — it is claim-guarded.
+// the cluster, and every replica sweeps, so duplicates are routine: the
+// operator drops a save-and-exit for an analysis whose upload is already
+// running. The notification, by contrast, goes out exactly once — it is
+// claim-guarded.
 func (w *Worker) terminate(ctx context.Context, analysis *db.Analysis, client *operatorclient.Client) {
 	log.Infof(
 		"terminating analysis %s (external %s) on operator %s: it is past its planned end date",

--- a/expiration/termination.go
+++ b/expiration/termination.go
@@ -1,0 +1,98 @@
+package expiration
+
+import (
+	"context"
+
+	"github.com/cyverse-de/app-exposer/db"
+	"github.com/cyverse-de/app-exposer/operatorclient"
+)
+
+// terminateExpired terminates the analyses that have run past their planned end
+// date, and reconciles the ones that are already gone.
+func (w *Worker) terminateExpired(ctx context.Context) {
+	analyses, err := w.db.ListExpiredAnalyses(ctx)
+	if err != nil {
+		log.Errorf("listing analyses past their planned end date: %v", err)
+		return
+	}
+
+	for i := range analyses {
+		analysis := &analyses[i]
+
+		if analysis.ExternalID == "" {
+			log.Warnf(
+				"analysis %s is past its planned end date but has no external ID; "+
+					"skipping it. This usually means its job_steps row hasn't been written yet",
+				analysis.ID,
+			)
+			continue
+		}
+
+		// Ask the operators directly rather than trusting the operator id
+		// recorded in the database: the question here is whether the analysis
+		// still exists in a cluster, and acting on a stale answer either kills
+		// nothing or marks a live analysis Completed.
+		client, err := w.scheduler.FindAnalysis(ctx, analysis.ID)
+		if err != nil {
+			// An operator was unreachable, so "not found" can't be trusted.
+			// Leave the analysis alone: it will be reconsidered next sweep.
+			// Marking it Completed here would end a possibly-live analysis on
+			// the strength of an outage.
+			log.Errorf(
+				"cannot determine whether expired analysis %s is still running, leaving it as-is: %v",
+				analysis.ID, err,
+			)
+			continue
+		}
+
+		if client == nil {
+			w.markCompleted(ctx, analysis)
+			continue
+		}
+
+		w.terminate(ctx, analysis, client)
+	}
+}
+
+// markCompleted records an analysis as Completed because it is past its planned
+// end date and no longer present in any cluster — the DE's record of it is
+// simply out of date. No notification is sent: from the user's point of view
+// the analysis already finished.
+func (w *Worker) markCompleted(ctx context.Context, analysis *db.Analysis) {
+	log.Infof(
+		"expired analysis %s (external %s) is not running in any cluster; marking it Completed",
+		analysis.ID, analysis.ExternalID,
+	)
+
+	if err := w.status.Success(ctx, string(analysis.ExternalID), completedMessage); err != nil {
+		log.Errorf("marking analysis %s Completed: %v", analysis.ID, err)
+	}
+}
+
+// terminate asks the owning operator to save the analysis's outputs and exit,
+// then tells the user it was terminated.
+//
+// The termination request is re-sent on every sweep until the analysis leaves
+// the cluster; the operator's save-and-exit is expected to tolerate that. The
+// notification, by contrast, goes out exactly once — it is claim-guarded.
+func (w *Worker) terminate(ctx context.Context, analysis *db.Analysis, client *operatorclient.Client) {
+	log.Infof(
+		"terminating analysis %s (external %s) on operator %s: it is past its planned end date",
+		analysis.ID, analysis.ExternalID, client.Name(),
+	)
+
+	if err := client.SaveAndExit(ctx, analysis.ID); err != nil {
+		// Don't stop here: the user should still learn their analysis hit its
+		// time limit, and the next sweep retries the termination.
+		log.Errorf(
+			"requesting save-and-exit for analysis %s on operator %s failed; will retry next sweep: %v",
+			analysis.ID, client.Name(), err,
+		)
+	}
+
+	if !w.trackNotifications(ctx, analysis) {
+		return
+	}
+
+	w.deliver(ctx, analysis, db.KillWarning)
+}

--- a/expiration/termination.go
+++ b/expiration/termination.go
@@ -98,7 +98,34 @@ func (w *Worker) handleIndeterminate(ctx context.Context, analysis *db.Analysis,
 // end date and no longer present in any cluster — the DE's record of it is
 // simply out of date. No notification is sent: from the user's point of view
 // the analysis already finished.
+//
+// Publishing the status once is meant to be enough: the DE transitions the
+// analysis and it stops matching ListExpiredAnalyses. When that transition does
+// not happen the analysis stays Running and expired indefinitely, so the publish
+// is guarded — without that, every sweep on every replica publishes another
+// status update, without bound, for a condition no amount of publishing fixes.
 func (w *Worker) markCompleted(ctx context.Context, analysis *db.Analysis) {
+	published, err := w.db.HasCompletedStatus(ctx, analysis.ExternalID)
+	if err != nil {
+		// Publishing regardless would risk the unbounded loop this check exists
+		// to prevent, so leave the analysis for the next sweep.
+		log.Errorf(
+			"checking whether analysis %s was already reported Completed, skipping it this pass: %v",
+			analysis.ID, err,
+		)
+		return
+	}
+
+	if published {
+		log.Debugf(
+			"expired analysis %s is gone from every cluster and has already been reported Completed, but "+
+				"the DE still has it Running. This usually means the job-status pipeline is stalled or the "+
+				"analysis's jobs row is held by a long-running transaction; re-publishing would fix neither",
+			analysis.ID,
+		)
+		return
+	}
+
 	log.Infof(
 		"expired analysis %s (external %s) is not running in any cluster; marking it Completed",
 		analysis.ID, analysis.ExternalID,

--- a/expiration/termination.go
+++ b/expiration/termination.go
@@ -18,13 +18,18 @@ import (
 const terminationGracePeriod = 24 * time.Hour
 
 // terminateExpired terminates the analyses that have run past their planned end
-// date, and reconciles the ones that are already gone.
-func (w *Worker) terminateExpired(ctx context.Context) {
+// date, and reconciles the ones that are already gone. It returns the analyses
+// whose owners are owed a termination notice, which the sweep sends afterwards:
+// the notification path is the slow one, and nothing about it should stand
+// between the next expired analysis and its termination.
+func (w *Worker) terminateExpired(ctx context.Context) []*db.Analysis {
 	analyses, err := w.db.ListExpiredAnalyses(ctx)
 	if err != nil {
 		log.Errorf("listing analyses past their planned end date: %v", err)
-		return
+		return nil
 	}
+
+	terminated := make([]*db.Analysis, 0, len(analyses))
 
 	for i := range analyses {
 		analysis := &analyses[i]
@@ -54,7 +59,10 @@ func (w *Worker) terminateExpired(ctx context.Context) {
 		}
 
 		w.terminate(ctx, analysis, client)
+		terminated = append(terminated, analysis)
 	}
+
+	return terminated
 }
 
 // handleIndeterminate decides what to do with an expired analysis whose
@@ -136,8 +144,9 @@ func (w *Worker) markCompleted(ctx context.Context, analysis *db.Analysis) {
 	}
 }
 
-// terminate asks the owning operator to save the analysis's outputs and exit,
-// then tells the user it was terminated.
+// terminate asks the owning operator to save the analysis's outputs and exit.
+// The user is told separately, by the sweep, once every termination has been
+// requested.
 //
 // The termination request is re-sent on every sweep until the analysis leaves
 // the cluster, and every replica sweeps, so duplicates are routine: the
@@ -158,10 +167,4 @@ func (w *Worker) terminate(ctx context.Context, analysis *db.Analysis, client *o
 			analysis.ID, client.Name(), err,
 		)
 	}
-
-	if !w.trackNotifications(ctx, analysis) {
-		return
-	}
-
-	w.deliver(ctx, analysis, db.KillWarning)
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cyverse-de/app-exposer
 
-go 1.25.7
+go 1.26.0
 
 replace github.com/cyverse-de/millicores => ./millicores
 
@@ -24,7 +24,7 @@ require (
 	github.com/cyverse-de/go-mod/logging v0.0.2
 	github.com/cyverse-de/go-mod/otelutils v0.0.3
 	github.com/cyverse-de/go-mod/viceauth v1.0.0
-	github.com/cyverse-de/messaging/v12 v12.0.0
+	github.com/cyverse-de/messaging/v12 v12.0.2
 	github.com/cyverse-de/model/v10 v10.0.2
 	github.com/cyverse-de/p/go/qms v0.3.0
 	github.com/google/go-cmp v0.7.0
@@ -35,6 +35,7 @@ require (
 	github.com/labstack/echo/v4 v4.13.3
 	github.com/lib/pq v1.10.9
 	github.com/pkg/errors v0.9.1
+	github.com/rabbitmq/amqp091-go v1.11.0
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/sirupsen/logrus v1.9.3
 	github.com/stretchr/testify v1.11.1
@@ -80,7 +81,7 @@ require (
 	github.com/evilmonkeyinc/jsonpath v0.8.1 // indirect
 	github.com/expr-lang/expr v1.17.7 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
-	github.com/fsnotify/fsnotify v1.9.0 // indirect
+	github.com/fsnotify/fsnotify v1.10.1 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
 	github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32 // indirect
 	github.com/go-jose/go-jose/v3 v3.0.5 // indirect
@@ -135,13 +136,12 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
 	github.com/ncruces/go-strftime v0.1.9 // indirect
-	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
+	github.com/pelletier/go-toml/v2 v2.3.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_golang v1.23.0 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.65.0 // indirect
 	github.com/prometheus/procfs v0.17.0 // indirect
-	github.com/rabbitmq/amqp091-go v1.10.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/sagikazarmark/locafero v0.12.0 // indirect
 	github.com/segmentio/fasthash v1.0.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -125,8 +125,8 @@ github.com/cyverse-de/go-mod/otelutils v0.0.3 h1:4DAxvkZhf7YRUJeHaCyodbWv7t+tLzF
 github.com/cyverse-de/go-mod/otelutils v0.0.3/go.mod h1:h75ZnGtwiwGwHgqpxFQL0912bnHMrcOKfyGAv2+q2Vw=
 github.com/cyverse-de/go-mod/viceauth v1.0.0 h1:k5lCiBi7Lfa4eHZfkD1Msnez5kcAgoyUELPVSSr61H4=
 github.com/cyverse-de/go-mod/viceauth v1.0.0/go.mod h1:58UZ7WOFEAA3gy4Allc9NzVviiK10c4/2fwZDuQVXVo=
-github.com/cyverse-de/messaging/v12 v12.0.0 h1:fS+QMiFid0tSDFR5jDqSJLPqU9UlptPRs4kbjw5X4hM=
-github.com/cyverse-de/messaging/v12 v12.0.0/go.mod h1:psHZ100y28PAE06Aa/O8rLTf8ZLRba7zDoC9Q7efsiw=
+github.com/cyverse-de/messaging/v12 v12.0.2 h1:aamPlXKXL9ooor8Ikq7nbX1MlpAHaFtn2n4u+AJCTFU=
+github.com/cyverse-de/messaging/v12 v12.0.2/go.mod h1:ceXfVNIx/VTxfkqU6orpVBLs8Pl8lI6/qjtVip6OeLM=
 github.com/cyverse-de/model/v10 v10.0.2 h1:tnHetsB0hWh863lVzmz9TdFsKQFaURa2eXAn+j5SAQA=
 github.com/cyverse-de/model/v10 v10.0.2/go.mod h1:qwjX1ryxtMGJKPUf4KRjw8kzkqMQuSzjYlrPyPuPxE4=
 github.com/cyverse-de/p/go/header v0.1.0 h1:GA3VBQGLXqmFld4ANAQ8p5xaiJq2mWNoG3Pvzvc0fPQ=
@@ -167,8 +167,8 @@ github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSw
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
-github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
-github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
+github.com/fsnotify/fsnotify v1.10.1 h1:b0/UzAf9yR5rhf3RPm9gf3ehBPpf0oZKIjtpKrx59Ho=
+github.com/fsnotify/fsnotify v1.10.1/go.mod h1:TLheqan6HD6GBK6PrDWyDPBaEV8LspOxvPSjC+bVfgo=
 github.com/fxamacker/cbor/v2 v2.9.0 h1:NpKPmjDBgUfBms6tr6JZkTHtfFGcMKsw3eGcmD/sapM=
 github.com/fxamacker/cbor/v2 v2.9.0/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
@@ -563,8 +563,8 @@ github.com/pelletier/go-toml v1.7.0/go.mod h1:vwGMzjaWMwyfHwgIBhI2YUM4fB6nL6lVAv
 github.com/pelletier/go-toml v1.9.3/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3ve8=
 github.com/pelletier/go-toml v1.9.5/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
-github.com/pelletier/go-toml/v2 v2.2.4 h1:mye9XuhQ6gvn5h28+VilKrrPoQVanw5PMw/TB0t5Ec4=
-github.com/pelletier/go-toml/v2 v2.2.4/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
+github.com/pelletier/go-toml/v2 v2.3.1 h1:MYEvvGnQjeNkRF1qUuGolNtNExTDwct51yp7olPtrEc=
+github.com/pelletier/go-toml/v2 v2.3.1/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -599,8 +599,8 @@ github.com/prometheus/procfs v0.1.3/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4O
 github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/prometheus/procfs v0.17.0 h1:FuLQ+05u4ZI+SS/w9+BWEM2TXiHKsUQ9TADiRH7DuK0=
 github.com/prometheus/procfs v0.17.0/go.mod h1:oPQLaDAMRbA+u8H5Pbfq+dl3VDAvHxMUOVhe0wYB2zw=
-github.com/rabbitmq/amqp091-go v1.10.0 h1:STpn5XsHlHGcecLmMFCtg7mqq0RnD+zFr4uzukfVhBw=
-github.com/rabbitmq/amqp091-go v1.10.0/go.mod h1:Hy4jKW5kQART1u+JkDTF9YYOQUHXqMuhrgxOEeS7G4o=
+github.com/rabbitmq/amqp091-go v1.11.0 h1:HxIctVm9Gid/Vtn706necmZ7Wj6pgGI2eqplRbEY8O8=
+github.com/rabbitmq/amqp091-go v1.11.0/go.mod h1:Hy4jKW5kQART1u+JkDTF9YYOQUHXqMuhrgxOEeS7G4o=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/rhnvrm/simples3 v0.6.1/go.mod h1:Y+3vYm2V7Y4VijFoJHHTrja6OgPrJ2cBti8dPGkC3sA=

--- a/httphandlers/handlers.go
+++ b/httphandlers/handlers.go
@@ -136,72 +136,11 @@ func (h *HTTPHandlers) operatorClientForAnalysis(ctx context.Context, analysisID
 	return client, nil
 }
 
-// searchOperatorsForAnalysis queries all configured operators in parallel
-// to find which one is running the given analysis. Returns (client, nil)
-// on success. Returns (nil, nil) when every operator responded and none
-// has the analysis — truly not found. Returns (nil, err) only when one
-// or more operators errored AND nothing reported found: in that case we
-// cannot distinguish "not running anywhere" from "hiding on a degraded
-// cluster", so the caller should surface the ambiguity (typically as 502)
-// rather than return 404.
+// searchOperatorsForAnalysis asks every operator which one is running the given
+// analysis. See Scheduler.FindAnalysis for the (nil, nil) vs (nil, err)
+// semantics — a miss is only authoritative when the error is nil.
 func (h *HTTPHandlers) searchOperatorsForAnalysis(ctx context.Context, analysisID constants.AnalysisID) (*operatorclient.Client, error) {
-	type result struct {
-		client *operatorclient.Client
-		found  bool
-		err    error
-	}
-
-	clients := h.scheduler.Clients()
-	if len(clients) == 0 {
-		return nil, nil
-	}
-
-	// Use a cancellable child context so we can stop remaining searches
-	// once we find the analysis.
-	searchCtx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
-	ch := make(chan result, len(clients))
-
-	// wg.Go (Go 1.25+) handles Add/Done internally. Range variables are
-	// per-iteration in Go 1.22+ so no parameter capture is needed.
-	var wg sync.WaitGroup
-	for _, c := range clients {
-		wg.Go(func() {
-			found, err := c.HasAnalysis(searchCtx, analysisID)
-			if err != nil {
-				log.Warnf("search: operator %s error for analysis %s: %v", c.Name(), analysisID, err)
-				ch <- result{client: c, err: err}
-				return
-			}
-			ch <- result{client: c, found: found}
-		})
-	}
-
-	// Close the channel once all goroutines finish to avoid leaks.
-	go func() {
-		wg.Wait()
-		close(ch)
-	}()
-
-	var failed []string
-	for r := range ch {
-		if r.err != nil {
-			failed = append(failed, r.client.Name())
-			continue
-		}
-		if r.found {
-			cancel() // Signal remaining goroutines to stop.
-			return r.client, nil
-		}
-	}
-
-	// Nothing found. If any operator failed during the search, report the
-	// outage so the caller can return 502 rather than a misleading 404.
-	if len(failed) > 0 {
-		return nil, fmt.Errorf("analysis %s not found; %d operator(s) could not be checked: %v", analysisID, len(failed), failed)
-	}
-	return nil, nil
+	return h.scheduler.FindAnalysis(ctx, analysisID)
 }
 
 // operatorLabelParams is the set of query parameter names that the vice-operator

--- a/httphandlers/handlers.go
+++ b/httphandlers/handlers.go
@@ -95,7 +95,8 @@ func (h *HTTPHandlers) GetScheduler() *operatorclient.Scheduler {
 // database outage) and the caller should surface that to the client rather
 // than treat the analysis as missing. Callers requiring a live client must
 // treat nil-client-with-nil-error as "not found". Callers answering an
-// "exists?" question may use nil-with-nil-error as "no".
+// "exists?" question may use nil-with-nil-error as "no". An empty scheduler
+// is a miss rather than an error: there is nowhere for the analysis to be.
 func (h *HTTPHandlers) operatorClientForAnalysis(ctx context.Context, analysisID constants.AnalysisID) (*operatorclient.Client, error) {
 	// Fast path: check the DB for a recorded operator id. GetOperatorID
 	// normalizes sql.ErrNoRows to (uuid.Nil, nil); a non-nil error here
@@ -121,6 +122,16 @@ func (h *HTTPHandlers) operatorClientForAnalysis(ctx context.Context, analysisID
 	// Search path: ask every operator in parallel whether it has this analysis.
 	client, searchErr := h.searchOperatorsForAnalysis(ctx, analysisID)
 	if client == nil {
+		if errors.Is(searchErr, operatorclient.ErrNoOperators) {
+			// There is nowhere for the analysis to be running, which answers
+			// the question rather than failing it. Callers turn a non-nil error
+			// into a 503, and the scheduler is legitimately empty for as long
+			// as it takes the reconciler to sync the operators table after a
+			// restart — a 503 there would tell the apps service to retry a
+			// save-and-exit for an analysis that is genuinely gone.
+			log.Warnf("no operators are registered, so analysis %s is not running anywhere", analysisID)
+			return nil, nil
+		}
 		if searchErr != nil {
 			// Some operators errored AND none reported found. We can't
 			// tell whether the analysis is genuinely missing or hiding

--- a/httphandlers/launch.go
+++ b/httphandlers/launch.go
@@ -174,6 +174,18 @@ func (h *HTTPHandlers) launchAsync(job *model.Job) {
 		return h.incluster.BuildAnalysisBundle(ctx, job, analysisID)
 	}
 
+	// Derive the analysis's routing subdomain and planned end date before the
+	// operator is asked to launch, which is what makes this handler the canonical
+	// writer of both rather than a straggler. The expiration package's job-status
+	// consumer performs the same write as a safety net, and it cannot run until
+	// the analysis reports Running — so writing first here keeps that path to the
+	// anomaly it is meant to report. Best-effort for the same reason as
+	// SetOperatorID below: a failure is recovered by that backfill rather than
+	// failing the launch.
+	if _, err := h.db.InitializeRuntime(ctx, analysisID, job.UserID, job.InvocationID); err != nil {
+		log.Errorf("async launch %s: failed to set the subdomain and planned end date: %v", job.ID, err)
+	}
+
 	// Route to an available operator. The scheduler returns both the id (used
 	// for the DB write below) and the name (used in human-readable log lines).
 	operatorID, operatorName, err := h.scheduler.LaunchAnalysisSpec(ctx, spec, legacyBundle)
@@ -190,15 +202,6 @@ func (h *HTTPHandlers) launchAsync(job *model.Job) {
 	// onto an already-contended jobs table.
 	if err := h.apps.SetOperatorID(ctx, constants.AnalysisID(job.ID), operatorID); err != nil {
 		log.Errorf("async launch %s: failed to set operator id: %v", job.ID, err)
-	}
-
-	// Derive the analysis's routing subdomain and planned end date. The launch
-	// handler is the canonical writer of both; the expiration package's
-	// job-status consumer backfills them only for analyses that miss this
-	// write. Best-effort for the same reason as SetOperatorID above — a failure
-	// is recovered by that backfill rather than failing the launch.
-	if _, err := h.db.InitializeRuntime(ctx, analysisID, job.UserID, job.InvocationID); err != nil {
-		log.Errorf("async launch %s: failed to set the subdomain and planned end date: %v", job.ID, err)
 	}
 
 	log.Infof("async launch %s: successfully launched on operator %s (id=%s)", job.ID, operatorName, operatorID)

--- a/httphandlers/launch.go
+++ b/httphandlers/launch.go
@@ -192,6 +192,15 @@ func (h *HTTPHandlers) launchAsync(job *model.Job) {
 		log.Errorf("async launch %s: failed to set operator id: %v", job.ID, err)
 	}
 
+	// Derive the analysis's routing subdomain and planned end date. The launch
+	// handler is the canonical writer of both; the expiration package's
+	// job-status consumer backfills them only for analyses that miss this
+	// write. Best-effort for the same reason as SetOperatorID above — a failure
+	// is recovered by that backfill rather than failing the launch.
+	if _, err := h.db.InitializeRuntime(ctx, analysisID, job.UserID, job.InvocationID); err != nil {
+		log.Errorf("async launch %s: failed to set the subdomain and planned end date: %v", job.ID, err)
+	}
+
 	log.Infof("async launch %s: successfully launched on operator %s (id=%s)", job.ID, operatorName, operatorID)
 }
 

--- a/httphandlers/routing_test.go
+++ b/httphandlers/routing_test.go
@@ -1,0 +1,44 @@
+package httphandlers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/cyverse-de/app-exposer/apps"
+	"github.com/cyverse-de/app-exposer/operatorclient"
+	"github.com/jmoiron/sqlx"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestOperatorClientForAnalysisWithNoOperators covers the answer the handlers
+// give while the scheduler is empty, which it is on every restart until the
+// reconciler has synced the operators table.
+//
+// An empty scheduler means the analysis is not running anywhere, and the
+// handlers turn a non-nil error into a 503. Reporting one here tells the apps
+// service that a save-and-exit is worth retrying, and turns
+// /vice/admin/is-deployed — an "exists?" question with a perfectly good answer —
+// into an outage.
+func TestOperatorClientForAnalysisWithNoOperators(t *testing.T) {
+	rawDB, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = rawDB.Close() })
+
+	// No recorded operator id, which is what sends the lookup down the search
+	// path in the first place.
+	mock.ExpectQuery("SELECT operator_id").
+		WillReturnRows(sqlmock.NewRows([]string{"operator_id"}).AddRow(nil))
+
+	h := &HTTPHandlers{
+		apps:      &apps.Apps{DB: sqlx.NewDb(rawDB, "postgres")},
+		scheduler: operatorclient.NewScheduler(nil),
+	}
+
+	client, err := h.operatorClientForAnalysis(context.Background(), "analysis-1")
+
+	require.NoError(t, err, "an empty scheduler is an answer, not a failed lookup")
+	assert.Nil(t, client)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}

--- a/incluster/incluster.go
+++ b/incluster/incluster.go
@@ -8,11 +8,13 @@ import (
 	"net/url"
 	"slices"
 	"strings"
+	"time"
 
 	"github.com/cockroachdb/apd"
 	"github.com/cyverse-de/app-exposer/apps"
 	"github.com/cyverse-de/app-exposer/common"
 	"github.com/cyverse-de/app-exposer/constants"
+	"github.com/cyverse-de/app-exposer/db"
 	"github.com/cyverse-de/app-exposer/incluster/jobinfo"
 	"github.com/cyverse-de/app-exposer/operatorclient"
 	"github.com/cyverse-de/app-exposer/quota"
@@ -197,21 +199,24 @@ func GetMillicoresFromDeployment(deployment *appsv1.Deployment) (*apd.Decimal, e
 	return millicores, nil
 }
 
+// Both statements return planned_end_date as stored rather than converting it to
+// an epoch in SQL. The column is naive and holds wall-clock time in the
+// deployment's zone, so any conversion has to name that zone; doing it with
+// current_setting('TimeZone') used the database session's zone instead and
+// returned an epoch off by the difference between the two — seven hours on a US
+// deployment against a UTC database. plannedEndEpoch converts it correctly.
+
 const updateTimeLimitSQL = `
 	UPDATE ONLY jobs
 	   SET planned_end_date = old_value.planned_end_date + interval '1 second' * $3
 	  FROM (SELECT planned_end_date FROM jobs WHERE id = $2) AS old_value
 	 WHERE jobs.id = $2
 	   AND jobs.user_id = $1
- RETURNING EXTRACT(EPOCH FROM
-    jobs.planned_end_date AT TIME ZONE current_setting('TimeZone')
- )::bigint
+ RETURNING jobs.planned_end_date
 `
 
 const getTimeLimitSQL = `
-	SELECT EXTRACT(EPOCH FROM
-	    planned_end_date AT TIME ZONE current_setting('TimeZone')
-	)::bigint
+	SELECT planned_end_date
 	  FROM jobs
 	 WHERE jobs.id = $2
 	   AND jobs.user_id = $1
@@ -229,19 +234,34 @@ type TimeLimit struct {
 	TimeLimit string `json:"time_limit"`
 }
 
+// plannedEndEpoch converts a planned end date read from the naive jobs column
+// into a Unix epoch, reporting false when the column is NULL. The relabeling is
+// shared with the expiration worker so the two cannot disagree about what these
+// timestamps mean — see db/timestamps.go.
+//
+// Rounded rather than truncated because the column carries fractional seconds
+// and the EXTRACT(EPOCH ...)::bigint this replaced rounded them. The zone was the
+// bug; the second this API reports should not move with the fix.
+func plannedEndEpoch(plannedEnd sql.NullTime) (int64, bool) {
+	if !plannedEnd.Valid {
+		return 0, false
+	}
+	return db.InLocalZone(&plannedEnd.Time).Round(time.Second).Unix(), true
+}
+
 // GetTimeLimit returns the planned end date (as a Unix epoch string) for the
 // analysis with the given ID, run by the given user.
 func (i *Incluster) GetTimeLimit(ctx context.Context, userID string, id constants.AnalysisID) (*TimeLimit, error) {
 	var err error
 
-	var epoch sql.NullInt64
-	if err = i.db.QueryRowContext(ctx, getTimeLimitSQL, userID, id).Scan(&epoch); err != nil {
+	var plannedEnd sql.NullTime
+	if err = i.db.QueryRowContext(ctx, getTimeLimitSQL, userID, id).Scan(&plannedEnd); err != nil {
 		return nil, errors.Wrapf(err, "error retrieving time limit for user %s on analysis %s", userID, id)
 	}
 
 	retval := &TimeLimit{}
-	if epoch.Valid {
-		retval.TimeLimit = fmt.Sprintf("%d", epoch.Int64)
+	if epoch, ok := plannedEndEpoch(plannedEnd); ok {
+		retval.TimeLimit = fmt.Sprintf("%d", epoch)
 	} else {
 		retval.TimeLimit = "null"
 	}
@@ -265,17 +285,17 @@ func (i *Incluster) UpdateTimeLimit(ctx context.Context, user string, id constan
 		return nil, errors.Wrapf(err, "error looking user ID for %s", user)
 	}
 
-	var epoch sql.NullInt64
-	if err = i.db.QueryRowContext(ctx, updateTimeLimitSQL, userID, id, i.TimeLimitExtensionSeconds).Scan(&epoch); err != nil {
+	var plannedEnd sql.NullTime
+	if err = i.db.QueryRowContext(ctx, updateTimeLimitSQL, userID, id, i.TimeLimitExtensionSeconds).Scan(&plannedEnd); err != nil {
 		return nil, errors.Wrapf(err, "error extending time limit for user %s on analysis %s", userID, id)
 	}
 
 	retval := &TimeLimit{}
-	if epoch.Valid {
-		retval.TimeLimit = fmt.Sprintf("%d", epoch.Int64)
-	} else {
+	epoch, ok := plannedEndEpoch(plannedEnd)
+	if !ok {
 		return nil, fmt.Errorf("the time limit for analysis %s was null after extension", id)
 	}
+	retval.TimeLimit = fmt.Sprintf("%d", epoch)
 
 	return retval, nil
 }

--- a/incluster/status.go
+++ b/incluster/status.go
@@ -27,6 +27,14 @@ type JSLPublisher struct {
 	statusURL string
 }
 
+// NewJSLPublisher returns a publisher that posts status updates to the
+// job-status-listener at statusURL. Exported for packages outside incluster
+// that need to publish analysis status without an *Incluster — notably the
+// expiration worker, which marks vanished analyses Completed.
+func NewJSLPublisher(statusURL string) *JSLPublisher {
+	return &JSLPublisher{statusURL: statusURL}
+}
+
 // AnalysisStatus contains the data needed to post a status update to the
 // notification-agent service.
 type AnalysisStatus struct {

--- a/incluster/timelimit_test.go
+++ b/incluster/timelimit_test.go
@@ -1,0 +1,83 @@
+package incluster
+
+import (
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPlannedEndEpoch pins the conversion behind the VICE time-limit API. The
+// jobs.planned_end_date column is naive and holds wall-clock time in the
+// deployment's zone; converting it with the database session's zone instead
+// returned an epoch off by the difference between the two, so the UI showed a
+// time limit hours away from the one actually enforced.
+func TestPlannedEndEpoch(t *testing.T) {
+	phoenix, err := time.LoadLocation("America/Phoenix")
+	require.NoError(t, err)
+
+	// 16:00:31 wall clock, as the column stores it.
+	stored := time.Date(2026, 8, 11, 16, 0, 31, 0, time.UTC)
+
+	tests := []struct {
+		name       string
+		plannedEnd sql.NullTime
+		wantOK     bool
+		// wantEpochIn is the zone the wall clock is expected to be read in; the
+		// conversion is relative to whatever zone the process runs in.
+		wantEpochIn *time.Location
+		// wantRoundedUp pins the fractional-second handling inherited from the
+		// EXTRACT(EPOCH ...)::bigint this replaced.
+		wantRoundedUp bool
+	}{
+		{
+			name:        "a stored wall clock converts using the deployment's zone",
+			plannedEnd:  sql.NullTime{Time: stored, Valid: true},
+			wantOK:      true,
+			wantEpochIn: time.Local,
+		},
+		{
+			name:          "fractional seconds round rather than truncate",
+			plannedEnd:    sql.NullTime{Time: stored.Add(658301 * time.Microsecond), Valid: true},
+			wantOK:        true,
+			wantEpochIn:   time.Local,
+			wantRoundedUp: true,
+		},
+		{
+			name:       "a NULL planned end date reports no epoch",
+			plannedEnd: sql.NullTime{Valid: false},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			epoch, ok := plannedEndEpoch(tt.plannedEnd)
+
+			assert.Equal(t, tt.wantOK, ok)
+			if !tt.wantOK {
+				assert.Zero(t, epoch)
+				return
+			}
+
+			want := time.Date(
+				stored.Year(), stored.Month(), stored.Day(),
+				stored.Hour(), stored.Minute(), stored.Second(), 0,
+				tt.wantEpochIn,
+			).Unix()
+			if tt.wantRoundedUp {
+				want++
+			}
+			assert.Equal(t, want, epoch)
+		})
+	}
+
+	// The bug concretely: reading the same stored value as UTC rather than as a
+	// US zone yields an epoch that is hours early.
+	t.Run("reading the wall clock as UTC loses the zone offset", func(t *testing.T) {
+		asPhoenix := time.Date(2026, 8, 11, 16, 0, 31, 0, phoenix).Unix()
+		assert.Equal(t, int64(7*3600), asPhoenix-stored.Unix(),
+			"the offset is exactly what the old current_setting('TimeZone') form dropped")
+	})
+}

--- a/iplantgroups/iplantgroups.go
+++ b/iplantgroups/iplantgroups.go
@@ -1,0 +1,105 @@
+// Package iplantgroups provides a client for the DE's iplant-groups service,
+// used here to resolve a username to the profile fields (notably the email
+// address) needed when notifying a user about their analysis.
+package iplantgroups
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/cyverse-de/app-exposer/common"
+	"github.com/sirupsen/logrus"
+)
+
+var log = common.Log.WithFields(logrus.Fields{"package": "iplantgroups"})
+
+// DefaultTimeout bounds a single iplant-groups lookup.
+const DefaultTimeout = 30 * time.Second
+
+// Subject is the subset of an iplant-groups subject record that the DE needs.
+// iplant-groups calls users "subjects"; ID is the bare username.
+type Subject struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	FirstName   string `json:"first_name"`
+	LastName    string `json:"last_name"`
+	Email       string `json:"email"`
+	Institution string `json:"institution"`
+	SourceID    string `json:"source_id"`
+}
+
+// Client looks up subjects in the iplant-groups service.
+type Client struct {
+	baseURL    *url.URL
+	actAsUser  string
+	httpClient *http.Client
+}
+
+// New returns a Client for the iplant-groups service at baseURL. actAsUser is
+// the privileged Grouper account the lookups are performed as; iplant-groups
+// requires it on every request.
+func New(baseURL, actAsUser string) (*Client, error) {
+	u, err := url.Parse(baseURL)
+	if err != nil {
+		return nil, fmt.Errorf("parsing iplant-groups base URL %q: %w", baseURL, err)
+	}
+	return &Client{
+		baseURL:    u,
+		actAsUser:  actAsUser,
+		httpClient: &http.Client{Timeout: DefaultTimeout},
+	}, nil
+}
+
+// GetSubject returns the subject record for the given username. The username
+// may carry the DE's domain suffix; only the portion to the left of the last
+// "@" is meaningful to iplant-groups.
+func (c *Client) GetSubject(ctx context.Context, username string) (*Subject, error) {
+	id := ParseID(username)
+
+	reqURL := c.baseURL.JoinPath("subjects", id)
+	q := reqURL.Query()
+	q.Set("user", c.actAsUser)
+	reqURL.RawQuery = q.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL.String(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("building subject lookup request for %s: %w", id, err)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("looking up subject %s: %w", id, err)
+	}
+	defer common.CloseBody(resp)
+
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		return nil, fmt.Errorf("subject lookup for %s returned %s", id, resp.Status)
+	}
+
+	var subject Subject
+	if err := json.NewDecoder(resp.Body).Decode(&subject); err != nil {
+		return nil, fmt.Errorf("decoding subject lookup response for %s: %w", id, err)
+	}
+
+	if subject.Email == "" {
+		log.Warnf("iplant-groups returned no email address for %s; notifications for this user cannot be emailed", id)
+	}
+
+	return &subject, nil
+}
+
+// ParseID reduces a DE username to the bare identifier iplant-groups expects:
+// everything to the left of the last "@". Usernames without a suffix are
+// returned unchanged.
+func ParseID(username string) string {
+	idx := strings.LastIndex(username, "@")
+	if idx < 0 {
+		return username
+	}
+	return username[:idx]
+}

--- a/iplantgroups/iplantgroups_test.go
+++ b/iplantgroups/iplantgroups_test.go
@@ -1,0 +1,135 @@
+package iplantgroups
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseID(t *testing.T) {
+	tests := []struct {
+		name     string
+		username string
+		want     string
+	}{
+		{name: "strips the DE domain suffix", username: "someone@iplantcollaborative.org", want: "someone"},
+		{name: "no suffix is unchanged", username: "someone", want: "someone"},
+		{name: "splits on the last @", username: "some.one@example.org@iplantcollaborative.org", want: "some.one@example.org"},
+		{name: "empty stays empty", username: "", want: ""},
+		{name: "a bare suffix yields an empty id", username: "@iplantcollaborative.org", want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, ParseID(tt.username))
+		})
+	}
+}
+
+func TestGetSubject(t *testing.T) {
+	tests := []struct {
+		name       string
+		status     int
+		body       string
+		wantErr    bool
+		wantErrMsg string
+		wantEmail  string
+	}{
+		{
+			name:      "returns the subject",
+			status:    http.StatusOK,
+			body:      `{"id":"someone","email":"someone@example.org","first_name":"Some","last_name":"One"}`,
+			wantEmail: "someone@example.org",
+		},
+		{
+			name:      "a subject with no email is not an error",
+			status:    http.StatusOK,
+			body:      `{"id":"someone"}`,
+			wantEmail: "",
+		},
+		{
+			// The standalone timelord treated a non-200 as success because it
+			// wrapped a nil error, which produced notifications addressed to an
+			// empty email. A non-2xx must be an error.
+			name:       "a not-found response is an error",
+			status:     http.StatusNotFound,
+			body:       `{"error":"no such subject"}`,
+			wantErr:    true,
+			wantErrMsg: "404",
+		},
+		{
+			name:       "a server error is an error",
+			status:     http.StatusInternalServerError,
+			body:       `boom`,
+			wantErr:    true,
+			wantErrMsg: "500",
+		},
+		{
+			name:       "an unparseable body is an error",
+			status:     http.StatusOK,
+			body:       `not json`,
+			wantErr:    true,
+			wantErrMsg: "decoding",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var gotPath, gotUser string
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotPath = r.URL.Path
+				gotUser = r.URL.Query().Get("user")
+				w.WriteHeader(tt.status)
+				_, _ = w.Write([]byte(tt.body))
+			}))
+			defer server.Close()
+
+			client, err := New(server.URL, "de_grouper")
+			require.NoError(t, err)
+
+			subject, err := client.GetSubject(context.Background(), "someone@iplantcollaborative.org")
+
+			assert.Equal(t, "/subjects/someone", gotPath, "the domain suffix is stripped from the path")
+			assert.Equal(t, "de_grouper", gotUser, "iplant-groups requires the acting user on every request")
+
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErrMsg)
+				assert.Nil(t, subject)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, subject)
+			assert.Equal(t, tt.wantEmail, subject.Email)
+		})
+	}
+}
+
+func TestGetSubjectPreservesBasePath(t *testing.T) {
+	var gotPath string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		_, _ = w.Write([]byte(`{"id":"someone"}`))
+	}))
+	defer server.Close()
+
+	client, err := New(server.URL+"/groups", "de_grouper")
+	require.NoError(t, err)
+
+	_, err = client.GetSubject(context.Background(), "someone")
+	require.NoError(t, err)
+
+	assert.Equal(t, "/groups/subjects/someone", gotPath,
+		"a base URL with a path prefix must keep it")
+}
+
+func TestNewRejectsAnUnparseableBaseURL(t *testing.T) {
+	_, err := New("http://[::1]:namedport", "de_grouper")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "parsing iplant-groups base URL")
+}

--- a/notifications/disabled.go
+++ b/notifications/disabled.go
@@ -1,0 +1,47 @@
+package notifications
+
+import (
+	"context"
+
+	"github.com/cyverse-de/app-exposer/db"
+)
+
+// Disabled is the notifier used when the deployment's notification settings
+// could not be turned into a working client. It reports success without sending
+// anything, so the caller records the notification as handled instead of
+// retrying a client that cannot be built.
+//
+// It exists so that a misconfigured notification URL costs the DE its analysis
+// notifications and nothing else. The alternative — refusing to start the
+// expiration worker — stops VICE analyses being terminated at their time limit,
+// which fills the cluster with analyses that run forever.
+type Disabled struct{}
+
+// Compile-time check that Disabled is a drop-in for the real notifier.
+var _ AnalysisNotifier = Disabled{}
+
+// NotifyTerminated drops the termination notice.
+func (Disabled) NotifyTerminated(_ context.Context, analysis *db.Analysis) error {
+	logDropped("terminated", analysis)
+	return nil
+}
+
+// NotifyExpiringSoon drops the expiry warning.
+func (Disabled) NotifyExpiringSoon(_ context.Context, analysis *db.Analysis) error {
+	logDropped("expiring soon", analysis)
+	return nil
+}
+
+// NotifyStillRunning drops the periodic reminder.
+func (Disabled) NotifyStillRunning(_ context.Context, analysis *db.Analysis) error {
+	logDropped("still running", analysis)
+	return nil
+}
+
+func logDropped(what string, analysis *db.Analysis) {
+	log.Warnf(
+		"dropping the %q notification for analysis %s: analysis notifications are disabled. "+
+			"This usually means notification_agent.base or iplant_groups.base is malformed",
+		what, analysis.ID,
+	)
+}

--- a/notifications/messages.go
+++ b/notifications/messages.go
@@ -41,10 +41,19 @@ func endTimeFormats(plannedEnd time.Time) (local, utc string) {
 }
 
 // shortDuration renders d as H:MM, the format the DE's analysis emails use for
-// both elapsed and remaining time.
+// both elapsed and remaining time. The sign is pulled out first: Go's integer
+// division truncates toward zero, so formatting a negative duration
+// component-wise would give each part its own sign ("0:-15"). Negative
+// durations are routine here — the termination notice reports the time
+// remaining on an analysis that is already past its planned end date.
 func shortDuration(d time.Duration) string {
 	d = d.Round(time.Minute)
-	hours := d / time.Hour
-	d -= hours * time.Hour
-	return fmt.Sprintf("%d:%02d", hours, d/time.Minute)
+
+	sign := ""
+	if d < 0 {
+		sign = "-"
+		d = -d
+	}
+
+	return fmt.Sprintf("%s%d:%02d", sign, d/time.Hour, (d%time.Hour)/time.Minute)
 }

--- a/notifications/messages.go
+++ b/notifications/messages.go
@@ -1,0 +1,50 @@
+package notifications
+
+import (
+	"fmt"
+	"time"
+)
+
+// Message formats for the notifications the DE sends about a VICE analysis's
+// remaining runtime. The wording is part of the user-facing contract; changing
+// it changes the emails users receive.
+const (
+	killMessageFormat = `Analysis "%s" (%s) had a configured end date of "%s" (%s), which has passed.
+
+Output files should be available in the %s folder in iRODS.`
+
+	killSubjectFormat = "Analysis %s canceled due to time limit restrictions."
+
+	warningMessageFormat = `Analysis "%s" (%s) is set to expire on "%s" (%s).
+
+Please finish any work that is in progress. Output files will be transferred to the %s folder in iRODS when the application shuts down.`
+
+	warningSubjectFormat = "Analysis %s will terminate on %s (%s)."
+
+	// Parameters: analysis name, elapsed duration, duration until the planned end date.
+	periodicMessageFormat = `Analysis "%s" has been running for %s and will stop in %s.`
+
+	// Carries a timestamp so mail clients don't thread successive reminders together.
+	periodicSubjectFormat = `CyVerse: Your analysis is still running (%s)`
+)
+
+// Email templates the notification-agent renders for each notification type.
+const (
+	statusChangeTemplate     = "analysis_status_change"
+	periodicReminderTemplate = "analysis_periodic_notification"
+)
+
+// endTimeFormats renders a planned end date the two ways every message quotes
+// it: in the DE's configured local zone and again in UTC.
+func endTimeFormats(plannedEnd time.Time) (local, utc string) {
+	return plannedEnd.Format("Mon Jan 2 15:04:05 -0700 MST 2006"), plannedEnd.UTC().Format(time.UnixDate)
+}
+
+// shortDuration renders d as H:MM, the format the DE's analysis emails use for
+// both elapsed and remaining time.
+func shortDuration(d time.Duration) string {
+	d = d.Round(time.Minute)
+	hours := d / time.Hour
+	d -= hours * time.Hour
+	return fmt.Sprintf("%d:%02d", hours, d/time.Minute)
+}

--- a/notifications/notifications.go
+++ b/notifications/notifications.go
@@ -218,11 +218,21 @@ func (n *Notifier) send(ctx context.Context, analysis *db.Analysis, status, subj
 	}
 
 	if email {
+		// A failed lookup downgrades the notification to in-app only rather
+		// than dropping it: the DE UI notification is how the user learns their
+		// analysis is ending, and losing that because an address could not be
+		// resolved is worse than losing the email.
 		subj, err := n.subjects.GetSubject(ctx, analysis.Username)
 		if err != nil {
-			return fmt.Errorf("resolving email address for %s: %w", analysis.Username, err)
+			log.Errorf(
+				"resolving the email address for %s; sending the notification for analysis %s without email. "+
+					"This usually means iplant-groups is unreachable or has no subject for the user: %v",
+				analysis.Username, analysis.ID, err,
+			)
+			email = false
+		} else {
+			payload.Email = subj.Email
 		}
-		payload.Email = subj.Email
 	}
 
 	notification := &Notification{

--- a/notifications/notifications.go
+++ b/notifications/notifications.go
@@ -1,0 +1,272 @@
+// Package notifications sends the DE's user-facing notifications about VICE
+// analysis runtime — the one-day and one-hour expiry warnings, the periodic
+// "still running" reminder, and the notice that an analysis was terminated for
+// exceeding its time limit. Notifications are POSTed to the notification-agent
+// service, which fans them out to the DE UI and to email.
+package notifications
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"time"
+
+	"github.com/cyverse-de/app-exposer/common"
+	"github.com/cyverse-de/app-exposer/db"
+	"github.com/cyverse-de/app-exposer/iplantgroups"
+	"github.com/sirupsen/logrus"
+)
+
+var log = common.Log.WithFields(logrus.Fields{"package": "notifications"})
+
+// DefaultTimeout bounds a single POST to notification-agent.
+const DefaultTimeout = 30 * time.Second
+
+// notificationPath is the notification-agent endpoint that accepts a
+// notification for delivery.
+const notificationPath = "/notification"
+
+// Payload is the analysis-specific body carried by an analysis notification.
+// The JSON field names are the wire contract with notification-agent and the
+// DE UI; do not rename them.
+type Payload struct {
+	AnalysisID            string `json:"analysisid"`
+	AnalysisName          string `json:"analysisname"`
+	AnalysisDescription   string `json:"analysisdescription"`
+	AnalysisStatus        string `json:"analysisstatus"`
+	StartDate             string `json:"startdate"`
+	AnalysisResultsFolder string `json:"analysisresultsfolder"`
+	RunDuration           string `json:"runduration"`
+	EndDuration           string `json:"endduration"`
+	AccessURL             string `json:"access_url"`
+	Email                 string `json:"email_address"`
+	Action                string `json:"action"`
+	User                  string `json:"user"`
+}
+
+// Notification is the message POSTed to notification-agent.
+type Notification struct {
+	Type          string   `json:"type"`
+	User          string   `json:"user"`
+	Subject       string   `json:"subject"`
+	Message       string   `json:"message"`
+	Email         bool     `json:"email"`
+	EmailTemplate string   `json:"email_template"`
+	Payload       *Payload `json:"payload"`
+}
+
+// SubjectLookup resolves a DE username to the profile fields a notification
+// needs. *iplantgroups.Client satisfies it.
+type SubjectLookup interface {
+	GetSubject(ctx context.Context, username string) (*iplantgroups.Subject, error)
+}
+
+// AnalysisNotifier sends the notifications the DE emits about a VICE analysis's
+// remaining runtime. *Notifier is the production implementation; the interface
+// exists so the background worker that drives these can be tested without a
+// notification-agent.
+type AnalysisNotifier interface {
+	// NotifyTerminated reports that the analysis was canceled for exceeding
+	// its time limit.
+	NotifyTerminated(ctx context.Context, analysis *db.Analysis) error
+
+	// NotifyExpiringSoon warns that the analysis is about to expire.
+	NotifyExpiringSoon(ctx context.Context, analysis *db.Analysis) error
+
+	// NotifyStillRunning is the periodic reminder that the analysis is up.
+	NotifyStillRunning(ctx context.Context, analysis *db.Analysis) error
+}
+
+// Compile-time check that *Notifier satisfies the interface its consumers use.
+var _ AnalysisNotifier = (*Notifier)(nil)
+
+// Notifier builds and sends analysis notifications.
+type Notifier struct {
+	notificationURL *url.URL
+	frontendBaseURL *url.URL
+	subjects        SubjectLookup
+	httpClient      *http.Client
+}
+
+// New returns a Notifier that POSTs to the notification-agent at
+// notificationAgentBase. frontendBaseURL is the DE's VICE base URL, used to
+// build the access URL included in each notification; an empty value omits the
+// access URL. subjects resolves the recipient's email address.
+func New(notificationAgentBase, frontendBaseURL string, subjects SubjectLookup) (*Notifier, error) {
+	notifURL, err := url.Parse(notificationAgentBase)
+	if err != nil {
+		return nil, fmt.Errorf("parsing notification-agent base URL %q: %w", notificationAgentBase, err)
+	}
+
+	n := &Notifier{
+		notificationURL: notifURL.JoinPath(notificationPath),
+		subjects:        subjects,
+		httpClient:      &http.Client{Timeout: DefaultTimeout},
+	}
+
+	if frontendBaseURL != "" {
+		frontURL, err := url.Parse(frontendBaseURL)
+		if err != nil {
+			return nil, fmt.Errorf("parsing frontend base URL %q: %w", frontendBaseURL, err)
+		}
+		n.frontendBaseURL = frontURL
+	}
+
+	return n, nil
+}
+
+// NotifyTerminated tells the user their analysis was canceled for running past
+// its planned end date.
+func (n *Notifier) NotifyTerminated(ctx context.Context, analysis *db.Analysis) error {
+	if analysis.PlannedEndDate == nil {
+		return fmt.Errorf("analysis %s has no planned end date; cannot build termination notification", analysis.ID)
+	}
+
+	endLocal, endUTC := endTimeFormats(*analysis.PlannedEndDate)
+	subject := fmt.Sprintf(killSubjectFormat, analysis.Name)
+	message := fmt.Sprintf(
+		killMessageFormat,
+		analysis.Name,
+		analysis.ID,
+		endLocal,
+		endUTC,
+		analysis.ResultFolder,
+	)
+
+	// "Canceled" rather than the analysis's current status: the DB row still
+	// reads Running at the point the termination notice goes out.
+	return n.send(ctx, analysis, "Canceled", subject, message, true, statusChangeTemplate)
+}
+
+// NotifyExpiringSoon warns the user that their analysis is about to hit its
+// planned end date.
+func (n *Notifier) NotifyExpiringSoon(ctx context.Context, analysis *db.Analysis) error {
+	if analysis.PlannedEndDate == nil {
+		return fmt.Errorf("analysis %s has no planned end date; cannot build expiry warning", analysis.ID)
+	}
+
+	endLocal, endUTC := endTimeFormats(*analysis.PlannedEndDate)
+	subject := fmt.Sprintf(warningSubjectFormat, analysis.Name, endLocal, endUTC)
+	message := fmt.Sprintf(
+		warningMessageFormat,
+		analysis.Name,
+		analysis.ID,
+		endLocal,
+		endUTC,
+		analysis.ResultFolder,
+	)
+
+	return n.send(ctx, analysis, analysis.Status, subject, message, true, statusChangeTemplate)
+}
+
+// NotifyStillRunning sends the periodic reminder that a long-running analysis
+// is still up. Emailing is opt-out per analysis via the submission's
+// notify_periodic flag.
+func (n *Notifier) NotifyStillRunning(ctx context.Context, analysis *db.Analysis) error {
+	elapsed, remaining, err := n.durations(analysis)
+	if err != nil {
+		return err
+	}
+
+	subject := fmt.Sprintf(periodicSubjectFormat, time.Now().Format("2006-01-02 15:04"))
+	message := fmt.Sprintf(periodicMessageFormat, analysis.Name, elapsed, remaining)
+
+	return n.send(ctx, analysis, analysis.Status, subject, message, analysis.NotifyPeriodic, periodicReminderTemplate)
+}
+
+// durations returns the analysis's elapsed runtime and the time remaining
+// before its planned end date, both rendered as H:MM.
+func (n *Notifier) durations(analysis *db.Analysis) (elapsed, remaining string, err error) {
+	if analysis.StartDate == nil {
+		return "", "", fmt.Errorf("analysis %s has no start date", analysis.ID)
+	}
+	if analysis.PlannedEndDate == nil {
+		return "", "", fmt.Errorf("analysis %s has no planned end date", analysis.ID)
+	}
+	return shortDuration(time.Since(*analysis.StartDate)),
+		shortDuration(time.Until(*analysis.PlannedEndDate)),
+		nil
+}
+
+// send assembles the notification for an analysis and POSTs it. The recipient's
+// email address is resolved from iplant-groups only when the notification is
+// meant to be emailed.
+func (n *Notifier) send(ctx context.Context, analysis *db.Analysis, status, subject, message string, email bool, emailTemplate string) error {
+	elapsed, remaining, err := n.durations(analysis)
+	if err != nil {
+		return err
+	}
+
+	recipient := iplantgroups.ParseID(analysis.Username)
+
+	payload := &Payload{
+		Action:                "job_status_change",
+		AnalysisID:            string(analysis.ID),
+		AnalysisName:          analysis.Name,
+		AnalysisDescription:   analysis.Description,
+		AnalysisStatus:        status,
+		StartDate:             strconv.FormatInt(analysis.StartDate.UnixMilli(), 10),
+		AnalysisResultsFolder: analysis.ResultFolder,
+		RunDuration:           elapsed,
+		EndDuration:           remaining,
+		AccessURL:             n.accessURL(analysis),
+		User:                  recipient,
+	}
+
+	if email {
+		subj, err := n.subjects.GetSubject(ctx, analysis.Username)
+		if err != nil {
+			return fmt.Errorf("resolving email address for %s: %w", analysis.Username, err)
+		}
+		payload.Email = subj.Email
+	}
+
+	notification := &Notification{
+		Type:          "analysis",
+		User:          recipient,
+		Subject:       subject,
+		Message:       message,
+		Email:         email,
+		EmailTemplate: emailTemplate,
+		Payload:       payload,
+	}
+
+	body, err := json.Marshal(notification)
+	if err != nil {
+		return fmt.Errorf("marshaling notification for analysis %s: %w", analysis.ID, err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, n.notificationURL.String(), bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("building notification request for analysis %s: %w", analysis.ID, err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := n.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("posting notification for analysis %s: %w", analysis.ID, err)
+	}
+	defer common.CloseBody(resp)
+
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		return fmt.Errorf("notification for analysis %s returned %s", analysis.ID, resp.Status)
+	}
+
+	log.Infof("sent %q notification for analysis %s (email=%t)", subject, analysis.ID, email)
+	return nil
+}
+
+// accessURL returns the user-facing URL of a VICE analysis, or "" when either
+// no frontend base URL is configured or the analysis has no subdomain yet.
+func (n *Notifier) accessURL(analysis *db.Analysis) string {
+	if n.frontendBaseURL == nil || analysis.Subdomain == "" {
+		return ""
+	}
+	accessURL := *n.frontendBaseURL
+	accessURL.Host = analysis.Subdomain + "." + accessURL.Host
+	return accessURL.String()
+}

--- a/notifications/notifications_test.go
+++ b/notifications/notifications_test.go
@@ -1,0 +1,333 @@
+package notifications
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/cyverse-de/app-exposer/db"
+	"github.com/cyverse-de/app-exposer/iplantgroups"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeSubjects returns a fixed subject, or an error when one is set.
+type fakeSubjects struct {
+	subject *iplantgroups.Subject
+	err     error
+	calls   int
+}
+
+func (f *fakeSubjects) GetSubject(context.Context, string) (*iplantgroups.Subject, error) {
+	f.calls++
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.subject, nil
+}
+
+func timePtr(t time.Time) *time.Time { return &t }
+
+func testAnalysis() *db.Analysis {
+	start := time.Date(2026, 8, 10, 12, 0, 0, 0, time.UTC)
+	return &db.Analysis{
+		ID:             "analysis-1",
+		ExternalID:     "external-1",
+		Name:           "my analysis",
+		Description:    "does a thing",
+		Status:         "Running",
+		Username:       "someone@iplantcollaborative.org",
+		ResultFolder:   "/iplant/home/someone/analyses/my-analysis",
+		Subdomain:      "a1b2c3d4e",
+		StartDate:      timePtr(start),
+		PlannedEndDate: timePtr(start.Add(72 * time.Hour)),
+		NotifyPeriodic: true,
+	}
+}
+
+// notifierForTest returns a Notifier pointed at a test server that captures the
+// request body, along with a pointer to the captured body.
+func notifierForTest(t *testing.T, subjects SubjectLookup, status int, frontendBase string) (*Notifier, *[]byte) {
+	t.Helper()
+
+	var captured []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		captured = body
+
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, notificationPath, r.URL.Path)
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+
+		w.WriteHeader(status)
+	}))
+	t.Cleanup(server.Close)
+
+	notifier, err := New(server.URL, frontendBase, subjects)
+	require.NoError(t, err)
+
+	return notifier, &captured
+}
+
+// TestNotificationWireShape pins the JSON the DE's notification-agent and UI
+// consume. The field names are a wire contract shared with other services, so a
+// rename here would silently break notifications rather than fail a build.
+func TestNotificationWireShape(t *testing.T) {
+	subjects := &fakeSubjects{subject: &iplantgroups.Subject{Email: "someone@example.org"}}
+	notifier, captured := notifierForTest(t, subjects, http.StatusOK, "https://cyverse.run")
+
+	require.NoError(t, notifier.NotifyTerminated(context.Background(), testAnalysis()))
+
+	var payload map[string]any
+	require.NoError(t, json.Unmarshal(*captured, &payload))
+
+	assert.Equal(t, "analysis", payload["type"])
+	assert.Equal(t, "someone", payload["user"], "the domain suffix is stripped for notification-agent")
+	assert.Equal(t, true, payload["email"])
+	assert.Equal(t, statusChangeTemplate, payload["email_template"])
+	assert.Contains(t, payload["subject"], "my analysis")
+	assert.Contains(t, payload["message"], "my analysis")
+
+	inner, ok := payload["payload"].(map[string]any)
+	require.True(t, ok, "payload object present")
+
+	// Every key notification-agent and the DE UI read. Compared as a set so a
+	// dropped or renamed field fails loudly.
+	wantKeys := []string{
+		"analysisid", "analysisname", "analysisdescription", "analysisstatus",
+		"startdate", "analysisresultsfolder", "runduration", "endduration",
+		"access_url", "email_address", "action", "user",
+	}
+	gotKeys := make([]string, 0, len(inner))
+	for k := range inner {
+		gotKeys = append(gotKeys, k)
+	}
+	assert.ElementsMatch(t, wantKeys, gotKeys)
+
+	assert.Equal(t, "analysis-1", inner["analysisid"])
+	assert.Equal(t, "job_status_change", inner["action"])
+	assert.Equal(t, "Canceled", inner["analysisstatus"],
+		"a termination notice reports Canceled even though the DB row still reads Running")
+	assert.Equal(t, "someone@example.org", inner["email_address"])
+	assert.Equal(t, "https://a1b2c3d4e.cyverse.run", inner["access_url"])
+	// 2026-08-10T12:00:00Z as epoch milliseconds.
+	assert.Equal(t, "1786363200000", inner["startdate"], "start date is epoch milliseconds as a string")
+}
+
+func TestNotificationTypes(t *testing.T) {
+	tests := []struct {
+		name          string
+		notify        func(*Notifier, *db.Analysis) error
+		wantTemplate  string
+		wantEmail     bool
+		wantStatus    string
+		wantSubjectIn string
+	}{
+		{
+			name: "terminated",
+			notify: func(n *Notifier, a *db.Analysis) error {
+				return n.NotifyTerminated(context.Background(), a)
+			},
+			wantTemplate:  statusChangeTemplate,
+			wantEmail:     true,
+			wantStatus:    "Canceled",
+			wantSubjectIn: "canceled due to time limit restrictions",
+		},
+		{
+			name: "expiring soon",
+			notify: func(n *Notifier, a *db.Analysis) error {
+				return n.NotifyExpiringSoon(context.Background(), a)
+			},
+			wantTemplate:  statusChangeTemplate,
+			wantEmail:     true,
+			wantStatus:    "Running",
+			wantSubjectIn: "will terminate on",
+		},
+		{
+			name: "still running",
+			notify: func(n *Notifier, a *db.Analysis) error {
+				return n.NotifyStillRunning(context.Background(), a)
+			},
+			wantTemplate:  periodicReminderTemplate,
+			wantEmail:     true,
+			wantStatus:    "Running",
+			wantSubjectIn: "Your analysis is still running",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			subjects := &fakeSubjects{subject: &iplantgroups.Subject{Email: "someone@example.org"}}
+			notifier, captured := notifierForTest(t, subjects, http.StatusOK, "https://cyverse.run")
+
+			require.NoError(t, tt.notify(notifier, testAnalysis()))
+
+			var payload struct {
+				Subject       string `json:"subject"`
+				Email         bool   `json:"email"`
+				EmailTemplate string `json:"email_template"`
+				Payload       struct {
+					AnalysisStatus string `json:"analysisstatus"`
+				} `json:"payload"`
+			}
+			require.NoError(t, json.Unmarshal(*captured, &payload))
+
+			assert.Equal(t, tt.wantTemplate, payload.EmailTemplate)
+			assert.Equal(t, tt.wantEmail, payload.Email)
+			assert.Equal(t, tt.wantStatus, payload.Payload.AnalysisStatus)
+			assert.Contains(t, payload.Subject, tt.wantSubjectIn)
+		})
+	}
+}
+
+// TestStillRunningRespectsNotifyPeriodic verifies that the per-analysis opt-out
+// suppresses the email but still records the in-app notification, and that no
+// email address is looked up when it isn't needed.
+func TestStillRunningRespectsNotifyPeriodic(t *testing.T) {
+	subjects := &fakeSubjects{subject: &iplantgroups.Subject{Email: "someone@example.org"}}
+	notifier, captured := notifierForTest(t, subjects, http.StatusOK, "https://cyverse.run")
+
+	analysis := testAnalysis()
+	analysis.NotifyPeriodic = false
+
+	require.NoError(t, notifier.NotifyStillRunning(context.Background(), analysis))
+
+	var payload struct {
+		Email   bool `json:"email"`
+		Payload struct {
+			Email string `json:"email_address"`
+		} `json:"payload"`
+	}
+	require.NoError(t, json.Unmarshal(*captured, &payload))
+
+	assert.False(t, payload.Email)
+	assert.Empty(t, payload.Payload.Email)
+	assert.Zero(t, subjects.calls, "no subject lookup is needed when the notification isn't emailed")
+}
+
+func TestNotifierErrors(t *testing.T) {
+	tests := []struct {
+		name       string
+		status     int
+		subjects   SubjectLookup
+		mutate     func(*db.Analysis)
+		wantErrMsg string
+	}{
+		{
+			name:       "a non-2xx response is an error",
+			status:     http.StatusInternalServerError,
+			subjects:   &fakeSubjects{subject: &iplantgroups.Subject{Email: "someone@example.org"}},
+			wantErrMsg: "500",
+		},
+		{
+			name:       "a failed subject lookup is an error",
+			status:     http.StatusOK,
+			subjects:   &fakeSubjects{err: assert.AnError},
+			wantErrMsg: "resolving email address",
+		},
+		{
+			name:     "a missing planned end date is an error",
+			status:   http.StatusOK,
+			subjects: &fakeSubjects{subject: &iplantgroups.Subject{}},
+			mutate: func(a *db.Analysis) {
+				a.PlannedEndDate = nil
+			},
+			wantErrMsg: "no planned end date",
+		},
+		{
+			name:     "a missing start date is an error",
+			status:   http.StatusOK,
+			subjects: &fakeSubjects{subject: &iplantgroups.Subject{}},
+			mutate: func(a *db.Analysis) {
+				a.StartDate = nil
+			},
+			wantErrMsg: "no start date",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			notifier, _ := notifierForTest(t, tt.subjects, tt.status, "https://cyverse.run")
+
+			analysis := testAnalysis()
+			if tt.mutate != nil {
+				tt.mutate(analysis)
+			}
+
+			err := notifier.NotifyTerminated(context.Background(), analysis)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErrMsg)
+		})
+	}
+}
+
+func TestAccessURL(t *testing.T) {
+	tests := []struct {
+		name         string
+		frontendBase string
+		subdomain    string
+		want         string
+	}{
+		{
+			name:         "built from the frontend base and the subdomain",
+			frontendBase: "https://cyverse.run",
+			subdomain:    "a1b2c3d4e",
+			want:         "https://a1b2c3d4e.cyverse.run",
+		},
+		{
+			name:         "port is preserved",
+			frontendBase: "https://cyverse.run:4343",
+			subdomain:    "a1b2c3d4e",
+			want:         "https://a1b2c3d4e.cyverse.run:4343",
+		},
+		{
+			name:         "omitted when no frontend base is configured",
+			frontendBase: "",
+			subdomain:    "a1b2c3d4e",
+			want:         "",
+		},
+		{
+			name:         "omitted when the analysis has no subdomain yet",
+			frontendBase: "https://cyverse.run",
+			subdomain:    "",
+			want:         "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			notifier, err := New("http://notification-agent", tt.frontendBase, &fakeSubjects{})
+			require.NoError(t, err)
+
+			analysis := testAnalysis()
+			analysis.Subdomain = tt.subdomain
+
+			assert.Equal(t, tt.want, notifier.accessURL(analysis))
+		})
+	}
+}
+
+func TestShortDuration(t *testing.T) {
+	tests := []struct {
+		name string
+		d    time.Duration
+		want string
+	}{
+		{name: "zero", d: 0, want: "0:00"},
+		{name: "minutes only", d: 42 * time.Minute, want: "0:42"},
+		{name: "rounds to the nearest minute", d: 42*time.Minute + 31*time.Second, want: "0:43"},
+		{name: "single-digit hours", d: 3*time.Hour + 5*time.Minute, want: "3:05"},
+		{name: "multi-digit hours", d: 72*time.Hour + 15*time.Minute, want: "72:15"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, shortDuration(tt.d))
+		})
+	}
+}

--- a/notifications/notifications_test.go
+++ b/notifications/notifications_test.go
@@ -225,12 +225,6 @@ func TestNotifierErrors(t *testing.T) {
 			wantErrMsg: "500",
 		},
 		{
-			name:       "a failed subject lookup is an error",
-			status:     http.StatusOK,
-			subjects:   &fakeSubjects{err: assert.AnError},
-			wantErrMsg: "resolving email address",
-		},
-		{
 			name:     "a missing planned end date is an error",
 			status:   http.StatusOK,
 			subjects: &fakeSubjects{subject: &iplantgroups.Subject{}},
@@ -264,6 +258,21 @@ func TestNotifierErrors(t *testing.T) {
 			assert.Contains(t, err.Error(), tt.wantErrMsg)
 		})
 	}
+}
+
+// TestFailedSubjectLookupStillNotifies pins the degraded path: the DE UI
+// notification is how a user learns their analysis is ending, so an email
+// address that cannot be resolved downgrades the notification rather than
+// dropping it.
+func TestFailedSubjectLookupStillNotifies(t *testing.T) {
+	notifier, captured := notifierForTest(t, &fakeSubjects{err: assert.AnError}, http.StatusOK, "https://cyverse.run")
+
+	require.NoError(t, notifier.NotifyTerminated(context.Background(), testAnalysis()))
+
+	var sent Notification
+	require.NoError(t, json.Unmarshal(*captured, &sent))
+	assert.False(t, sent.Email, "the notification should be downgraded to in-app only")
+	assert.Empty(t, sent.Payload.Email)
 }
 
 func TestAccessURL(t *testing.T) {
@@ -323,6 +332,12 @@ func TestShortDuration(t *testing.T) {
 		{name: "rounds to the nearest minute", d: 42*time.Minute + 31*time.Second, want: "0:43"},
 		{name: "single-digit hours", d: 3*time.Hour + 5*time.Minute, want: "3:05"},
 		{name: "multi-digit hours", d: 72*time.Hour + 15*time.Minute, want: "72:15"},
+
+		// The termination notice reports the time remaining on an analysis
+		// that is already past its planned end date, so negative durations
+		// reach users and must carry a single leading sign.
+		{name: "minutes past the planned end date", d: -15 * time.Minute, want: "-0:15"},
+		{name: "hours past the planned end date", d: -(time.Hour + 30*time.Minute), want: "-1:30"},
 	}
 
 	for _, tt := range tests {

--- a/operator/handlers.go
+++ b/operator/handlers.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"sync"
 	"time"
 
 	"github.com/cyverse-de/app-exposer/common"
@@ -69,6 +70,14 @@ type Operator struct {
 	httpClient          HTTPClient          // Client for contacting the vice-proxy sidecar.
 	userSuffix          string              // Domain suffix for usernames (e.g. "@iplantcollaborative.org").
 	localStorageClass   string              // StorageClass for the per-analysis working-dir PVC; empty means cluster default.
+
+	// saveAndExitInFlight holds the analysis ids whose save-and-exit is still
+	// running. Save-and-exit uploads outputs and then deletes the analysis's
+	// resources, so a second concurrent run would tear the Deployment down
+	// while the first is still streaming files to iRODS. Duplicate requests are
+	// routine: the expiration worker re-sends one on every sweep, from every
+	// replica, until the analysis leaves the cluster.
+	saveAndExitInFlight sync.Map
 
 	// Construction config for the operator-side VICESpec build path. These are
 	// the cluster values vicebuild needs that the legacy transform path didn't

--- a/operator/handlers.go
+++ b/operator/handlers.go
@@ -76,7 +76,13 @@ type Operator struct {
 	// resources, so a second concurrent run would tear the Deployment down
 	// while the first is still streaming files to iRODS. Duplicate requests are
 	// routine: the expiration worker re-sends one on every sweep, from every
-	// replica, until the analysis leaves the cluster.
+	// app-exposer replica, until the analysis leaves the cluster.
+	//
+	// The guard is per process, and the duplicates arrive over HTTP through the
+	// operator's Service, so it only holds while vice-operator runs a single
+	// replica per cluster — which is what the DE deploys. Scaling it out needs a
+	// cluster-wide claim (a Lease, or a marker on the analysis's Deployment)
+	// first; without one, two replicas would race exactly as described above.
 	saveAndExitInFlight sync.Map
 
 	// Construction config for the operator-side VICESpec build path. These are

--- a/operator/transfers.go
+++ b/operator/transfers.go
@@ -54,7 +54,9 @@ type transferStatus struct {
 }
 
 // HandleSaveAndExit triggers the file transfer sidecar to upload outputs,
-// then deletes all analysis resources.
+// then deletes all analysis resources. A request for an analysis whose
+// save-and-exit is already running is accepted and dropped rather than started
+// a second time — see saveAndExitInFlight.
 //
 //	@Summary		Save outputs and exit
 //	@Description	Triggers the file-transfer sidecar to upload output files,
@@ -72,6 +74,11 @@ func (o *Operator) HandleSaveAndExit(c echo.Context) error {
 
 	log.Infof("save-and-exit requested for analysis %s", analysisID)
 
+	if _, running := o.saveAndExitInFlight.LoadOrStore(analysisID, struct{}{}); running {
+		log.Infof("save-and-exit is already running for analysis %s; ignoring the duplicate request", analysisID)
+		return c.NoContent(http.StatusAccepted)
+	}
+
 	// Run transfer + cleanup asynchronously with a detached, lifetime-bounded
 	// context so the caller doesn't block and a stuck sidecar can't leak the
 	// goroutine.
@@ -80,6 +87,10 @@ func (o *Operator) HandleSaveAndExit(c echo.Context) error {
 	// response is sent, the user has no visibility into a failed transfer
 	// today beyond the log line below.
 	go func() {
+		// Released even on failure, so a save-and-exit that could not finish is
+		// retried by the next request rather than blocked forever.
+		defer o.saveAndExitInFlight.Delete(analysisID)
+
 		bgCtx, cancel := context.WithTimeout(context.Background(), maxTransferLifetime)
 		defer cancel()
 

--- a/operator/transfers_test.go
+++ b/operator/transfers_test.go
@@ -17,7 +17,9 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
 )
 
 // rewriteTransport redirects every outbound request to target, preserving
@@ -439,4 +441,54 @@ func TestHandleSaveOutputFiles(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestSaveAndExitIsDeduplicated covers the guard against concurrent
+// save-and-exit runs for one analysis. Save-and-exit uploads outputs and then
+// deletes the analysis's resources, so a second run would tear the Deployment
+// down while the first is still streaming files to iRODS. Duplicates are
+// routine: the expiration worker re-sends the request on every sweep, from
+// every replica, until the analysis leaves the cluster.
+func TestSaveAndExitIsDeduplicated(t *testing.T) {
+	const analysisID = "save-and-exit-dedupe"
+
+	newOperator := func(t *testing.T) (*Operator, *atomic.Bool) {
+		t.Helper()
+
+		op, clientset, _ := newTestOperator(t, 10)
+
+		// Listing the analysis's Services is the first thing the background
+		// goroutine does, so it stands in for "the transfer started".
+		var started atomic.Bool
+		clientset.PrependReactor("list", "services", func(k8stesting.Action) (bool, runtime.Object, error) {
+			started.Store(true)
+			return false, nil, nil
+		})
+
+		return op, &started
+	}
+
+	t.Run("a first request starts the transfer", func(t *testing.T) {
+		op, started := newOperator(t)
+
+		c, rec := newTransferContext(echo.New(), analysisID)
+		require.NoError(t, op.HandleSaveAndExit(c))
+		assert.Equal(t, http.StatusAccepted, rec.Code)
+
+		assert.Eventually(t, started.Load, time.Second, 10*time.Millisecond)
+	})
+
+	t.Run("a request for an analysis already saving is dropped", func(t *testing.T) {
+		op, started := newOperator(t)
+		op.saveAndExitInFlight.Store(analysisID, struct{}{})
+
+		c, rec := newTransferContext(echo.New(), analysisID)
+		require.NoError(t, op.HandleSaveAndExit(c))
+
+		// Still accepted: the caller asked for a state the operator is already
+		// working toward, which is not an error.
+		assert.Equal(t, http.StatusAccepted, rec.Code)
+		assert.Never(t, started.Load, 200*time.Millisecond, 10*time.Millisecond,
+			"a duplicate request must not start a second upload")
+	})
 }

--- a/operatorclient/scheduler.go
+++ b/operatorclient/scheduler.go
@@ -401,10 +401,11 @@ func (s *Scheduler) ClientByID(id uuid.UUID) *Client {
 // recorded operator id (see ClientByID) and fall back to this.
 //
 // Returns (nil, nil) when every operator answered and none has the analysis —
-// genuinely not running. Returns (nil, err) only when one or more operators
-// errored and nothing reported found: in that case "not running anywhere" and
-// "hiding on a degraded cluster" are indistinguishable, so callers must not
-// treat the miss as authoritative.
+// genuinely not running. Returns (nil, err) when one or more operators errored
+// and nothing reported found, and ErrNoOperators when there was nobody to ask:
+// in both cases "not running anywhere" and "hiding on a cluster we couldn't
+// reach" are indistinguishable, so callers must not treat the miss as
+// authoritative.
 func (s *Scheduler) FindAnalysis(ctx context.Context, analysisID AnalysisID) (*Client, error) {
 	type result struct {
 		client *Client
@@ -414,7 +415,7 @@ func (s *Scheduler) FindAnalysis(ctx context.Context, analysisID AnalysisID) (*C
 
 	clients := s.Clients()
 	if len(clients) == 0 {
-		return nil, nil
+		return nil, ErrNoOperators
 	}
 
 	// Cancellable child context so the remaining searches stop as soon as one

--- a/operatorclient/scheduler.go
+++ b/operatorclient/scheduler.go
@@ -391,3 +391,71 @@ func (s *Scheduler) ClientByID(id uuid.UUID) *Client {
 	}
 	return nil
 }
+
+// FindAnalysis asks every operator in parallel whether its cluster is running
+// the given analysis, and returns the client that reports it.
+//
+// This is the authoritative "is it actually deployed" check: each operator
+// answers from its own cluster resources rather than from anything recorded in
+// the DE database. Callers that can tolerate a cheaper answer should prefer a
+// recorded operator id (see ClientByID) and fall back to this.
+//
+// Returns (nil, nil) when every operator answered and none has the analysis —
+// genuinely not running. Returns (nil, err) only when one or more operators
+// errored and nothing reported found: in that case "not running anywhere" and
+// "hiding on a degraded cluster" are indistinguishable, so callers must not
+// treat the miss as authoritative.
+func (s *Scheduler) FindAnalysis(ctx context.Context, analysisID AnalysisID) (*Client, error) {
+	type result struct {
+		client *Client
+		found  bool
+		err    error
+	}
+
+	clients := s.Clients()
+	if len(clients) == 0 {
+		return nil, nil
+	}
+
+	// Cancellable child context so the remaining searches stop as soon as one
+	// operator claims the analysis.
+	searchCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	ch := make(chan result, len(clients))
+
+	var wg sync.WaitGroup
+	for _, c := range clients {
+		wg.Go(func() {
+			found, err := c.HasAnalysis(searchCtx, analysisID)
+			if err != nil {
+				log.Warnf("search: operator %s error for analysis %s: %v", c.Name(), analysisID, err)
+				ch <- result{client: c, err: err}
+				return
+			}
+			ch <- result{client: c, found: found}
+		})
+	}
+
+	go func() {
+		wg.Wait()
+		close(ch)
+	}()
+
+	var failed []string
+	for r := range ch {
+		if r.err != nil {
+			failed = append(failed, r.client.Name())
+			continue
+		}
+		if r.found {
+			cancel() // Signal the remaining goroutines to stop.
+			return r.client, nil
+		}
+	}
+
+	if len(failed) > 0 {
+		return nil, fmt.Errorf("analysis %s not found; %d operator(s) could not be checked: %v", analysisID, len(failed), failed)
+	}
+	return nil, nil
+}

--- a/operatorclient/scheduler_test.go
+++ b/operatorclient/scheduler_test.go
@@ -755,3 +755,15 @@ func TestSchedulerSyncAndSetTokenSource(t *testing.T) {
 	// After concurrent churn the scheduler must still be operational.
 	assert.NotNil(t, scheduler.Clients(), "scheduler should still have clients after concurrent Sync/SetTokenSource")
 }
+
+// TestFindAnalysisWithNoOperators pins an empty scheduler as an indeterminate
+// answer rather than a miss. Callers read a nil client with a nil error as
+// "genuinely not running anywhere" — for the expiration worker that means
+// marking the analysis Completed, which must not happen on the strength of an
+// answer no operator was ever asked for.
+func TestFindAnalysisWithNoOperators(t *testing.T) {
+	client, err := NewScheduler(nil).FindAnalysis(context.Background(), "analysis-1")
+
+	assert.Nil(t, client)
+	assert.ErrorIs(t, err, ErrNoOperators)
+}


### PR DESCRIPTION
Merges [`cyverse-de/timelord`](https://github.com/cyverse-de/timelord) into app-exposer. timelord's job — warning users about VICE analyses nearing their time limit and terminating the ones that pass it — now runs inside app-exposer as a background worker alongside the reconciler.

This supersedes `plans/job-runtime-table-design.md`, whose multi-stage rollout existed only because the two writers lived in separate processes.

## Why this was straightforward

timelord was already an app-exposer satellite: it held **no Kubernetes client** (`k8s.io/api` was imported only for types it duplicated), every cluster action was an HTTP call back into app-exposer, and it already ran under the `app-exposer` service account. Its Service existed only for expvar probes, and nothing in the DE called it.

## New packages

| Package | Contents |
| --- | --- |
| `expiration/` | The sweep worker, the termination path, and the AMQP consumer |
| `notifications/` | notification-agent client and message templates |
| `iplantgroups/` | iplant-groups client, for the recipient's email address |

DB access lives in `db/expiration.go` + `db/notifstatuses.go` behind a narrow `db.ExpirationDB` interface, mirroring the existing `ReconcilerDB` pattern so the worker is unit-testable against a fake.

## Duplication removed rather than carried over

- `generateSubdomain` — a second implementation of `common.Subdomain`. Two hashes that must agree or analyses become unroutable.
- timelord's copy of the `reporting` resource types, already stale (no `AnalysisID`, no `Routes`).
- `sendCompletedStatus` — `incluster`'s `JSLPublisher.Success` already does exactly this; `messaging.SucceededState` *is* the string `"Completed"`.
- The parallel operator-search logic in `httphandlers` moved onto `Scheduler.FindAnalysis` so the worker and the handlers share one implementation.

## Behavioral changes, all deliberate

- **`jobs.subdomain` and `jobs.planned_end_date` are now written by the VICE launch handler** (`db.InitializeRuntime`), with the AMQP consumer demoted to a safety net that logs at warn level whenever it has to backfill. In steady state it should never fire.
- **Notifications are claimed with `FOR UPDATE SKIP LOCKED`** on the `notif_statuses` row. timelord ran two replicas doing read-flag → send → set-flag, which duplicated a user's email whenever the two polls interleaved.
- **An unreachable operator no longer marks analyses Completed.** timelord logged the error and fell through with `found = false`, so an app-exposer outage could force-complete live analyses. It now skips and retries next sweep.
- **A non-2xx from iplant-groups is now an error.** timelord called `errors.Wrapf(err, …)` with a nil `err`, so a failed lookup returned success and produced a notification with an empty email address.
- **DB timestamps are read through `AT TIME ZONE current_setting('TimeZone')`** instead of being formatted and reparsed as local time. Same result, minus the string round-trip, and consistent with the existing time-limit SQL.

## Dependency and toolchain

`messaging/v12` goes to **v12.0.2** for its fixed reconnect. v12.0.0's `doReconnect` reassigns its own receiver (so reconnect silently does nothing) and `Listen` calls `os.Exit(-1)` when reconnect is disabled — survivable in timelord, not in the process serving the VICE API. v12.0.2 removes `os.Exit` and returns errors instead.

That requires the `go` directive to move 1.25.7 → 1.26. **CI already pinned `go-version: 1.26`**, so no workflow changes were needed.

## Verification

- `go build`, `go vet`, `golangci-lint run ./...` (0 issues), full `go test ./...` all green.
- New table-driven tests for the worker sweeps, the notification wire shape (that JSON is a contract with notification-agent and the DE UI), the iplant-groups client, and the DB layer via sqlmock.
- Because sqlmock only compares SQL strings, **every new query was additionally run through `PREPARE` against a throwaway Postgres 12 loaded with de-database's migrations**, and the guarded runtime `UPDATE` was exercised against real rows. Postgres's inferred parameter types caught a real bug: `last_periodic_warning` was being read without the timezone conversion, which would have thrown the periodic-reminder pacing off by the local UTC offset.

## Paired deployment change

Requires cyverse-de/deployments#94 — it retires the timelord role, Deployment, Service, config secret, and build descriptor. Merge that alongside this.

Not included here: the `app_exposer_replicas` sizing review. The worker now runs in every replica, which is correct by design, but the count deserves a conscious choice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0187aZRBCsKwZz9DpFrYcnuA
