### PR TITLE
Record the vice-status-listener retirement

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -112,6 +112,9 @@ test-operator:
 test-operatorclient:
     go test ./operatorclient/...
 
+test-reconciler:
+    go test ./reconciler/...
+
 test-app-exposer:
     go test ./cmd/app-exposer/...
 
@@ -139,7 +142,7 @@ test-vice-bundle:
 test-vice-userid:
     go test ./cmd/vice-userid/...
 
-test: test-imageinfo test-common test-db test-expiration test-iplantgroups test-notifications test-operator test-operatorclient test-app-exposer test-vice-operator test-vice-operator-tool test-vice-export test-vice-import test-vice-launch test-vice-list test-vice-bundle test-vice-userid
+test: test-imageinfo test-common test-db test-expiration test-iplantgroups test-notifications test-operator test-operatorclient test-reconciler test-app-exposer test-vice-operator test-vice-operator-tool test-vice-export test-vice-import test-vice-launch test-vice-list test-vice-bundle test-vice-userid
 
 fmt-docs:
     swag fmt -g app.go -d cmd/app-exposer/,httphandlers/,common/,incluster/

--- a/operator/statusinformer.go
+++ b/operator/statusinformer.go
@@ -244,9 +244,9 @@ func (s *StatusInformer) handleAddOrUpdate(ctx context.Context, dep *appsv1.Depl
 	s.publishIfChanged(ctx, constants.ExternalID(externalID), messaging.RunningState, message)
 }
 
-// handleDelete publishes a Succeeded update when a Deployment is removed.
-// Mirrors vice-status-listener's assumption that deletion implies a clean
-// finish. Known gap: a crashed pod (replicas 1 → 0) generates no event here
+// handleDelete publishes a Succeeded update when a Deployment is removed, on
+// the assumption that deletion implies a clean finish. Known gap: a crashed
+// pod (replicas 1 → 0) generates no event here
 // because handleAddOrUpdate skips on AvailableReplicas < 1, so the eventual
 // delete reports Succeeded over what was actually a failure. The reconciler
 // safety net catches this only if it observes the Failed pod phase before

--- a/plans/push-based-status-updates.md
+++ b/plans/push-based-status-updates.md
@@ -67,7 +67,11 @@ When a new leader takes over, its informer's `AddFunc` fires for every existing 
 
 ### vice-status-listener retirement
 
-The new operator-internal informer covers the local cluster too, so `vice-status-listener` becomes redundant. Recommend deleting it in a follow-up PR after the new path has been running in QA for a week. Out of scope for this change.
+**Done, 2026-08-11.** The new operator-internal informer covers the local cluster too, so `vice-status-listener` became redundant and has been retired. `operator/statusinformer.go` is now the only per-cluster status publisher; the standalone service, its deployments role, and its GitHub repo are gone.
+
+The soak ran far longer than the week originally recommended — the informer went live in QA on 2026-05-18 and both publishers ran side by side for ~3 months. During that window the listener emitted 4-5 duplicate `Running` updates per analysis (one per Deployment update event) against the informer's one, and the remote `ai-sandboxes-qa` operator — which never had a listener — demonstrated the push path standing on its own.
+
+One deliberate behavior change came with the retirement: the listener published `Running` the instant the Deployment object appeared, while the informer waits for `AvailableReplicas >= 1`. Analyses now stay in `Submitted` through image pull and report `Running` when the pod is actually ready.
 
 ## Files
 
@@ -112,5 +116,4 @@ Tests to add:
 ## Open questions (decide before implementation)
 
 - **Cluster identifier in payload** — `vice-status-listener`'s current body is `{Host, State, Message}` with `Host` being the deployment hostname. We could put the cluster name there for the new path, or extend the body. Recommend keeping body identical to vice-status-listener for now and adding a cluster field with the auth follow-up.
-- **vice-status-listener retirement timeline** — once the new path has soaked in QA, vice-status-listener becomes pure duplication and should be deleted. Worth pinning a date.
 - **Auth follow-up scope** — token/role/dedup all land together in a separate PR. Note in the implementation that the publisher's HTTP client is positioned to drop in a token-injecting transport later without restructuring.

--- a/reconciler/reconciler.go
+++ b/reconciler/reconciler.go
@@ -384,13 +384,14 @@ func (r *Reconciler) reconcileAnalysis(ctx context.Context, tx *sqlx.Tx, pod rep
 	dbStatus, err := r.db.GetLatestStatusByExternalID(ctx, tx, pod.ExternalID)
 	switch {
 	case errors.Is(err, sql.ErrNoRows):
-		// No prior status row. Probable cause: the analysis was launched
-		// against a remote-cluster operator (e.g. AWS) where
-		// vice-status-listener isn't running, so nothing else ever
-		// published an initial Submitted/Running update. Seed the table
-		// with the cluster's current state so downstream consumers like
-		// job-status-to-apps-adapter pick it up; subsequent ticks then
-		// fall through to the normal change-detection path.
+		// No prior status row. Probable cause: the analysis never reached
+		// an available replica, so the operator's status informer — which
+		// only publishes once a Deployment reports one — never emitted
+		// anything for it. A bad image tag or a crash on start looks like
+		// this. Seed the table with the cluster's current state so
+		// downstream consumers like job-status-to-apps-adapter pick it up;
+		// subsequent ticks then fall through to the normal
+		// change-detection path.
 		log.Infof("analysis %s (external %s) has no prior status; recording initial %s from cluster",
 			pod.AnalysisID, pod.ExternalID, clusterStatus)
 		return r.recordStatusUpdate(ctx, tx, pod.ExternalID, clusterStatus, pod.Message)

--- a/reconciler/reconciler_test.go
+++ b/reconciler/reconciler_test.go
@@ -215,9 +215,9 @@ func TestReconcileAnalysis(t *testing.T) {
 		},
 		{
 			// Bootstraps the job_status_updates row from the cluster state
-			// when nothing else has published one — the only way analyses
-			// on remote-cluster operators (e.g. AWS, where
-			// vice-status-listener isn't running) ever leave Submitted.
+			// when nothing else has published one — the only way an
+			// analysis that never reached an available replica, and so
+			// never triggered the operator's informer, leaves Submitted.
 			name: "seeds initial status when no prior row exists",
 			pod: reporting.PodInfo{
 				MetaInfo: reporting.MetaInfo{AnalysisID: "an-1", ExternalID: "ext-1"},


### PR DESCRIPTION
Paired with cyverse-de/deployments#96, which does the actual retirement. This side is documentation and comments only — no behavior change.

`vice-status-listener`'s Deployment informer was absorbed into `vice-operator` on 2026-05-18 (`operator/statusinformer.go`, commit 51469cf). `plans/push-based-status-updates.md` deferred the retirement to "a follow-up PR after the new path has been running in QA for a week." This is that follow-up; the soak ran ~3 months.

## Evidence the push path is sufficient

- The `vice-operator-status-publisher` lease is held in both `vice-apps` (local) and `ai-sandboxes-qa` (remote), with zero publish failures in either operator's logs.
- `ai-sandboxes-qa` has **never** had a listener, and its analyses reach terminal states — the push path already stands alone there.
- In `vice-apps` the listener was emitting 4-5 duplicate `Running` updates per analysis (one per Deployment update event) against the informer's one.

## Changes

- `plans/push-based-status-updates.md` — record the retirement, resolve the open question about its timeline.
- `operator/statusinformer.go`, `reconciler/reconciler.go`, `reconciler/reconciler_test.go` — drop comments that cite the service as a live reason for behavior. The reconciler's initial-seed path is still needed, but the real reason is that the informer only publishes once a Deployment reports an available replica, so an analysis that never gets one produces no push update at all.
- `Justfile` — add the missing `test-reconciler` target. `./reconciler/...` has tests but was absent from the `test:` aggregate, so they never ran under `just test`. Found while verifying the comment change above.

## Behavior change to be aware of

The listener published `Running` the instant the Deployment object appeared; the informer waits for `AvailableReplicas >= 1`. Analyses will stay in `Submitted` through image pull and report `Running` when the pod is actually ready. QA has been receiving this for ~3 months alongside the old behavior.

## Verification

`just test` green (now including `reconciler`), `golangci-lint run` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)